### PR TITLE
First pass at file system schema (rlauxe.proto).

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ Table of Contents
     STYLISH	    Stylish Risk-Limiting Audits in Practice.		Glazer, Spertus, Stark  16 Sep 2023
       https://github.com/pbstark/SHANGRLA
 
+    VERIFIABLE  Publicly Verifiable RLAs.     Alexander Ek, Aresh Mirzaei, Alex Ozdemir, Olivier Pereira, Philip Stark, Vanessa Teague
+
 
 ## SHANGRLA framework
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/AuditConfig.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/AuditConfig.kt
@@ -7,7 +7,7 @@ data class AuditConfig(val auditType: AuditType,
                        val seed: Long,
                        val ntrials: Int = 100,
                        val quantile: Double = .80,
-                       val fuzzPct: Double = .001,
+                       val fuzzPct: Double? = null, // with or without mvr fuzz.
                        val p1: Double = 1.0e-2,
                        val p2: Double = 1.0e-4,
                        val p3: Double = 1.0e-2,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/BettingMart.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/BettingMart.kt
@@ -97,7 +97,7 @@ class BettingMart(
         }
 
         val status = when {
-            (mj < 0.0) -> TestH0Status.SampleSum // 5
+            (mj < 0.0) -> TestH0Status.SampleSumRejectNull // 5
             (mj > upperBound) -> TestH0Status.AcceptNull
             else -> {
                 val pvalue = pvalues.last()

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
@@ -9,17 +9,17 @@ interface CvrIF {
     fun hasOneVote(contestId: Int, candidates: List<Int>): Boolean
 }
 
-// there must be an entry in votes for every contest on the ballot, even if no candidate was voted for
-open class Cvr(
+// immutable
+data class Cvr(
     override val id: String,
     override val votes: Map<Int, IntArray>, // contest : list of candidates voted for; for IRV, ranked hi to lo
+    override val phantom: Boolean = false,
 ): CvrIF {
-    override val phantom = false
     override fun hasContest(contestId: Int): Boolean = votes[contestId] != null
 
-    constructor(oldCvr: CvrIF, votes: Map<Int, IntArray>) : this(oldCvr.id, votes)
+    constructor(oldCvr: CvrIF, votes: Map<Int, IntArray>) : this(oldCvr.id, votes, oldCvr.phantom)
     constructor(contest: Int, ranks: List<Int>): this( "testing", mapOf(contest to ranks.toIntArray())) // for quick testing
-    constructor(contest: Int, id: String, ranks: List<Int>): this( id, mapOf(contest to ranks.toIntArray())) // for quick testing
+    constructor(contest: Int, id: String, ranks: List<Int>, phantom: Boolean): this( id, mapOf(contest to ranks.toIntArray()), phantom) // for quick testing
 
     // Let 1candidate(bi) = 1 if ballot i has a mark for candidate, and 0 if not; SHANGRLA section 2, page 4
     override fun hasMarkFor(contestId: Int, candidateId: Int): Int {
@@ -64,16 +64,17 @@ open class Cvr(
 }
 
 /** Mutable version of Cvr. sampleNum >= 0  */
-class CvrUnderAudit (val cvr: Cvr, override val phantom: Boolean, var sampleNum: Long = 0L): CvrIF {
+class CvrUnderAudit (val cvr: Cvr, var sampleNum: Long = 0L): CvrIF {
     var sampled = false //  # is this CVR in the sample?
 
     override val id = cvr.id
     override val votes = cvr.votes
+    override val phantom = cvr.phantom
     override fun hasContest(contestId: Int) = cvr.hasContest(contestId)
     override fun hasMarkFor(contestId: Int, candidateId: Int) = cvr.hasMarkFor(contestId, candidateId)
     override fun hasOneVote(contestId: Int, candidates: List<Int>) = cvr.hasOneVote(contestId, candidates)
 
-    constructor(id: String, contestIdx: Int) : this( Cvr(id, mapOf(contestIdx to IntArray(0))), false)
+    constructor(id: String, contestIdx: Int) : this( Cvr(id, mapOf(contestIdx to IntArray(0)), false))
 
     override fun toString() = buildString {
         append("$id ($phantom)")
@@ -81,8 +82,7 @@ class CvrUnderAudit (val cvr: Cvr, override val phantom: Boolean, var sampleNum:
     }
 
     companion object {
-        fun fromCvrIF(cvr: CvrIF, phantom: Boolean) = if (cvr is CvrUnderAudit) cvr else CvrUnderAudit( cvr as Cvr, phantom)
-        fun makePhantom(cvrId: String, contestId: Int) = CvrUnderAudit(Cvr(contestId, cvrId, emptyList()), true)
+        fun makePhantom(cvrId: String, contestId: Int) = CvrUnderAudit(Cvr(contestId, cvrId, emptyList(), true))
     }
 }
 
@@ -103,28 +103,34 @@ data class BallotStyle(val contestNames: List<String>, val contestIds: List<Int>
     }
 }
 
-// id should probably be String
-open class BallotUnderAudit(val id: Int, val ballotStyle: BallotStyle) {
+// The id must uniquely identify the paper ballot. Here it may be some simple thing (seq number) that points to
+// the paper ballot location. Its necessary that the system publically commit to that mapping before the Audit,
+// as well as to sampleNum.
+// TODO conform better to this spec:
+// B7. Proper bookkeeping of voter participation records and voter registration, and proper ballot
+//      accounting. This gives a trustworthy upper bound on the number of cards validly cast in each
+//      contest under audit. This upper bound must come from some procedure distict/decoupled from the voting system/equipment
+// B8. The ballots are stored securely, creating a trustworthy but possibly incomplete paper trail (some ballots might be missing).
+//      A ballot manifest is created (untrusted, possibly by card style), giving a list of where the ballots are.
+//      It may also be a style manifest which tells you which contests are on which ballots. This does not need to be trusted, but the upper bounds on
+//      the number of cards for each contest do.
+// B9. Untrusted imprinter claims to assign a unique identifier to every card in the manifest. Imprinter
+//      commits to the identifiers it claims to have used. Identifiers, once applied, cannot be altered.
+//      Once audit starts, identifiers cannot be added.
+// B10. Voting system commits to reported winners and possibly other information such as totals, batch
+//      subtotals, or CVRs. Public commitment to CVRs can shroud votes, eg using SOBA or VAULT.
+//      For card-level comparison audits, each CVR is labeled with a unique identifier from the set of
+//      identifiers previously reported (checked later). Identifier is in plaintext even if votes are shrouded.
+
+// C16. Commit to and disclose mapping from PRNG output to identifiers.
+
+// this is ballot_manifest_with_ids
+open class BallotWithStyle(val id: String, val ballotStyle: BallotStyle) {
     var sampleNum: Long = 0L
-    var sampled: Boolean = false // needed?
-    var p = 0.0
+    var sampled: Boolean = false
     var phantom = false
 
     fun hasContest(contestId: Int): Boolean = ballotStyle.hasContest(contestId)
 }
 
-/*
-fun makeBallots(cvrs: List<Cvr>): List<BallotUnderAudit> {
-    val ballotStyles: List<BallotStyle> = makeBallotStyles(cvrs)
-    val result = mutableListOf<BallotUnderAudit>()
-    var ballotId = 0
-    ballotStyles.forEach { ballotStyle ->
-        repeat(ballotStyle.ncards) {
-            result.add(BallotUnderAudit(ballotId, ballotStyle))
-            ballotId++
-        }
-    }
-    return result
-}
- */
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/RiskTestingFn.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/RiskTestingFn.kt
@@ -5,7 +5,7 @@ enum class TestH0Status(val fail: Boolean) {
     LimitReached(true), // cant tell from the number of samples available
 
     //// only when sampling without replacement all the way to N, in practice, this never happens I think
-    SampleSum(false), // SampleSum > N * t, so we know H0 is false
+    SampleSumRejectNull(false), // SampleSum > N * t, so we know H0 is false
     AcceptNull(true), // SampleSum + (all remaining ballots == 1) < N * t, so we know that H0 is true.
 }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/corla/DominionBallotManifest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/corla/DominionBallotManifest.kt
@@ -1,4 +1,4 @@
-package org.cryptobiotic.rlauxe.csv
+package org.cryptobiotic.rlauxe.corla
 
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVParser

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/corla/DominionCvrReader.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/corla/DominionCvrReader.kt
@@ -1,4 +1,4 @@
-package org.cryptobiotic.rlauxe.csv
+package org.cryptobiotic.rlauxe.corla
 
 import org.apache.commons.csv.CSVFormat
 import org.apache.commons.csv.CSVParser

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireAssertions.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireAssertions.kt
@@ -1,9 +1,7 @@
 package org.cryptobiotic.rlauxe.raire
 
-import org.cryptobiotic.rlaux.core.raire.RaireCvr
 import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.core.ContestUnderAudit
-import org.cryptobiotic.rlauxe.util.Stopwatch
 import org.cryptobiotic.rlauxe.util.Welford
 
 // The ouput of RAIRE assertion generator, read from JSON files

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireCvrs.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireCvrs.kt
@@ -1,4 +1,4 @@
-package org.cryptobiotic.rlaux.core.raire
+package org.cryptobiotic.rlauxe.raire
 
 import org.cryptobiotic.rlauxe.core.Cvr
 import org.cryptobiotic.rlauxe.core.CvrIF

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireReader.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireReader.kt
@@ -1,8 +1,5 @@
 package org.cryptobiotic.rlauxe.raire
 
-import org.cryptobiotic.rlaux.core.raire.RaireCvr
-import org.cryptobiotic.rlaux.core.raire.RaireCvrContest
-import org.cryptobiotic.rlaux.core.raire.RaireCvrs
 import org.cryptobiotic.rlauxe.core.Cvr
 import java.io.File
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/ComparisonSamplerSimulation.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/ComparisonSamplerSimulation.kt
@@ -7,6 +7,7 @@ import kotlin.math.max
 
 private val show = true
 
+// TODO maybe lost the sampleNum?
 // create internal cvr and mvr with the correct under/over statements.
 // specific to a contest. only used for estimating the sample size
 class ComparisonSamplerSimulation(
@@ -21,7 +22,7 @@ class ComparisonSamplerSimulation(
 
     val N = rcvrs.size
     val isIRV = contestUA.contest.choiceFunction == SocialChoiceFunction.IRV
-    val mvrs: List<CvrUnderAudit>
+    val mvrs: List<Cvr>
     val cvrs: List<CvrUnderAudit>
     val usedCvrs = mutableSetOf<String>()
 
@@ -40,8 +41,8 @@ class ComparisonSamplerSimulation(
 
         // we want to flip the exact number of votes, for reproducibility
         // note we only do this on construction, reset just uses a different permutation
-        val mmvrs = mutableListOf<CvrUnderAudit>()
-        mmvrs.addAll(rcvrs)
+        val mmvrs = mutableListOf<Cvr>()
+        rcvrs.forEach{ mmvrs.add(it.cvr) }
         val ccvrs = mutableListOf<CvrUnderAudit>()
         ccvrs.addAll(rcvrs)
 
@@ -90,7 +91,7 @@ class ComparisonSamplerSimulation(
     //  plurality:  two vote overstatement: cvr has winner (1), mvr has loser (0)
     //  NEB two vote overstatement: cvr has winner as first pref (1), mvr has loser preceeding winner (0)
     //  NEN two vote overstatement: cvr has winner as first pref among remaining (1), mvr has loser as first pref among remaining (0)
-    fun flip2votes(mcvrs: MutableList<CvrUnderAudit>, needToChange: Int): Int {
+    fun flip2votes(mcvrs: MutableList<Cvr>, needToChange: Int): Int {
         if (needToChange == 0) return 0
         val ncards = mcvrs.size
         val startingAvotes = mcvrs.filter { cassorter.assorter.assort(it) == 1.0 }.count()
@@ -107,8 +108,8 @@ class ComparisonSamplerSimulation(
                 mcvrs[cardIdx] = alteredMvr
                 if (show && cassorter.assorter.assort(alteredMvr) != 0.0) {
                     println("  flip2votes ${cassorter.assorter.assort(alteredMvr)} != 0.0")
-                    println("    cvr=${cvr.cvr}")
-                    println("    alteredMvr=${alteredMvr.cvr}")
+                    println("    cvr=${cvr}")
+                    println("    alteredMvr=${alteredMvr}")
                 }
                 require(cassorter.assorter.assort(alteredMvr) == 0.0)
                 val bassort = cassorter.bassort(alteredMvr, cvr) // mvr, cvr
@@ -130,7 +131,7 @@ class ComparisonSamplerSimulation(
     //  plurality: two vote understatement: cvr has loser (0), mvr has winner (1)
     //  NEB two vote understatement: cvr has loser preceeding winner (0), mvr has winner as first pref (1)
     //  NEN two vote understatement: cvr has loser as first pref among remaining (0), mvr has winner as first pref among remaining (1)
-    fun flip4votes(mcvrs: MutableList<CvrUnderAudit>, needToChange: Int): Int {
+    fun flip4votes(mcvrs: MutableList<Cvr>, needToChange: Int): Int {
         if (needToChange == 0) return 0
         val ncards = mcvrs.size
         val startingAvotes = mcvrs.filter { cassorter.assorter.assort(it) == 0.0 }.count()
@@ -146,8 +147,8 @@ class ComparisonSamplerSimulation(
                 mcvrs[cardIdx] = alteredMvr
                 if (show && cassorter.assorter.assort(alteredMvr) != 1.0) {
                     println("  flip4votes ${cassorter.assorter.assort(alteredMvr)} != 1.0")
-                    println("    cvr=${cvr.cvr}")
-                    println("    alteredMvr=${alteredMvr.cvr}")
+                    println("    cvr=${cvr}")
+                    println("    alteredMvr=${alteredMvr}")
                 }
                 require(cassorter.assorter.assort(alteredMvr) == 1.0)
                 val bassort = cassorter.bassort(alteredMvr, cvr)
@@ -170,7 +171,7 @@ class ComparisonSamplerSimulation(
     //  plurality: one vote overstatement: cvr has winner (1), mvr has other (1/2)
     //  NEB one vote overstatement: cvr has winner as first pref (1), mvr has winner preceding loser, but not first (1/2)
     //  NEN one vote overstatement: cvr has winner as first pref among remaining (1), mvr has neither winner nor loser as first pref among remaining (1/2)
-    fun flip1votes(mcvrs: MutableList<CvrUnderAudit>, needToChange: Int): Int {
+    fun flip1votes(mcvrs: MutableList<Cvr>, needToChange: Int): Int {
         if (needToChange == 0) return 0
         val ncards = mcvrs.size
         var changed = 0
@@ -186,8 +187,8 @@ class ComparisonSamplerSimulation(
                 mcvrs[cardIdx] = alteredMvr
                 if (show && cassorter.assorter.assort(alteredMvr) != 0.5) {
                     println("  flip1votes ${cassorter.assorter.assort(alteredMvr)} != 0.5")
-                    println("    cvr=${cvr.cvr}")
-                    println("    alteredMvr=${alteredMvr.cvr}")
+                    println("    cvr=${cvr}")
+                    println("    alteredMvr=${alteredMvr}")
                 }
                 require(cassorter.assorter.assort(alteredMvr) == 0.5)
                 val bassort = cassorter.bassort(alteredMvr, cvr)
@@ -210,7 +211,7 @@ class ComparisonSamplerSimulation(
     //  plurality: one vote understatement: cvr has other (1/2), mvr has winner (1)
     //  NEB one vote understatement: cvr has winner preceding loser (1/2), but not first, mvr has winner as first pref (1)
     //  NEN one vote understatement: cvr has neither winner nor loser as first pref among remaining (1/2), mvr has winner as first pref among remaining (1)
-    fun flip3votes(mcvrs: MutableList<CvrUnderAudit>, needToChange: Int): Int {
+    fun flip3votes(mcvrs: MutableList<Cvr>, needToChange: Int): Int {
         if (needToChange == 0) return 0
         val ncards = mcvrs.size
         var changed = 0
@@ -242,7 +243,7 @@ class ComparisonSamplerSimulation(
     }
 
     //  plurality: one vote understatement: cvr has other (1/2), mvr has winner (1). have to change cvr to other
-    fun flip3votesP(mcvrs: MutableList<CvrUnderAudit>, cvrs: MutableList<CvrUnderAudit>, needToChange: Int): Int {
+    fun flip3votesP(mcvrs: MutableList<Cvr>, cvrs: MutableList<CvrUnderAudit>, needToChange: Int): Int {
         if (needToChange == 0) return 0
         val ncards = mcvrs.size
         val otherCandidate = max(cassorter.assorter.winner(), cassorter.assorter.loser()) + 1
@@ -262,7 +263,7 @@ class ComparisonSamplerSimulation(
                     cassorter.bassort(mvr, alteredCvr)
                 }
                 require(cassorter.bassort(mvr, alteredCvr) == 1.5 * cassorter.noerror)
-                cvrs[cardIdx] = alteredCvr // Note we are changing the cvr, not the mvr
+                cvrs[cardIdx] = CvrUnderAudit(alteredCvr) // Note we are changing the cvr, not the mvr
                 changed++
             }
             cardIdx++
@@ -271,34 +272,6 @@ class ComparisonSamplerSimulation(
         if (checkAvotes != startingAvotes - needToChange)
             println("flip3votesP could only flip $changed, wanted $needToChange")
         require(checkAvotes == startingAvotes - needToChange)
-
-        return changed
-    }
-
-    // previous
-    fun flip3votes(mcvrs: MutableList<CvrUnderAudit>, cvrs: MutableList<CvrUnderAudit>, changeCvrToOther: Int): Int {
-        if (changeCvrToOther == 0) return 0
-        val ncards = mcvrs.size
-        var changed = 0
-
-        // random other candidate, just cant be winner or loser
-        val otherCandidate = max(cassorter.assorter.winner(), cassorter.assorter.loser()) + 1
-
-        val startingAvotes = cvrs.sumOf { it.hasMarkFor(contestUA.id, cassorter.assorter.winner()) }
-        while (changed < changeCvrToOther) {
-            val cvrIdx = secureRandom.nextInt(ncards)
-            val mvr = mcvrs[cvrIdx]
-            val cvr = cvrs[cvrIdx]
-            if ((cvr.hasMarkFor(contestUA.id, cassorter.assorter.winner()) == 1) && (mvr.votes == cvr.votes)) {
-                val votes = mapOf(contestUA.id to intArrayOf(otherCandidate))
-                val altered = makeNewCvr(cvr, votes)
-                cvrs[cvrIdx] = altered // Note we are changing the cvr, not the mvr
-                require(cassorter.bassort(mvr, altered) == 1.5 * cassorter.noerror) // p3 loser -> other
-                changed++
-            }
-        }
-        val checkAvotes = cvrs.sumOf { it.hasMarkFor(contestUA.id, cassorter.assorter.winner()) }
-        require(checkAvotes == startingAvotes - changeCvrToOther)
 
         return changed
     }
@@ -319,8 +292,8 @@ class ComparisonSamplerSimulation(
         return result
     }
 
-    fun makeNewCvr(old: CvrUnderAudit, votes: Map<Int, IntArray>): CvrUnderAudit {
+    fun makeNewCvr(old: Cvr, votes: Map<Int, IntArray>): Cvr {
         usedCvrs.add(old.id)
-        return CvrUnderAudit(Cvr(old.cvr, votes), old.phantom, old.sampleNum)
+        return Cvr(old, votes)
     }
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/ConsistentSampling.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/ConsistentSampling.kt
@@ -49,7 +49,7 @@ class PhantomBuilder(val id: String) {
     val contests = mutableListOf<Int>()
     fun build(prng: Prng): CvrUnderAudit {
         val votes = contests.associateWith { IntArray(0) }
-        return CvrUnderAudit(Cvr(id, votes), phantom = true, prng.next())
+        return CvrUnderAudit(Cvr(id, votes, phantom = true), prng.next())
     }
 }
 ///////////////////////////////////////////////////////////////////////
@@ -104,7 +104,7 @@ fun consistentCvrSampling(
 
 fun consistentPollingSampling(
     contests: List<ContestUnderAudit>, // all the contests you want to sample
-    ballots: List<BallotUnderAudit>, // all the ballots available to sample
+    ballots: List<BallotWithStyle>, // all the ballots available to sample
 ): List<Int> {
     if (ballots.isEmpty()) return emptyList()
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/FuzzSampler.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/FuzzSampler.kt
@@ -6,7 +6,7 @@ import org.cryptobiotic.rlauxe.util.CvrBuilders
 import org.cryptobiotic.rlauxe.util.CvrContest
 import org.cryptobiotic.rlauxe.util.secureRandom
 
-class ComparisonSamplerRegen(
+class ComparisonFuzzSampler(
     val fuzzPct: Double,
     val cvrs: List<Cvr>,
     val contestUA: ContestUnderAudit,
@@ -49,7 +49,7 @@ class ComparisonSamplerRegen(
     override fun N() = N
 }
 
-class PollingSamplerRegen(
+class PollingFuzzSampler(
     val fuzzPct: Double,
     val cvrs: List<Cvr>,
     val contestUA: ContestUnderAudit,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/MultiContestTestData.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/MultiContestTestData.kt
@@ -65,12 +65,12 @@ data class MultiContestTestData(
         return fcontests.map { it.makeContest() }
     }
 
-    fun makeBallots(): List<BallotUnderAudit> {
-        val result = mutableListOf<BallotUnderAudit>()
+    fun makeBallots(): List<BallotWithStyle> {
+        val result = mutableListOf<BallotWithStyle>()
         var ballotId = 0
         ballotStyles.forEach { ballotStyle ->
             repeat(ballotStyle.ncards) {
-                result.add(BallotUnderAudit(ballotId, ballotStyle))
+                result.add(BallotWithStyle("ballot$ballotId", ballotStyle))
                 ballotId++
             }
         }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/CvrBuilder.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/CvrBuilder.kt
@@ -40,7 +40,7 @@ class CvrBuilders {
         return cb
     }
 
-    fun build(): List<CvrIF> {
+    fun build(): List<Cvr> {
         return builders.map { it.build() }
     }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Cvrs.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Cvrs.kt
@@ -46,8 +46,8 @@ fun makeCvrsByMargin(ncards: Int, margin: Double = 0.0) : List<Cvr> {
 fun margin2mean(margin: Double) = (margin + 1.0) / 2.0
 fun mean2margin(mean: Double) = 2.0 * mean - 1.0
 
-fun makeCvrsByExactMean(ncards: Int, mean: Double) : List<CvrIF> {
-    val randomCvrs = mutableListOf<CvrIF>()
+fun makeCvrsByExactMean(ncards: Int, mean: Double) : List<Cvr> {
+    val randomCvrs = mutableListOf<Cvr>()
     repeat(ncards) {
         val random = secureRandom.nextDouble(1.0)
         val cand = if (random < mean) 0 else 1
@@ -79,10 +79,10 @@ class SimContest(val contest: Contest, val assorter: AssorterFunction) {
     }
 
     // makes a new, independent set of Cvrs with the contest votes
-    fun makeCvrs(): List<CvrIF> {
+    fun makeCvrs(): List<Cvr> {
         resetTracker()
         val cvrbs = CvrBuilders().addContests(listOf(this.info))
-        val result = mutableListOf<CvrIF>()
+        val result = mutableListOf<Cvr>()
         repeat(this.ncards) {
             val cvrb = cvrbs.addCrv()
             cvrb.addContest(info.name, chooseCandidate(Random.nextInt(votesLeft))).done()

--- a/core/src/main/proto/rlauxe.proto
+++ b/core/src/main/proto/rlauxe.proto
@@ -1,20 +1,12 @@
 syntax = "proto3";
 
-option java_package = "org.cryptobiotic.protogen";
+option java_package = "org.cryptobiotic.rlauxe.protogen";
 option java_outer_classname = "RlauxeProto";
 
-// data class AuditConfig(val auditType: AuditType,
-//                       val riskLimit: Double,
-//                       val seed: Long,
-//                       val ntrials: Int = 100,
-//                       val quantile: Double = .80,
-//                       val p1: Double = 1.0e-2,
-//                       val p2: Double = 1.0e-4,
-//                       val p3: Double = 1.0e-2,
-//                       val p4: Double = 1.0e-4,
-//                       val d1: Int = 100,  // for trunc_shrinkage
-//                       val d2: Int = 100,
-message AuditConfig {
+////////////////////////////////////////////////////////////////////////////////
+//// Pre Election Information
+
+message AuditInfo {
   enum AuditType {
     unknown = 0;
     polling = 1;
@@ -22,24 +14,15 @@ message AuditConfig {
     one_audit = 3;
   }
 
-  string spec_version = 1;
+  string audit_name = 1;
   AuditType audit_type = 2;
-  double risk_limit = 3;
-  bytes seed = 4;
-  int32 ntrials = 5;
-  double quantile = 6;
-  repeated double errorRates = 7;
-  repeated double trunc_shrinkae_params = 8;
-  map<string, string> contest_max_cards = 10;
+  repeated ContestInfo contest_info = 3;
+  double risk_limit = 4;
+  bool cvrs_are_complete = 5; // cvrs have an entry for all contests on that ballot, dont need ballot manifest
+  bool has_styles = 6; // implies cvrs_are_complete or BallotManifest not null
 }
 
-//     val name: String,
-//    val id: Int,
-//    val candidateNames: Map<String, Int>, // candidate name -> candidate id
-//    val winnerNames: List<String>,
-//    val choiceFunction: SocialChoiceFunction,
-//    val minFraction: Double? = null, // supermajority only.
-message Contest {
+message ContestInfo {
   enum SocialChoiceType {
     unknown = 0;
     plurality = 1;
@@ -49,22 +32,137 @@ message Contest {
   }
 
   string name = 1;
-  int32 id = 2;
-  map<string, int32> candidates = 3;
-  repeated string winnerNames = 4;
-  SocialChoiceType choiceFunction = 5;
-  double minFraction = 6; // supermajority only.
-
-  int32 ncvrs = 7;
-  int32 upperBound = 8;
-  int32 estSampleSize = 9;
-  bytes thresholdSampleNumber = 10;
+  uint32 id = 2;
+  map<string, uint32> candidates = 3; // name -> candidate id
+  SocialChoiceType choiceFunction = 4;
+  uint32 nwinners = 5;
+  double minFraction = 6; // supermajority only. between 0 and 1.
 }
 
-// The constants for mathematical functions during the election.
+////////////////////////////////////////////////////////////////////////////////
+//// Election Information
+
+message Audit {
+  AuditInfo audit_info = 1;
+  AuditConfig audit_config = 2;
+  bytes sample_seed = 3;
+  ContestBounds contest_bounds = 4;
+  repeated Contest contests = 5;
+
+  Cvrs cvrs = 6; // must be present if AuditType.comparison. could use pointer instead of embedding.
+  BallotManifest ballot_manifest = 7;
+}
+
+message AuditConfig {
+  int32 ntrials = 1;
+  double quantile = 2;
+  repeated double errorRates = 3;
+  repeated double trunc_shrinkage_params = 4;
+}
+
+message ContestBounds {
+  map<string, uint32> bounds = 1; // contest name -> bound. B7. trustworthy upper bound on number of ballots for this contest
+}
+
+message Contest {
+  ContestInfo info = 1;
+  repeated string reported_winners = 2; // B8
+  repeated Votes reported_votes = 3; // B8
+
+  // assertions with their margins ??
+  // nphantoms ??
+}
+
+message Votes {
+    string contest_id = 1;
+    repeated uint32 candidate_ids = 2; // assume each candidate has 0 or 1 votes.
+                                       // for irv, the order of candidate_ids is their ranking
+}
+
+// used for polling, or with non-complete cvrs.
+message BallotManifest {
+  oneof bm {
+    BallotManifestWithIds ballot_manifest_with_ids = 1;
+    BallotManifestWithCount ballot_manifest_with_count = 2;
+  }
+}
+
+// if we have this, we can massage the cvrs so that cvrs_are_complete.
+// for polling, we can derive BallotManifestWithCount, whic i think is just as good.
+message BallotManifestWithIds  {
+  repeated BallotStyleWithIds bs = 1;
+}
+
+message BallotStyleWithIds {
+  string name = 1; // name of ballot style
+  repeated uint32 contests = 2;  // which contests are in this style
+  repeated string ballot_ids = 3; // list of ballots with this style; matches CVR.
+}
+
+
+message BallotManifestWithCount  {
+  repeated BallotStyleWithCount bs = 1;
+}
+
+message BallotStyleWithCount {
+  string name = 1; // name of ballot style
+  repeated uint32 contests = 2;  // which contests are on this ballot style
+  uint32 nballots = 3; // number of ballots that voted that have this style
+}
+
 message Cvr {
-  string id = 1;
-  map<int32, bytes> votes = 2; // more than 255 candidates ? could switch to base 128 encoding
+  string ballot_id = 1;
+  repeated Votes votes = 2; // one for each contest on the ballot.
+                            // cvrs_are_complete implies all contests have an entry, even if candidate_ids is empty
+  // phantom implies candidate_ids always empty
   bool phantom = 3;
-  bytes sampleNumber = 4; // randomly assigned
+  bytes sampleNum = 4; // deterministically generated from sample_seed.
+}
+
+message Cvrs {
+  repeated Cvr mvr = 1;
+}
+
+// options (pick one)
+// comparison
+//  cvrs_are_complete
+//  has ballot_manifest_with_ids. equivilent to cvrs_are_complete
+//  has ballot_manifest_with_count
+//  with_styles = false
+// polling
+//  has ballot_manifest_with_ids.
+//  has ballot_manifest_with_count
+//  with_styles = false
+
+////////////////////////////////////////////////////////////////////////////////
+//// Audit results
+
+message AuditResult {
+  string audit_name = 1;
+  repeated AuditedContest contests = 2;
+  Mvrs mvrs = 3; // could use pointer instead of embedding.
+}
+
+message AuditedContest {
+
+  enum AuditStatus {
+    Unknown = 0;
+    StatRejectNull = 1; // statistical rejection of H0
+    LimitReached = 2; // cant tell from the number of samples available
+
+    //// only when sampling without replacement all the way to N, in practice, this never happens.
+    SampleSumRejectNull = 3; // SampleSum > N * t, so we know H0 is false
+    AcceptNull = 4; // SampleSum + (all remaining ballots == 1) < N * t, so we know that H0 is true.
+  }
+
+  Contest contest = 1;
+  uint32 estSampleSize = 2;
+  uint32 actualSampleSize = 3;
+  AuditStatus status = 4;
+  double pvalue = 5;  // probability of null hypotheris (H0) being true
+  uint32 nrounds = 6; // how many rounds of sampling were done?
+}
+
+message Mvrs {
+  repeated Cvr mvr = 1;
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestCvrReader.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestCvrReader.kt
@@ -1,9 +1,5 @@
 package org.cryptobiotic.rlauxe.corla
 
-import org.cryptobiotic.rlauxe.csv.CastVoteRecord
-import org.cryptobiotic.rlauxe.csv.ContestInfo
-import org.cryptobiotic.rlauxe.csv.CvrExport
-import org.cryptobiotic.rlauxe.csv.readDominionCvrExport
 import org.junit.jupiter.api.Assertions.assertTrue
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestRaireAssertions.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestRaireAssertions.kt
@@ -23,7 +23,7 @@ class TestRaireAssertions {
 
         val prng = Prng(123456789011L)
         val phantomCVRs = makePhantomCvrs(contestsUA, "phantom-", prng)
-        val cvrsUA = cvrs.map { CvrUnderAudit(it, false, prng.next()) } + phantomCVRs
+        val cvrsUA = cvrs.map { CvrUnderAudit(it, prng.next()) } + phantomCVRs
 
         contestsUA.forEach { contest ->
             contest.makeComparisonAssertions(cvrsUA)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestRaireReader.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestRaireReader.kt
@@ -1,6 +1,5 @@
 package org.cryptobiotic.rlauxe.raire
 
-import org.cryptobiotic.rlaux.core.raire.RaireCvrs
 import org.junit.jupiter.api.Assertions.assertEquals
 import java.io.File
 import kotlin.test.Test

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestRcvAssorter.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestRcvAssorter.kt
@@ -1,6 +1,5 @@
 package org.cryptobiotic.rlauxe.raire
 
-import org.cryptobiotic.rlaux.core.raire.RaireCvr
 import org.cryptobiotic.rlauxe.core.Cvr
 import kotlin.test.Test
 import kotlin.test.assertEquals

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestComparisonSamplerSimulation.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestComparisonSamplerSimulation.kt
@@ -16,8 +16,8 @@ class TestComparisonSamplerSimulation {
         val margins = listOf(.017, .03, .05)
         for (margin in margins) {
             val theta = margin2mean(margin)
-            val cvrs: List<CvrIF> = makeCvrsByExactMean(N, theta)
-            val cvrsUA = cvrs.map { CvrUnderAudit(it as Cvr, false) }
+            val cvrs: List<Cvr> = makeCvrsByExactMean(N, theta)
+            val cvrsUA = cvrs.map { CvrUnderAudit(it) }
 
             val contest = makeContestsFromCvrs(cvrs).first()
             val contestUA = ContestUnderAudit(contest).makeComparisonAssertions(cvrs)
@@ -47,8 +47,8 @@ class TestComparisonSamplerSimulation {
         val margins = listOf(.017, .03, .05)
         for (margin in margins) {
             val theta = margin2mean(margin)
-            val cvrs: List<CvrIF> = makeCvrsByExactMean(N, theta)
-            val cvrsUA = cvrs.map { CvrUnderAudit(it as Cvr, false) }
+            val cvrs: List<Cvr> = makeCvrsByExactMean(N, theta)
+            val cvrsUA = cvrs.map { CvrUnderAudit(it) }
 
             val contest = makeContestsFromCvrs(cvrs).first()
             val contestUA = ContestUnderAudit(contest).makeComparisonAssertions(cvrs)
@@ -70,7 +70,7 @@ class TestComparisonSamplerSimulation {
             "/home/stormy/dev/github/rla/rlauxe/core/src/test/data/SFDA2019/SFDA2019_PrelimReport12VBMJustDASheets.raire"
         val raireCvrs = readRaireBallots(cvrFile)
         val cvrs = raireCvrs.cvrs
-        val cvrsUA = cvrs.map { CvrUnderAudit(it, false) }
+        val cvrsUA = cvrs.map { CvrUnderAudit(it) }
 
         contestUA.makeComparisonAssertions(cvrsUA)
 
@@ -91,7 +91,7 @@ class TestComparisonSamplerSimulation {
 
         val before = cvrsUA.map { assorter.bassort(it, it) }.average()
         sampler.reset()
-        var welford = Welford()
+        val welford = Welford()
         repeat(cvrsUA.size) {
             welford.update(sampler.sample())
         }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestComparisonWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestComparisonWorkflow.kt
@@ -18,7 +18,7 @@ class TestComparisonWorkflow {
         val contests: List<Contest> = testData.makeContests()
         val cvrs = testData.makeCvrsFromContests()
 
-        val workflow = StylishWorkflow(contests, emptyList(), auditConfig, cvrs)
+        val workflow = ComparisonWithCompleteCvrs(contests, emptyList(), auditConfig, cvrs)
         println("initialize took ${stopwatch.elapsed(TimeUnit.MILLISECONDS)} ms\n")
         stopwatch.start()
 
@@ -87,7 +87,7 @@ class TestComparisonWorkflow {
             rrc.Nc = rc.ncvrs
         }
 
-        val workflow = StylishWorkflow(emptyList(), raireResults.contests, auditConfig, cvrs)
+        val workflow = ComparisonWithCompleteCvrs(emptyList(), raireResults.contests, auditConfig, cvrs)
         println("initialize took ${stopwatch.elapsed(TimeUnit.MILLISECONDS)} ms\n")
         stopwatch.start()
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestConsistentSampling.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestConsistentSampling.kt
@@ -34,7 +34,7 @@ class TestConsistentSampling {
 
         val prng = Prng(12345678901L)
         val cvrsUA = cvrs.mapIndexed { idx, it ->
-            CvrUnderAudit( it as Cvr, false, prng.next()) // here we assign sample number deterministically
+            CvrUnderAudit( it, prng.next()) // here we assign sample number deterministically
         }
         val contestsUA = contestInfos.mapIndexed { idx, it ->
             ContestUnderAudit( it, cvrs)
@@ -79,7 +79,7 @@ class TestConsistentSampling {
 
         val prng = Prng(123456789012L)
         val cvrsUA = cvrs.mapIndexed { idx, it ->
-            CvrUnderAudit( it as Cvr, false, prng.next())
+            CvrUnderAudit( it, prng.next())
         }
 
         val contestsUA = contestInfos.mapIndexed { idx, it ->
@@ -122,7 +122,7 @@ class TestConsistentSampling {
             contestsUA.forEach { it.estSampleSize = it.Nc / 11 } // random
 
             val prng = Prng(secureRandom.nextLong())
-            val cvrsUAP = test.makeCvrsFromContests().map { CvrUnderAudit( it as Cvr, false, prng.next()) }
+            val cvrsUAP = test.makeCvrsFromContests().map { CvrUnderAudit( it, prng.next()) }
 
             val sample_cvr_indices = consistentCvrSampling(contestsUA, cvrsUAP)
             println("nsamples = ${sample_cvr_indices.size}\n")

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestEstimateSampleSize.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestEstimateSampleSize.kt
@@ -10,12 +10,12 @@ import kotlin.math.ceil
 import kotlin.test.Test
 
 
-class TestFindSampleSize {
+class TestEstimateSampleSize {
     @Test
     fun testFindSampleSize() {
         val test = MultiContestTestData(20, 11, 20000)
         val contestsUA: List<ContestUnderAudit> = test.makeContests().map { ContestUnderAudit( it, it.Nc) }
-        val cvrsUAP = test.makeCvrsFromContests().map { CvrUnderAudit.fromCvrIF( it, false) }
+        val cvrsUAP = test.makeCvrsFromContests().map { CvrUnderAudit( it) }
 
         contestsUA.forEach { contest ->
             println("contest = ${contest}")
@@ -42,7 +42,7 @@ class TestFindSampleSize {
 
         val gamma = 1.2
         val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, riskLimit=0.05, seed = 1234567890L, quantile=.50)
-        val finder = FindSampleSize(auditConfig)
+        val finder = EstimateSampleSize(auditConfig)
 
         contestsUA.forEach { contestUA ->
             val cn = contestUA.ncvrs

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestPollingWithManifestIds.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestPollingWithManifestIds.kt
@@ -5,24 +5,26 @@ import org.cryptobiotic.rlauxe.util.*
 import java.util.concurrent.TimeUnit
 import kotlin.test.Test
 
-class TestPollingWorkflow {
+class TestPollingWithManifestIds {
 
     @Test
     fun testPollingWorkflow() {
         val stopwatch = Stopwatch()
         val auditConfig = AuditConfig(AuditType.POLLING, riskLimit=0.05, seed = 12356667890L, quantile=.80, fuzzPct = .01)
 
+        // each contest has a specific margin between the top two vote getters.
         val test = MultiContestTestData(20, 11, 20000)
         val contests: List<Contest> = test.makeContests()
-        // contests.forEach { println(it) }
 
-        // in practice, we dont actually have any cvrs.
+        // Synthetic cvrs for testing reflecting the exact contest votes. In practice, we dont actually have the cvrs.
         val testCvrs = test.makeCvrsFromContests()
+        // However "polling with styles" requires that we know how many ballots each contest has.
         val ballots = test.makeBallots()
 
-        val testMvrs: List<Cvr> = makeFuzzedCvrsFrom(contests, testCvrs, auditConfig.fuzzPct)
+        // fuzzPct of the Mvrs have their votes randomly changes ("fuzzed")
+        val testMvrs: List<Cvr> = makeFuzzedCvrsFrom(contests, testCvrs, auditConfig.fuzzPct!!)
 
-        val workflow = PollingWorkflow(auditConfig, contests, ballots)
+        val workflow = PollingWithManifestIds(auditConfig, contests, ballots)
         println("initialize took ${stopwatch.elapsed(TimeUnit.MILLISECONDS)} ms\n")
         stopwatch.start()
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCvrBuilders.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCvrBuilders.kt
@@ -20,7 +20,7 @@ class TestCvrBuilders {
         cvrs.forEach { CvrBuilder.fromCvr(cvrsbs, it) }
 
         // convert back to Cvr
-        val roundtrip: List<Cvr>  = cvrsbs.build().map { it as Cvr}
+        val roundtrip: List<Cvr>  = cvrsbs.build().map { it }
         // same order
         roundtrip.forEachIndexed { idx, it ->
             assertEquals( cvrs[idx], it)
@@ -34,7 +34,7 @@ class TestCvrBuilders {
         val contests: List<Contest> = test.makeContests()
         val cvrs = test.makeCvrsFromContests()
         val detail = false
-        val ntrials = 100
+        val ntrials = 1
         val fuzzPcts = listOf(0.0, 0.001, .005, .01, .02, .05)
         fuzzPcts.forEach { fuzzPct ->
             val fcvrs = makeFuzzedCvrsFrom(contests, cvrs, fuzzPct)
@@ -55,8 +55,8 @@ class TestCvrBuilders {
                         }
                     }
                     val fuzz = count.toDouble() / ccount
+                    println("$it ${contest.name} changed = $count out of ${ccount} = ${df(fuzz)}")
                     if (detail) {
-                        println(" ${contest.name} changed = $count out of ${ccount} = ${df(fuzz)}")
                         println("  errors = ${samples.samplingErrors()}")
                         println("  rates =  ${samples.samplingErrors(ccount.toDouble())}")
                         println("  error% = ${samples.samplingErrors(ccount * fuzz)}")

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/AssertionRLAipynb.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/AssertionRLAipynb.kt
@@ -1,7 +1,7 @@
 package org.cryptobiotic.rlauxe.workflow
 
 import org.cryptobiotic.rlauxe.core.*
-import org.cryptobiotic.rlauxe.csv.readDominionBallotManifest
+import org.cryptobiotic.rlauxe.corla.readDominionBallotManifest
 import org.cryptobiotic.rlauxe.raire.*
 import org.cryptobiotic.rlauxe.sampling.*
 import org.cryptobiotic.rlauxe.util.*
@@ -431,7 +431,7 @@ class AssertionRLA {
 //CVR.assign_sample_nums(cvr_list, prng)
         // TODO evaluate secureRandom for production, also needs to be deterministic, ie seeded
         val prng = Prng(secureRandom.nextLong())
-        val cvras = rcvrs.map { CvrUnderAudit(it, phantom = false, prng.next()) }
+        val cvras = rcvrs.map { CvrUnderAudit(it, prng.next()) }
         println("calc_sample_sizes = $results")
 
 //#%%

--- a/docs/Development.md
+++ b/docs/Development.md
@@ -6,6 +6,9 @@ last changed: 11/25/2024
 ### core
 * raire library
 * hybrid audits
+* DONE PollingWithStyles
+* PollingWithoutStyles
+* the effect of adding n worst-case ballots to an audit.
 
 ### sampling
 * Estimate sample sizes with fixed formula
@@ -15,8 +18,7 @@ last changed: 11/25/2024
 * SecureRandom must be deterministic using a given seed, so verifiers can test. 
   Make a version that agrees exactly with SHANGRLA's version. (3)
   BigIntegers? Strings? Maybe hex strings?
-* DONE Polling
-* without CSD?
+
 * COBRA 4.3 Diversified betting
 
 ### multiple rounds

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/comparison/CompareAuditType.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/comparison/CompareAuditType.kt
@@ -38,7 +38,7 @@ import kotlin.test.Test
 class CompareAuditType {
     val N = 10000
 
-    data class AlphaMartTask(val idx: Int, val N: Int, val theta: Double, val cvrs: List<CvrIF>)
+    data class AlphaMartTask(val idx: Int, val N: Int, val theta: Double, val cvrs: List<Cvr>)
 
     @Test
     fun plotOver() {
@@ -199,7 +199,7 @@ class CompareAuditType {
 
     fun runDiffAuditTypes(
         theta: Double,
-        cvrs: List<CvrIF>,
+        cvrs: List<Cvr>,
         reportedMeanDiff: Double,
         nrepeat: Int,
         d: Int = 500,

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/comparison/CompareAuditTypeWithErrors.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/comparison/CompareAuditTypeWithErrors.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.sync.withLock
 
 import kotlinx.coroutines.yield
 import org.cryptobiotic.rlauxe.core.ContestUnderAudit
+import org.cryptobiotic.rlauxe.core.Cvr
 import org.cryptobiotic.rlauxe.sampling.ComparisonWithErrors
 import org.cryptobiotic.rlauxe.core.CvrIF
 import org.cryptobiotic.rlauxe.sampling.PollWithoutReplacement
@@ -42,7 +43,7 @@ import kotlin.test.Test
 // compare ballot polling to card comparison
 class CompareAuditTypeWithErrors {
     val showCalculation = false
-    data class AlphaMartTask(val idx: Int, val N: Int, val cvrMean: Double, val eta0Factor: Double, val cvrs: List<CvrIF>)
+    data class AlphaMartTask(val idx: Int, val N: Int, val cvrMean: Double, val eta0Factor: Double, val cvrs: List<Cvr>)
 
     @Test
     fun plotAuditTypesNT() {
@@ -308,7 +309,7 @@ class CompareAuditTypeWithErrors {
 
     fun runDiffAuditTypes(
         cvrMean: Double,
-        cvrs: List<CvrIF>,
+        cvrs: List<Cvr>,
         cvrMeanDiff: Double,
         ntrials: Int,
         eta0Factor: Double,

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/plots/ComparisonWithErrors.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/plots/ComparisonWithErrors.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
 
 import kotlinx.coroutines.yield
+import org.cryptobiotic.rlauxe.core.Cvr
 import org.cryptobiotic.rlauxe.sampling.ComparisonWithErrors
 import org.cryptobiotic.rlauxe.core.CvrIF
 import org.cryptobiotic.rlauxe.core.comparisonAssorterCalc
@@ -42,7 +43,7 @@ class ComparisonWithErrors {
         val cvrMean: Double,
         val cvrMeanDiff: Double,
         val eta0Factor: Double,
-        val cvrs: List<CvrIF>
+        val cvrs: List<Cvr>
     )
 
     @Test
@@ -610,7 +611,7 @@ class ComparisonWithErrors {
 
 fun runComparisonWithMeanDiff(
     cvrMean: Double,
-    cvrs: List<CvrIF>,
+    cvrs: List<Cvr>,
     cvrMeanDiff: Double,
     nrepeat: Int,
     eta0Factor: Double,

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/plots/CreatePollingDIffMeans.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/plots/CreatePollingDIffMeans.kt
@@ -48,7 +48,7 @@ class CreatePollingDiffMeans {
     val N = 50000
 
     // theta is the true mean
-    data class AlphaMartTask(val idx: Int, val N: Int, val theta: Double, val cvrs: List<CvrIF>)
+    data class AlphaMartTask(val idx: Int, val N: Int, val theta: Double, val cvrs: List<Cvr>)
 
     @Test
     fun plotOver() {
@@ -211,7 +211,7 @@ class CreatePollingDiffMeans {
 
     fun runAlphaMartWithMeanDiff(
         theta: Double,
-        cvrs: List<CvrIF>,
+        cvrs: List<Cvr>,
         reportedMeanDiff: Double,
         nrepeat: Int,
         d: Int = 500,

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/polling/TestAuditPolling.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/polling/TestAuditPolling.kt
@@ -47,7 +47,7 @@ class TestAuditPolling {
         plotDDsample(srs, "PollingWithoutDD")
     }
 
-    fun testPollingWorkflow(margin: Double, withoutReplacement: Boolean, cvrs: List<CvrIF>, d: Int, silent: Boolean = true): List<RunTestRepeatedResult> {
+    fun testPollingWorkflow(margin: Double, withoutReplacement: Boolean, cvrs: List<Cvr>, d: Int, silent: Boolean = true): List<RunTestRepeatedResult> {
         val N = cvrs.size
         if (!silent) println(" d= $d, N=${cvrs.size} margin=$margin ${if (withoutReplacement) "withoutReplacement" else "withReplacement"}")
 

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/rlaplots/TestSrt.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/rlaplots/TestSrt.kt
@@ -3,7 +3,6 @@ package org.cryptobiotic.rlauxe.rlaplots
 import org.cryptobiotic.rlauxe.core.TestH0Status
 import org.cryptobiotic.rlauxe.sampling.RunTestRepeatedResult
 import org.cryptobiotic.rlauxe.util.Deciles
-import org.cryptobiotic.rlauxe.util.mean2margin
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
@@ -40,7 +39,7 @@ class TestSrt {
         val ntrials = 111
         val hist = Deciles(ntrials)
         repeat(ntrials) { hist.add(it + 1) }
-        val status = mapOf(TestH0Status.LimitReached to 1, TestH0Status.AcceptNull to 2, TestH0Status.StatRejectNull to 3, TestH0Status.SampleSum to 4 )
+        val status = mapOf(TestH0Status.LimitReached to 1, TestH0Status.AcceptNull to 2, TestH0Status.StatRejectNull to 3, TestH0Status.SampleSumRejectNull to 4 )
 
         //                val testParameters: Map<String, Double>, // various parameters, depends on the test
         //               val N: Int,                  // population size (eg number of ballots)

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sim/AlphaComparisonTask.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sim/AlphaComparisonTask.kt
@@ -16,7 +16,7 @@ data class AlphaComparisonTask(
     val cvrMeanDiff: Double,
     val eta0Factor: Double,
     val d: Int, // parameter for shrinkTruncate
-    val cvrs: List<CvrIF>,
+    val cvrs: List<Cvr>,
     val withoutReplacement: Boolean = true,
     val estimFn: EstimFn? = null, // if not supplied, use TruncShrinkage
 ): RepeatedTask {

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sim/BettingTask.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sim/BettingTask.kt
@@ -9,7 +9,7 @@ data class BettingTask(
     val idx: Int,
     val N: Int,
     val cvrMean: Double,
-    val cvrs: List<CvrIF>,
+    val cvrs: List<Cvr>,
     val d2: Int, // weight p2, p4
     val p2oracle: Double, // oracle rate of 2-vote overstatements
     val p2prior: Double, // apriori rate of 2-vote overstatements; set to 0 to remove consideration

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sim/CorlaTask.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sim/CorlaTask.kt
@@ -1,5 +1,6 @@
 package org.cryptobiotic.rlauxe.sim
 
+import org.cryptobiotic.rlauxe.core.Cvr
 import org.cryptobiotic.rlauxe.sampling.ComparisonWithErrorRates
 import org.cryptobiotic.rlauxe.core.CvrIF
 import org.cryptobiotic.rlauxe.core.RiskTestingFn
@@ -11,7 +12,7 @@ data class CorlaTask(
     val idx: Int,
     val N: Int,
     val cvrMean: Double,
-    val cvrs: List<CvrIF>,
+    val cvrs: List<Cvr>,
     val riskLimit: Double = 0.05,
     val p2: Double,      // oracle rate of 2-vote overstatements
     val p1: Double,     // oracle rate of 1-vote overstatements

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sim/PollingTask.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sim/PollingTask.kt
@@ -13,7 +13,7 @@ data class PollingTask(
     val cvrMean: Double,
     val cvrMeanDiff: Double,
     val d: Int, // parameter for shrinkTruncate
-    val cvrs: List<CvrIF>,
+    val cvrs: List<Cvr>,
     val withoutReplacement: Boolean = true,
     val useFixedEstimFn: Boolean = false
 ): RepeatedTask {


### PR DESCRIPTION
AuditConfig.fuzzPct controls if you use standard or fuzzed mvrs. 
Put phantom field back onto Cvr, not CvrUnderAudit. 
Fix corla package naming.
Withdraw most uses of CvrIF.
FindSampleSize -> EstimateSampleSize.
BallotUnderAudit -> BallotWithStyle.
PollingWorkflow -> PollingWithManifestIds.
ComparisonWorkflow -> ComparisonWithCompleteCvrs.