### PR TITLE
Make sample estimation concurrent.

### DIFF
--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/BallotManifest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/BallotManifest.kt
@@ -59,7 +59,7 @@ data class BallotStyle(
     fun hasContest(contestId: Int) = contestIds.contains(contestId)
 
     override fun toString() = buildString {
-        append(" BallotStyle(contestNames=$contestNames, contestIds=$contestIds, numberBallots=$ncards")
+        append(" BallotStyle($id, contestIds=$contestIds, numberBallots=$ncards")
     }
 
     companion object {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireAssertions.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireAssertions.kt
@@ -4,7 +4,6 @@ import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.core.ContestUnderAudit
 import org.cryptobiotic.rlauxe.util.Welford
 import org.cryptobiotic.rlauxe.util.mean2margin
-import kotlin.math.min
 
 // The ouput of RAIRE assertion generator, read from JSON files
 data class RaireResults(
@@ -13,12 +12,12 @@ data class RaireResults(
     val contests: List<RaireContestUnderAudit>,
 ) {
     fun show() = buildString {
-        appendLine("overallExpectedPollsNumber=$overallExpectedPollsNumber ballotsInvolvedInAuditNumber=$ballotsInvolvedInAuditNumber")
+        appendLine("RaireResults: overallExpectedPollsNumber=$overallExpectedPollsNumber ballotsInvolvedInAuditNumber=$ballotsInvolvedInAuditNumber")
         contests.forEach { append(it.show()) }
     }
 }
 
-class RaireContest(
+data class RaireContest(
     override val info: org.cryptobiotic.rlauxe.core.ContestInfo,
     override val winnerNames: List<String>,
     override val Nc: Int,
@@ -71,7 +70,7 @@ class RaireContestUnderAudit(
     }
 
     fun show() = buildString {
-        appendLine("  contest ${contest.info.name} winner $winner eliminated $eliminated")
+        appendLine("  RaireContestUnderAudit ${contest.info.name} winner $winner eliminated $eliminated")
         assertions.forEach { append(it.show()) }
     }
 
@@ -171,10 +170,10 @@ class RaireAssorter(contest: RaireContestUnderAudit, val assertion: RaireAsserti
     var reportedMargin: Double = 0.0
 
     override fun upperBound() = 1.0
-    override fun toString() = buildString {
+    /* override fun toString() = buildString {
         append("RaireAssorter contest ${contestName} type= ${assertion.assertionType} winner=${assertion.winner} loser=${assertion.loser}")
         if (assertion.assertionType == RaireAssertionType.irv_elimination) append(" alreadyElim=${assertion.alreadyEliminated}")
-    }
+    } */
     override fun desc() = buildString {
         append("RaireAssorter winner/loser=${assertion.winner}/${assertion.loser}")
         if (assertion.assertionType == RaireAssertionType.irv_elimination) append(" alreadyElim=${assertion.alreadyEliminated}")

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/EstimateSampleSize.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/EstimateSampleSize.kt
@@ -7,183 +7,245 @@ import org.cryptobiotic.rlauxe.workflow.AuditConfig
 import org.cryptobiotic.rlauxe.workflow.ComparisonErrorRates
 import org.cryptobiotic.rlauxe.workflow.EstimationResult
 import org.cryptobiotic.rlauxe.workflow.EstimationTask
+import org.cryptobiotic.rlauxe.workflow.EstimationTaskRunner
 import org.cryptobiotic.rlauxe.workflow.RunTestRepeatedResult
 import org.cryptobiotic.rlauxe.workflow.runTestRepeated
 import kotlin.math.min
 
-class EstimateSampleSize(val auditConfig: AuditConfig) {
 
-    ////////////////////////////////////////////////////////////////////////////////////////////
-    //// Both
+////////////////////////////////////////////////////////////////////////////////////////////
+//// Both Comparison and Polling
 
-    fun makeEstimationTasks(
-        contestUA: ContestUnderAudit,
-        cvrs: List<Cvr>,        // Comparison only
-        prevMvrs: List<CvrIF>,  // TODO should be used for subsequent round estimation
-        roundIdx: Int,
-        show: Boolean = false
-    ): List<EstimationTask> {
-        val tasks = mutableListOf<EstimationTask>()
+fun estimateSampleSizes(
+    auditConfig: AuditConfig,
+    contestsUA: List<ContestUnderAudit>,
+    cvrs: List<Cvr>,        // Comparison only
+    prevMvrs: List<CvrIF>,  // TODO should be used for subsequent round estimation
+    roundIdx: Int,
+    show: Boolean = false,
+): Int? {
+    val tasks = mutableListOf<EstimationTask>()
+    contestsUA.filter { !it.done }.forEach { contestUA ->
+        tasks.addAll(makeEstimationTasks(auditConfig, contestUA, cvrs, prevMvrs, roundIdx, show = true))
+    }
+    // run tasks concurrently
+    val results: List<EstimationResult> = EstimationTaskRunner().run(tasks)
 
-        contestUA.assertions().map { assert -> // pollingAssertions vs comparisonAssertions
-            if (!assert.proved) {
-                var maxSamples = contestUA.Nc
-                var prevSampleSize = 0
-                var startingTestStatistic = 1.0
-                if (roundIdx > 1) {
-                    if (assert.samplesUsed == contestUA.Nc) {
-                        println("***LimitReached $contestUA")
-                        contestUA.done = true
-                        contestUA.status = TestH0Status.LimitReached
-                    }
-                    // start where the audit left off
-                    prevSampleSize = assert.samplesUsed
-                    maxSamples = contestUA.Nc - prevSampleSize
-                    startingTestStatistic = 1.0 / assert.pvalue
+    // pull out the results for each contest
+    contestsUA.filter { !it.done }.forEach { contestUA ->
+        val sampleSizes = results.filter { it.contestUA.id == contestUA.id && it.success }
+            .map { it.assertion.estSampleSize }
+        contestUA.estSampleSize = if (sampleSizes.isEmpty()) 0 else sampleSizes.max()
+        if (show) println(" ${contestUA}")
+    }
+    if (show) println()
+    val maxContestSize = contestsUA.filter { !it.done }.maxOfOrNull { it.estSampleSize }
+    return maxContestSize
+}
+
+fun makeEstimationTasks(
+    auditConfig: AuditConfig,
+    contestUA: ContestUnderAudit,
+    cvrs: List<Cvr>,        // Comparison only
+    prevMvrs: List<CvrIF>,  // TODO should be used for subsequent round estimation
+    roundIdx: Int,
+    show: Boolean = false,
+): List<EstimationTask> {
+    val tasks = mutableListOf<EstimationTask>()
+
+    contestUA.assertions().map { assert -> // pollingAssertions vs comparisonAssertions
+        if (!assert.proved) {
+            var maxSamples = contestUA.Nc
+            var prevSampleSize = 0
+            var startingTestStatistic = 1.0
+            if (roundIdx > 1) {
+                if (assert.samplesUsed == contestUA.Nc) {
+                    println("***LimitReached $contestUA")
+                    contestUA.done = true
+                    contestUA.status = TestH0Status.LimitReached
                 }
-
-                if (!contestUA.done) {
-                    tasks.add( SimulateSampleSizeTask(contestUA, assert, cvrs, maxSamples, startingTestStatistic, prevSampleSize))
-                }
-            }
-            if (show) println("  ${contestUA.name} ${assert}")
-        }
-        return tasks
-    }
-
-    inner class SimulateSampleSizeTask(
-        val contestUA: ContestUnderAudit,
-        val assertion: Assertion,
-        val cvrs: List<Cvr>,
-        val maxSamples: Int,
-        val startingTestStatistic: Double,
-        val prevSampleSize: Int,
-    ): EstimationTask {
-        override fun name() = "task ${contestUA.name} ${assertion.assorter.desc()}"
-        override fun estimate() : EstimationResult {
-            val result = if (contestUA.isComparison) {
-                simulateSampleSizeComparisonAssorter(contestUA, (assertion as ComparisonAssertion).cassorter, cvrs, maxSamples, startingTestStatistic)
-            } else {
-                simulateSampleSizePollingAssorter(contestUA, assertion.assorter, maxSamples, startingTestStatistic)
+                // start where the audit left off
+                prevSampleSize = assert.samplesUsed
+                maxSamples = contestUA.Nc - prevSampleSize
+                startingTestStatistic = 1.0 / assert.pvalue
             }
 
-            return if (result.failPct() > 80.0) { // TODO 80% ??
-                assertion.estSampleSize = prevSampleSize + result.findQuantile(auditConfig.quantile)
-                println("***FailPct $contestUA ${result.failPct()} > 80% size=${assertion.estSampleSize}")
-                contestUA.done = true
-                contestUA.status = TestH0Status.FailPct
-                EstimationResult(contestUA, assertion, false)
-            } else {
-                val size = prevSampleSize + result.findQuantile(auditConfig.quantile)
-                assertion.estSampleSize = min(size, contestUA.Nc)
-                return EstimationResult(contestUA, assertion, true)
+            if (!contestUA.done) {
+                tasks.add(
+                    SimulateSampleSizeTask(
+                        auditConfig,
+                        contestUA,
+                        assert,
+                        cvrs,
+                        maxSamples,
+                        startingTestStatistic,
+                        prevSampleSize
+                    )
+                )
             }
         }
+        if (show) println("  ${contestUA.name} ${assert}")
     }
+    return tasks
+}
 
-    ///////////////////////////////////////////////////////////////////////////////////////////////////
-    //// Polling
-
-    // also called from MakeSampleSizePlots
-    fun simulateSampleSizePollingAssorter(
-            contestUA: ContestUnderAudit,
-            assorter: AssorterFunction,
-            maxSamples: Int,
-            startingTestStatistic: Double = 1.0,
-        ): RunTestRepeatedResult {
-        val margin = assorter.reportedMargin()
-        val simContest = SimContest(contestUA.contest as Contest, assorter)
-        val cvrs = simContest.makeCvrs()
-        require(cvrs.size == contestUA.ncvrs)
-
-        val sampler = if (auditConfig.fuzzPct == null) {
-            PollWithoutReplacement(contestUA, cvrs, assorter)
+class SimulateSampleSizeTask(
+    val auditConfig: AuditConfig,
+    val contestUA: ContestUnderAudit,
+    val assertion: Assertion,
+    val cvrs: List<Cvr>,
+    val maxSamples: Int,
+    val startingTestStatistic: Double,
+    val prevSampleSize: Int,
+) : EstimationTask {
+    override fun name() = "task ${contestUA.name} ${assertion.assorter.desc()}"
+    override fun estimate(): EstimationResult {
+        val result = if (contestUA.isComparison) {
+            simulateSampleSizeComparisonAssorter(
+                auditConfig,
+                contestUA,
+                (assertion as ComparisonAssertion).cassorter,
+                cvrs,
+                maxSamples,
+                startingTestStatistic
+            )
         } else {
-            PollingFuzzSampler(auditConfig.fuzzPct, cvrs, contestUA, assorter)
+            simulateSampleSizePollingAssorter(
+                auditConfig,
+                contestUA,
+                assertion.assorter,
+                maxSamples,
+                startingTestStatistic
+            )
         }
 
-        return simulateSampleSizeAlphaMart(sampler, margin, assorter.upperBound(), maxSamples, Nc=contestUA.Nc, startingTestStatistic)
-    }
-
-    fun simulateSampleSizeAlphaMart(
-        sampleFn: SampleGenerator,
-        margin: Double,
-        upperBound: Double,
-        maxSamples: Int,
-        Nc: Int,
-        startingTestStatistic: Double = 1.0,
-        moreParameters: Map<String, Double> = emptyMap(),
-    ): RunTestRepeatedResult {
-        val eta0 = margin2mean(margin)
-        val minsd = 1.0e-6
-        val t = 0.5
-        val c = (eta0 - t) / 2
-
-        val estimFn = TruncShrinkage(
-            N = Nc,
-            withoutReplacement = true,
-            upperBound = upperBound,
-            d = auditConfig.d1,
-            eta0 = eta0,
-            minsd = minsd,
-            c = c,
-        )
-        val testFn = AlphaMart(
-            estimFn = estimFn,
-            N = Nc,
-            upperBound = upperBound,
-            riskLimit = auditConfig.riskLimit,
-            withoutReplacement = true
-        )
-
-        val result: RunTestRepeatedResult = runTestRepeated(
-            drawSample = sampleFn,
-            maxSamples = maxSamples,
-            ntrials = auditConfig.ntrials,
-            testFn = testFn,
-            testParameters = mapOf("ntrials" to auditConfig.ntrials.toDouble(), "polling" to 1.0) + moreParameters,
-            showDetails = false,
-            startingTestStatistic = startingTestStatistic,
-            margin = margin,
-        )
-        return result
-    }
-
-    /////////////////////////////////////////////////////////////////////////////////////////////////
-    //// Comparison
-
-    fun simulateSampleSizeComparisonAssorter(
-            contestUA: ContestUnderAudit,
-            cassorter: ComparisonAssorter,
-            cvrs: List<Cvr>,
-            maxSamples: Int,
-            startingTestStatistic: Double = 1.0,
-        ): RunTestRepeatedResult {
-
-        val errorRates = ComparisonErrorRates.getErrorRates(contestUA.ncandidates, auditConfig.fuzzPct)
-        val sampler = if (auditConfig.fuzzPct == null) {
-            // ComparisonSamplerSimulation carefully adds that number of errors. So simulation has that error in it.
-            ComparisonSamplerSimulation(cvrs, contestUA, cassorter, errorRates)
+        return if (result.failPct() > 80.0) { // TODO 80% ??
+            assertion.estSampleSize = prevSampleSize + result.findQuantile(auditConfig.quantile)
+            println("***FailPct $contestUA ${result.failPct()} > 80% size=${assertion.estSampleSize}")
+            contestUA.done = true
+            contestUA.status = TestH0Status.FailPct
+            EstimationResult(contestUA, assertion, false)
         } else {
-            ComparisonFuzzSampler(auditConfig.fuzzPct, cvrs, contestUA, cassorter)
+            val size = prevSampleSize + result.findQuantile(auditConfig.quantile)
+            assertion.estSampleSize = min(size, contestUA.Nc)
+            return EstimationResult(contestUA, assertion, true)
         }
-
-        // we need a permutation to get uniform distribution of errors, since the ComparisonSamplerSimulation puts all the errros
-        // at the beginning
-        sampler.reset()
-
-        return simulateSampleSizeBetaMart(
-            auditConfig,
-            sampler,
-            cassorter.margin,
-            cassorter.noerror,
-            cassorter.upperBound(),
-            contestUA.Nc,
-            ComparisonErrorRates.getErrorRates(contestUA.ncandidates, auditConfig.fuzzPct),
-            maxSamples,
-            startingTestStatistic,
-        )
     }
+}
+
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//// Polling
+
+// also called from MakeSampleSizePlots
+fun simulateSampleSizePollingAssorter(
+    auditConfig: AuditConfig,
+    contestUA: ContestUnderAudit,
+    assorter: AssorterFunction,
+    maxSamples: Int,
+    startingTestStatistic: Double = 1.0,
+): RunTestRepeatedResult {
+    val margin = assorter.reportedMargin()
+    val simContest = SimContest(contestUA.contest as Contest, assorter)
+    val cvrs = simContest.makeCvrs()
+    require(cvrs.size == contestUA.ncvrs)
+
+    val sampler = if (auditConfig.fuzzPct == null) {
+        PollWithoutReplacement(contestUA, cvrs, assorter)
+    } else {
+        PollingFuzzSampler(auditConfig.fuzzPct, cvrs, contestUA, assorter)
+    }
+
+    return simulateSampleSizeAlphaMart(
+        auditConfig,
+        sampler,
+        margin,
+        assorter.upperBound(),
+        maxSamples,
+        Nc = contestUA.Nc,
+        startingTestStatistic
+    )
+}
+
+fun simulateSampleSizeAlphaMart(
+    auditConfig: AuditConfig,
+    sampleFn: SampleGenerator,
+    margin: Double,
+    upperBound: Double,
+    maxSamples: Int,
+    Nc: Int,
+    startingTestStatistic: Double = 1.0,
+    moreParameters: Map<String, Double> = emptyMap(),
+): RunTestRepeatedResult {
+    val eta0 = margin2mean(margin)
+    val minsd = 1.0e-6
+    val t = 0.5
+    val c = (eta0 - t) / 2
+
+    val estimFn = TruncShrinkage(
+        N = Nc,
+        withoutReplacement = true,
+        upperBound = upperBound,
+        d = auditConfig.d1,
+        eta0 = eta0,
+        minsd = minsd,
+        c = c,
+    )
+    val testFn = AlphaMart(
+        estimFn = estimFn,
+        N = Nc,
+        upperBound = upperBound,
+        riskLimit = auditConfig.riskLimit,
+        withoutReplacement = true
+    )
+
+    val result: RunTestRepeatedResult = runTestRepeated(
+        drawSample = sampleFn,
+        maxSamples = maxSamples,
+        ntrials = auditConfig.ntrials,
+        testFn = testFn,
+        testParameters = mapOf("ntrials" to auditConfig.ntrials.toDouble(), "polling" to 1.0) + moreParameters,
+        showDetails = false,
+        startingTestStatistic = startingTestStatistic,
+        margin = margin,
+    )
+    return result
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////
+//// Comparison
+
+fun simulateSampleSizeComparisonAssorter(
+    auditConfig: AuditConfig,
+    contestUA: ContestUnderAudit,
+    cassorter: ComparisonAssorter,
+    cvrs: List<Cvr>,
+    maxSamples: Int,
+    startingTestStatistic: Double = 1.0,
+): RunTestRepeatedResult {
+
+    val errorRates = ComparisonErrorRates.getErrorRates(contestUA.ncandidates, auditConfig.fuzzPct)
+    val sampler = if (auditConfig.fuzzPct == null) {
+        // ComparisonSamplerSimulation carefully adds that number of errors. So simulation has that error in it.
+        ComparisonSamplerSimulation(cvrs, contestUA, cassorter, errorRates)
+    } else {
+        ComparisonFuzzSampler(auditConfig.fuzzPct, cvrs, contestUA, cassorter)
+    }
+
+    // we need a permutation to get uniform distribution of errors, since the ComparisonSamplerSimulation puts all the errros
+    // at the beginning
+    sampler.reset()
+
+    return simulateSampleSizeBetaMart(
+        auditConfig,
+        sampler,
+        cassorter.margin,
+        cassorter.noerror,
+        cassorter.upperBound(),
+        contestUA.Nc,
+        ComparisonErrorRates.getErrorRates(contestUA.ncandidates, auditConfig.fuzzPct),
+        maxSamples,
+        startingTestStatistic,
+    )
 }
 
 fun simulateSampleSizeBetaMart(
@@ -215,14 +277,20 @@ fun simulateSampleSizeBetaMart(
         Nc = Nc,
         noerror = noerror,
         upperBound = upperBound,
-        withoutReplacement = false)
+        withoutReplacement = false
+    )
 
     val result: RunTestRepeatedResult = runTestRepeated(
         drawSample = sampleFn,
         maxSamples = maxSamples,
         ntrials = auditConfig.ntrials,
         testFn = testFn,
-        testParameters = mapOf("p1" to optimal.p1, "p2" to optimal.p2, "p3" to optimal.p3, "p4" to optimal.p4) + moreParameters,
+        testParameters = mapOf(
+            "p1" to optimal.p1,
+            "p2" to optimal.p2,
+            "p3" to optimal.p3,
+            "p4" to optimal.p4
+        ) + moreParameters,
         showDetails = false,
         startingTestStatistic = startingTestStatistic,
         margin = margin,
@@ -231,6 +299,7 @@ fun simulateSampleSizeBetaMart(
 }
 
 /////////////////////////////////////////////////////////////////////////////////
+// SHANGRLA computeSampleSize not needed, I think
 
 //4.a) Pick the (cumulative) sample sizes {𝑆_𝑐} for 𝑐 ∈ C to attain by the end of this round of sampling.
 //	    The software offers several options for picking {𝑆_𝑐}, including some based on simulation.

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/SampleGenerator.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/SampleGenerator.kt
@@ -334,30 +334,6 @@ fun generateSampleWithMean(N: Int, ratio: Double) : DoubleArray {
     }
 }
 
-class ArrayAsGenSampleFn(val assortValues : DoubleArray): SampleGenerator {
-    var index = 0
-
-    override fun sample(): Double {
-        return assortValues[index++]
-    }
-
-    override fun reset() {
-        index = 0
-    }
-
-    fun sampleMean(): Double {
-        return assortValues.toList().average()
-    }
-
-    fun sampleCount(): Double {
-        return assortValues.toList().sum()
-    }
-
-    override fun N(): Int {
-        return assortValues.size
-    }
-}
-
 class SampleFromArrayWithoutReplacement(val assortValues : DoubleArray): SampleGenerator {
     val N = assortValues.size
     val permutedIndex = MutableList(N) { it }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Cvrs.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Cvrs.kt
@@ -29,20 +29,6 @@ fun makeCvr(idx: Int): Cvr {
     return Cvr("card", votes)
 }
 
-// default one contest, two candidates ("A" and "B"), no phantoms, plurality
-// margin = percent margin of victory of A over B (between += .5)
-fun makeCvrsByMargin(ncards: Int, margin: Double = 0.0) : List<Cvr> {
-    val result = mutableListOf<Cvr>()
-    repeat(ncards) {
-        val random = secureRandom.nextDouble(1.0)
-        val cand = if (random < .5 + margin/2.0) 0 else 1
-        val votes = mutableMapOf<Int, IntArray>()
-        votes[0] = intArrayOf(cand)
-        result.add(Cvr("card-$it", votes))
-    }
-    return result
-}
-
 fun margin2mean(margin: Double) = (margin + 1.0) / 2.0
 fun mean2margin(mean: Double) = 2.0 * mean - 1.0
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Prng.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Prng.kt
@@ -1,6 +1,5 @@
 package org.cryptobiotic.rlauxe.util
 
-import java.math.BigInteger
 import java.nio.ByteOrder
 import java.util.concurrent.atomic.AtomicInteger
 import javax.crypto.Mac
@@ -60,23 +59,4 @@ fun ByteArray.toLong(): Long {
 
 fun isBigEndian(): Boolean = ByteOrder.nativeOrder() == ByteOrder.BIG_ENDIAN
 
-////////////////////////////////////////////////////////////////////
-class Prng2(seed: BigInteger) {
-    val index = AtomicInteger(0)
-    val md: Mac = Mac.getInstance("HmacSHA256")
-
-    init {
-        val secretKey = SecretKeySpec((seed.toString(10) + ",").toByteArray(), "HmacSHA256")
-        md.init(secretKey)
-    }
-
-    fun next(): BigInteger {
-        val n = index.getAndIncrement() // appears that the first one has 0 bytes
-        val addto = ByteArray(n)
-        md.update(addto)
-        val result: ByteArray =  md.doFinal()
-        // maybe should be a BigInteger, then a String ??
-        return BigInteger(1, result) // positive
-    }
-}
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ComparisonWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ComparisonWorkflow.kt
@@ -76,24 +76,15 @@ class ComparisonWorkflow(
      * @parameter mvrs: use existing mvrs to estimate samples. may be empty.
      */
     fun chooseSamples(prevMvrs: List<CvrIF>, roundIdx: Int, show: Boolean = true): List<Int> {
-        println("EstimateSampleSize.simulateSampleSizeContest round $roundIdx")
+        println("estimateSampleSizes round $roundIdx")
 
-        val sampleSizer = EstimateSampleSize(auditConfig)
-        val tasks = mutableListOf<EstimationTask>()
-        contestsUA.filter{ !it.done }.forEach { contestUA ->
-            tasks.addAll(sampleSizer.makeEstimationTasks(contestUA, cvrs, prevMvrs, roundIdx, show=true))
-        }
-        val results: List<EstimationResult> = EstimationTaskRunner().run(tasks) // run tasks concurrently
-
-        // pull out the results for each contest
-        contestsUA.filter{ !it.done }.forEach { contestUA ->
-            val sampleSizes = results.filter{ it.contestUA.id == contestUA.id && it.success }
-                .map{ it.assertion.estSampleSize }
-            contestUA.estSampleSize = if (sampleSizes.isEmpty()) 0 else sampleSizes.max()
-            if (show) println(" ${contestUA}")
-        }
-        if (show) println()
-        val maxContestSize = contestsUA.filter { !it.done }.maxOfOrNull { it.estSampleSize }
+        val maxContestSize =  estimateSampleSizes(
+            auditConfig,
+            contestsUA,
+            cvrs,
+            prevMvrs,
+            roundIdx,
+        )
 
         // TODO how to control the round's sampleSize?
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ComparisonWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ComparisonWorkflow.kt
@@ -22,9 +22,9 @@ import org.cryptobiotic.rlauxe.util.*
 //	d) Read CVRs.
 
 class ComparisonWorkflow(
+    val auditConfig: AuditConfig,
     contests: List<Contest>, // the contests you want to audit
     raireContests: List<RaireContestUnderAudit>, // TODO or call raire from here ??
-    val auditConfig: AuditConfig,
     val cvrs: List<Cvr>,
 ) {
     val contestsUA: List<ContestUnderAudit>
@@ -75,28 +75,38 @@ class ComparisonWorkflow(
      * Choose lists of ballots to sample.
      * @parameter mvrs: use existing mvrs to estimate samples. may be empty.
      */
-    fun chooseSamples(prevMvrs: List<CvrIF>, roundIdx: Int): List<Int> {
+    fun chooseSamples(prevMvrs: List<CvrIF>, roundIdx: Int, show: Boolean = true): List<Int> {
         println("EstimateSampleSize.simulateSampleSizeContest round $roundIdx")
 
         val sampleSizer = EstimateSampleSize(auditConfig)
-        val contestsNotDone = contestsUA.filter{ !it.done }
-        contestsNotDone.forEach { contestUA ->
-            sampleSizer.simulateSampleSizeContest(contestUA, cvrs, prevMvrs, roundIdx, show=true)
+        val tasks = mutableListOf<EstimationTask>()
+        contestsUA.filter{ !it.done }.forEach { contestUA ->
+            tasks.addAll(sampleSizer.makeEstimationTasks(contestUA, cvrs, prevMvrs, roundIdx, show=true))
         }
-        println()
-        val maxContestSize = contestsNotDone.map { it.estSampleSize }.max()
+        val results: List<EstimationResult> = EstimationTaskRunner().run(tasks) // run tasks concurrently
 
-        // TODO should we know max sampling percent? or is it an absolute number?
-        //   should there be a minimum increment?? esp if its going to end up hand-counted?
-        //   user should be able to force a total count size.
+        // pull out the results for each contest
+        contestsUA.filter{ !it.done }.forEach { contestUA ->
+            val sampleSizes = results.filter{ it.contestUA.id == contestUA.id && it.success }
+                .map{ it.assertion.estSampleSize }
+            contestUA.estSampleSize = if (sampleSizes.isEmpty()) 0 else sampleSizes.max()
+            if (show) println(" ${contestUA}")
+        }
+        if (show) println()
+        val maxContestSize = contestsUA.filter { !it.done }.maxOfOrNull { it.estSampleSize }
+
+        // TODO how to control the round's sampleSize?
 
         //	c) Choose thresholds {𝑡_𝑐} 𝑐 ∈ C so that 𝑆_𝑐 ballot cards containing contest 𝑐 have a sample number 𝑢_𝑖 less than or equal to 𝑡_𝑐 .
         //     draws random ballots by consistent sampling, and returns their locations to the auditors.
-        println("consistentCvrSampling round $roundIdx")
-        val sampleIndices = consistentCvrSampling(contestsUA.filter{ !it.done }, cvrsUA)
-        println(" ComparisonWithStyle.chooseSamples maxContestSize=$maxContestSize consistentSamplingSize= ${sampleIndices.size}")
-
-        return sampleIndices
+        val contestsNotDone = contestsUA.filter{ !it.done }
+        if (contestsNotDone.size > 0) {
+            println("consistentCvrSampling round $roundIdx")
+            val sampleIndices = consistentCvrSampling(contestsNotDone, cvrsUA)
+            println(" ComparisonWithStyle.chooseSamples maxContestSize=$maxContestSize consistentSamplingSize= ${sampleIndices.size}")
+            return sampleIndices
+        }
+        return emptyList()
     }
 
     //   The auditors retrieve the indicated cards, manually read the votes from those cards, and input the MVRs

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/EstimationTaskRunner.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/EstimationTaskRunner.kt
@@ -64,7 +64,7 @@ class EstimationTaskRunner {
     ): EstimationResult {
         val stopwatch = Stopwatch()
         val result =  task.estimate()
-        if (showTaskResult) println("${task.name()} (${results.size}): ${stopwatch.elapsed(TimeUnit.SECONDS)}")
+        if (showTaskResult) println(" ${task.name()} (${results.size}): ${stopwatch.elapsed(TimeUnit.SECONDS)}")
         return result
     }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/EstimationTaskRunner.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/EstimationTaskRunner.kt
@@ -1,0 +1,94 @@
+@file:OptIn(ExperimentalCoroutinesApi::class)
+
+package org.cryptobiotic.rlauxe.workflow
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.yield
+
+import org.cryptobiotic.rlauxe.core.Assertion
+import org.cryptobiotic.rlauxe.core.ContestUnderAudit
+import org.cryptobiotic.rlauxe.util.Stopwatch
+import java.util.concurrent.TimeUnit
+
+// TODO: can we genericify?
+
+interface EstimationTask {
+    fun name() : String
+    fun estimate() : EstimationResult
+}
+
+data class EstimationResult(
+    val contestUA: ContestUnderAudit,
+    val assertion: Assertion,
+    val success: Boolean,
+)
+
+class EstimationTaskRunner {
+    private val show = true
+    private val showTaskResult = true
+    private val mutex = Mutex()
+    private val results = mutableListOf<EstimationResult>()
+
+    // run all the tasks concurrently
+    fun run(tasks: List<EstimationTask>, nthreads: Int = 30): List<EstimationResult> {
+        val stopwatch = Stopwatch()
+        if (show) println("\nEstimationTaskRunner run ${tasks.size} concurrent tasks with $nthreads threads")
+        runBlocking {
+            val taskProducer = produceTasks(tasks)
+            val calcJobs = mutableListOf<Job>()
+            repeat(nthreads) {
+                calcJobs.add(launchCalculations(taskProducer) { task -> runTask(task) })
+            }
+            // wait for all tasks to be done
+            joinAll(*calcJobs.toTypedArray())
+        }
+
+        // doesnt return until all tasks are done
+        if (show) println("EstimationTaskRunner took $stopwatch")
+        // println("that ${stopwatch.tookPer(tasks.size, "task")}")
+        return results
+    }
+
+    fun runTask(
+        task: EstimationTask,
+    ): EstimationResult {
+        val stopwatch = Stopwatch()
+        val result =  task.estimate()
+        if (showTaskResult) println("${task.name()} (${results.size}): ${stopwatch.elapsed(TimeUnit.SECONDS)}")
+        return result
+    }
+
+    private fun CoroutineScope.produceTasks(producer: Iterable<EstimationTask>): ReceiveChannel<EstimationTask> =
+        produce {
+            for (task in producer) {
+                send(task)
+                yield()
+            }
+            channel.close()
+        }
+
+    private fun CoroutineScope.launchCalculations(
+        input: ReceiveChannel<EstimationTask>,
+        taskRunner: (EstimationTask) -> EstimationResult?,
+    ) = launch(Dispatchers.Default) {
+        for (task in input) {
+            val result = taskRunner(task) // not inside the mutex!!
+            if (result != null) {
+                mutex.withLock {
+                    results.add(result)
+                }
+            }
+            yield()
+        }
+    }
+}

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingWorkflow.kt
@@ -33,24 +33,15 @@ class PollingWorkflow(
     }
 
     fun chooseSamples(prevMvrs: List<CvrIF>, roundIdx: Int, show: Boolean = true): List<Int> {
-        println("EstimateSampleSize.simulateSampleSizeContest round $roundIdx")
+        println("estimateSampleSizes round $roundIdx")
 
-        val sampleSizer = EstimateSampleSize(auditConfig)
-        val tasks = mutableListOf<EstimationTask>()
-        contestsUA.filter{ !it.done }.forEach { contestUA ->
-            tasks.addAll(sampleSizer.makeEstimationTasks(contestUA, emptyList(), prevMvrs, roundIdx, show))
-        }
-        val results: List<EstimationResult> = EstimationTaskRunner().run(tasks) // run tasks concurrently
-
-        // pull out the results for each contest
-        contestsUA.filter{ !it.done }.forEach { contestUA ->
-            val sampleSizes = results.filter{ it.contestUA.id == contestUA.id && it.success }
-                .map{ it.assertion.estSampleSize }
-            contestUA.estSampleSize = if (sampleSizes.isEmpty()) 0 else sampleSizes.max()
-            if (show) println(" ${contestUA}")
-        }
-        if (show) println()
-        val maxContestSize = contestsUA.filter { !it.done }.maxOfOrNull { it.estSampleSize }
+        val maxContestSize =  estimateSampleSizes(
+            auditConfig,
+            contestsUA,
+            emptyList(),
+            prevMvrs,
+            roundIdx,
+        )
 
         // choose samples
         val result = if (auditConfig.hasStyles) { // maybe should be in AuditConfig?

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/TestComparisonMasses.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/TestComparisonMasses.kt
@@ -4,12 +4,12 @@ package org.cryptobiotic.rlauxe.alpha
 import org.cryptobiotic.rlauxe.core.ContestUnderAudit
 import org.cryptobiotic.rlauxe.sampling.ComparisonNoErrors
 import org.cryptobiotic.rlauxe.sampling.ComparisonWithErrors
-import org.cryptobiotic.rlauxe.sampling.ArrayAsGenSampleFn
 import org.cryptobiotic.rlauxe.sampling.SampleFromArrayWithoutReplacement
 import org.cryptobiotic.rlauxe.sampling.generateUniformSample
 import org.cryptobiotic.rlauxe.util.makeCvrsByExactMean
 import org.cryptobiotic.rlauxe.doublePrecision
 import org.cryptobiotic.rlauxe.core.doOneAlphaMartRun
+import org.cryptobiotic.rlauxe.sampling.SampleGenerator
 import org.cryptobiotic.rlauxe.util.makeContestsFromCvrs
 import org.junit.jupiter.api.Test
 import kotlin.math.abs
@@ -152,7 +152,29 @@ class TestComparisonMasses {
         // it would seem that the idea of normalizing is wrong, the algorithm relies on alternative mean > 1/2.
         // probably violating the conditions of an assorter, namely B̄ ≡ Sum(B(bi, ci)) / N > 1/2
     }
+}
 
 
+class ArrayAsGenSampleFn(val assortValues : DoubleArray): SampleGenerator {
+    var index = 0
 
+    override fun sample(): Double {
+        return assortValues[index++]
+    }
+
+    override fun reset() {
+        index = 0
+    }
+
+    fun sampleMean(): Double {
+        return assortValues.toList().average()
+    }
+
+    fun sampleCount(): Double {
+        return assortValues.toList().sum()
+    }
+
+    override fun N(): Int {
+        return assortValues.size
+    }
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestComparisonFuzzSampler.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestComparisonFuzzSampler.kt
@@ -101,9 +101,9 @@ private fun runWithComparisonFuzzSampler(
         assorter.margin,
         assorter.noerror,
         assorter.upperBound(),
-        contestUA.ncvrs,
-        contestUA.Nc,
-        ComparisonErrorRates.getErrorRates(contestUA.ncandidates, auditConfig.fuzzPct!!),
+        Nc=contestUA.Nc,
+        ComparisonErrorRates.getErrorRates(contestUA.ncandidates, auditConfig.fuzzPct),
+        maxSamples=contestUA.ncvrs,
         moreParameters=moreParameters,
     )
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestEstimateSampleSize.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestEstimateSampleSize.kt
@@ -58,7 +58,7 @@ class TestEstimateSampleSize {
             val estSizes = mutableListOf<Int>()
             val sampleSizes = contestUA.comparisonAssertions.map { assert ->
                 //         contestsUA.forEach { contestUA -> finder.simulateSampleSizeComparisonContest(contestUA, cvrsUA, prevMvrs, round) }
-                val result = finder.simulateSampleSizeComparisonAssorter(contestUA, assert.cassorter, cvrs,)
+                val result = finder.simulateSampleSizeComparisonAssorter(contestUA, assert.cassorter, cvrs, contestUA.ncvrs)
                 //     riskLimit: Double,
                 //    dilutedMargin: Double,
                 //    gamma: Double = 1.03,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestMultiContestTestData.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestMultiContestTestData.kt
@@ -3,32 +3,39 @@ package org.cryptobiotic.rlauxe.sampling
 import org.cryptobiotic.rlauxe.util.df
 import org.cryptobiotic.rlauxe.workflow.checkEquivilentVotes
 import kotlin.test.Test
-import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class TestMultiContestTestData {
+
+    // @Test
+    fun testMakeSampleDataRepeat() {
+        repeat(100) { testMakeSampleData() }
+    }
+
     @Test
     fun testMakeSampleData() {
         val test = MultiContestTestData(20, 11, 20000, 0.011 .. 0.03)
-        println("countBallots = ${test.countBallots}")
-        println("partition = ${test.partition} total = ${test.partition.map{ it.value}.sum()} ")
+        println("testMakeSampleData--------------------------------------------------------------")
+        println("ballotStylePartition = ${test.ballotStylePartition} total = ${test.ballotStylePartition.map{ it.value}.sum()} ")
         print(test)
         println()
 
-        println("make contests")
+        println("test makeContests")
         val contests = test.makeContests()
-        contests.forEach {
-            it.winners.forEach { winner ->
-                it.losers.forEach { loser ->
-                    val margin = (it.votes[winner]!! - it.votes[loser]!!) / it.Nc.toDouble()
-                    println("  ${it.name}: votes=${it.votes} winner=$winner loser=$loser margin = ${df(margin)}")
-                    assertTrue(margin > .01)
+        contests.forEachIndexed { idx, contest ->
+            val fcontest = test.fcontests[idx]
+            contest.winners.forEach { winner ->
+                contest.losers.forEach { loser ->
+                    val margin = (contest.votes[winner]!! - contest.votes[loser]!! + 2) / contest.Nc.toDouble()
+                    println("  $contest margin = ${df(margin)} fmargin = ${df(fcontest.margin)}")
+                    assertTrue(fcontest.margin >= .011)
+                    assertTrue(margin >= fcontest.margin)
                 }
             }
         }
         println()
 
-        println("make cvrs, tabulate votes")
+        println("test makeCvrsFromContests")
         val cvrs = test.makeCvrsFromContests()
         val votes: Map<Int, Map<Int, Int>> = org.cryptobiotic.rlauxe.util.tabulateVotes(cvrs).toSortedMap()
         votes.forEach { vcontest ->

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/AssertionRLAipynb.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/AssertionRLAipynb.kt
@@ -5,6 +5,7 @@ import org.cryptobiotic.rlauxe.corla.readDominionBallotManifest
 import org.cryptobiotic.rlauxe.raire.*
 import org.cryptobiotic.rlauxe.sampling.*
 import org.cryptobiotic.rlauxe.util.*
+import kotlin.test.Test
 import kotlin.test.assertEquals
 
 // SHANGRLA examples/assertion-RLA.ipynb
@@ -204,7 +205,7 @@ data class ShangrlaContest(
 
 class AssertionRLA {
 
-    // @Test
+    @Test
     fun workflow() {
 
 //audit = Audit.from_dict({
@@ -649,7 +650,7 @@ fun calc_sample_sizes(
     //val minAssertion = comparisonAssertions.minBy { it.margin }
     //val minAssorter = minAssertion.assorter
 
-    val contest = contests.first()
+    val contest = contests.first().makeComparisonAssertions(cvrs)
     val minAssorter = contest.minComparisonAssertion()!!.cassorter // the one with the smallest margin
 
     val sampler: SampleGenerator = ComparisonNoErrors(cvrs, minAssorter)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestComparisonWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestComparisonWorkflow.kt
@@ -21,7 +21,7 @@ class TestComparisonWorkflow {
 
     @Test
     fun testComparisonWithStyle() {
-        val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles=true, seed = 12356667890L, quantile=.80, fuzzPct = .01)
+        val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles=true, seed = 12356667890L, quantile=.80, fuzzPct = 0.01)
         val N = 20000
         val testData = MultiContestTestData(20, 11, N)
         testComparisonWorkflow(auditConfig, N, testData)
@@ -29,7 +29,7 @@ class TestComparisonWorkflow {
 
     @Test
     fun testComparisonNoStyle() {
-        val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles=false, seed = 12356667890L, quantile=.80, fuzzPct = .01)
+        val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles=false, seed = 12356667890L, quantile=.80, fuzzPct = 0.01)
         val N = 20000
         val testData = MultiContestTestData(20, 11, N)
         testComparisonWorkflow(auditConfig, N, testData)
@@ -47,7 +47,7 @@ class TestComparisonWorkflow {
         // fuzzPct of the Mvrs have their votes randomly changed ("fuzzed")
         val fuzzedMvrs: List<Cvr> = makeFuzzedCvrsFrom(contests, cvrs, auditConfig.fuzzPct!!)
 
-        val workflow = ComparisonWorkflow(contests, emptyList(), auditConfig, cvrs)
+        val workflow = ComparisonWorkflow(auditConfig, contests, emptyList(), cvrs)
         val stopwatch = Stopwatch()
 
         var prevMvrs = emptyList<CvrIF>()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestComparisonWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestComparisonWorkflow.kt
@@ -21,17 +21,17 @@ class TestComparisonWorkflow {
 
     @Test
     fun testComparisonWithStyle() {
-        val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles=true, seed = 12356667890L, quantile=.80, fuzzPct = 0.01)
-        val N = 20000
-        val testData = MultiContestTestData(20, 11, N)
+        val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles=true, seed = 12356667890L, quantile=.50, fuzzPct = 0.01)
+        val N = 50000
+        val testData = MultiContestTestData(11, 4, N)
         testComparisonWorkflow(auditConfig, N, testData)
     }
 
     @Test
     fun testComparisonNoStyle() {
-        val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles=false, seed = 12356667890L, quantile=.80, fuzzPct = 0.01)
-        val N = 20000
-        val testData = MultiContestTestData(20, 11, N)
+        val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles=false, seed = 12356667890L, quantile=.50, fuzzPct = 0.01)
+        val N = 50000
+        val testData = MultiContestTestData(11, 4, N)
         testComparisonWorkflow(auditConfig, N, testData)
     }
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPollingWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPollingWorkflow.kt
@@ -17,11 +17,11 @@ class TestPollingWorkflow {
 
     @Test
     fun testPollingNoStyle() {
-        val auditConfig = AuditConfig(AuditType.POLLING, hasStyles=false, seed = 12356667890L, fuzzPct = 0.0)
+        val auditConfig = AuditConfig(AuditType.POLLING, hasStyles=false, seed = 12356667890L, quantile=.50, fuzzPct = 0.0)
 
         // each contest has a specific margin between the top two vote getters.
         val N = 100000
-        val test = MultiContestTestData(20, 11, N, marginRange= 0.04..0.10)
+        val test = MultiContestTestData(11, 4, N, marginRange= 0.04..0.10)
         val contests: List<Contest> = test.makeContests()
 
         println("Start testPollingNoStyle N=$N")
@@ -75,11 +75,11 @@ class TestPollingWorkflow {
     @Test
     fun testPollingWithStyle() {
         val stopwatch = Stopwatch()
-        val auditConfig = AuditConfig(AuditType.POLLING, hasStyles=true, seed = 12356667890L, fuzzPct = .01)
+        val auditConfig = AuditConfig(AuditType.POLLING, hasStyles=true, seed = 12356667890L, quantile=.50, fuzzPct = .01)
 
         // each contest has a specific margin between the top two vote getters.
         val N = 50000
-        val test = MultiContestTestData(20, 11, N, marginRange= 0.04..0.10)
+        val test = MultiContestTestData(11, 4, N, marginRange= 0.04..0.10)
         val contests: List<Contest> = test.makeContests()
         println("Start testPollingWithStyle N=$N")
         contests.forEach{ println(" $it")}

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestRaireWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestRaireWorkflow.kt
@@ -8,22 +8,14 @@ import kotlin.test.Test
 
 class TestRaireWorkflow {
 
-    fun testComparisonWithStyleRepeat() {
-        repeat(100) { testComparisonWithStyle() }
-    }
-
-   // @Test
-    fun testComparisonNoStyleRepeat() {
-        repeat(100) { testComparisonNoStyle() }
-    }
 
     @Test
-    fun testComparisonWithStyle() {
+    fun testRaireComparisonWithStyle() {
         testRaireWorkflow(AuditConfig(AuditType.CARD_COMPARISON, hasStyles=true, seed = 12356667890L, quantile=.80, fuzzPct = null))
     }
 
     @Test
-    fun testComparisonNoStyle() {
+    fun testRaireComparisonNoStyle() {
         testRaireWorkflow(AuditConfig(AuditType.CARD_COMPARISON, hasStyles=false, seed = 123568667890L, quantile=.80, fuzzPct = null))
     }
 
@@ -38,6 +30,7 @@ class TestRaireWorkflow {
 
         // The corresponding assertions file that has already been generated.
         val raireResults = readRaireResults("/home/stormy/dev/github/rla/rlauxe/core/src/test/data/SFDA2019/SFDA2019_PrelimReport12VBMJustDASheetsAssertions.json").import()
+        print(raireResults.show())
 
         // check consistencey
         raireResults.contests.forEach { rrc ->
@@ -48,8 +41,7 @@ class TestRaireWorkflow {
             rrc.Nc = rc.ncvrs
         }
 
-        val workflow = ComparisonWorkflow(emptyList(), raireResults.contests, auditConfig, cvrs)
-        val contests = workflow.contestsUA.map { it.contest }
+        val workflow = ComparisonWorkflow(auditConfig, emptyList(), raireResults.contests, cvrs)
 
         // fuzzPct of the Mvrs have their votes randomly changed ("fuzzed")
         // cant make fuzzed cvrs from raire as it stands
@@ -80,60 +72,6 @@ class TestRaireWorkflow {
 
         rounds.forEach { println(it) }
         workflow.showResults()
-
-        /*
-        println("initialize took ${stopwatch.elapsed(TimeUnit.MILLISECONDS)} ms\n")
-        stopwatch.start()
-
-        // form simulated mvrs. TODO kinda dicey because these are intended for a single assorter
-        val contestUA = workflow.contestsUA.first()
-        val assorter = contestUA.comparisonAssertions.first().cassorter // take the one with the smallest margin??
-        // dont permute
-        val sampler = ComparisonSamplerSimulation(workflow.cvrs, contestUA, assorter, ComparisonErrorRates.standard)
-        println(sampler.showFlips())
-
-        val cvrPairs: List<Pair<CvrIF, Cvr>> = sampler.mvrs.zip(sampler.cvrs)
-        cvrPairs.forEach { (mvr, cvr) -> require(mvr.id == cvr.id) }
-        var count = 0
-        cvrPairs.forEach { (mvr, cvr) ->
-            if (mvr.votes != cvr.votes) {
-                count++
-            }
-        }
-        println("diff = $count out of ${cvrPairs.size} = ${df(count.toDouble()/cvrPairs.size)}\n")
-
-        val samples = PrevSamplesWithRates(assorter.noerror)
-        cvrPairs.forEach { (mvr, cvr) -> samples.addSample(assorter.bassort(mvr,cvr)) }
-        println("samplingErrors= ${samples.samplingErrors()}")
-
-        var prevMvrs = emptyList<CvrIF>()
-        val previousSamples = mutableSetOf<Int>()
-        var rounds = mutableListOf<Round>()
-        var roundIdx = 1
-
-        var done = false
-        while (!done) {
-            val indices = workflow.chooseSamples(prevMvrs, roundIdx)
-            val currRound = Round(roundIdx, indices, previousSamples)
-            rounds.add(currRound)
-            previousSamples.addAll(indices)
-
-            println("$roundIdx choose ${indices.size} samples, new=${currRound.newSamples} took ${stopwatch.elapsed(TimeUnit.MILLISECONDS)} ms\n")
-            stopwatch.start()
-
-            println("$roundIdx chooseSamples ${indices.size} took ${stopwatch.elapsed(TimeUnit.MILLISECONDS)}\n")
-            stopwatch.start()
-
-
-            val sampledMvrs = indices.map { sampler.mvrs[it] }
-
-            done = workflow.runAudit(indices, sampledMvrs, roundIdx)
-            println("$roundIdx runAudit took ${stopwatch.elapsed(TimeUnit.MILLISECONDS)} ms\n")
-            prevMvrs = sampledMvrs
-            roundIdx++
-        }
-
-         */
     }
 
 }

--- a/docs/RlaOptions.md
+++ b/docs/RlaOptions.md
@@ -89,9 +89,8 @@ Jurisdiction Scenarios
 
 Audit types
 
-1. Polling
-2. Comparison without CSD
-3. Comparison with CSD
+1. Polling/Comparison
+2. hasStyles/noStyles
 4. ONEAudit?
 5. Hybrid?
 6. Stratified?

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,7 +18,7 @@ letsPlotImage = "4.3.3"
 mockk = "1.13.10"
 
 coroutines-version = "1.9.0-RC.2"
-kotest-version = "5.8.0"
+kotest-version = "5.9.1"
 ktor-version = "2.3.4"
 xmlutil-version = "0.90.0-RC3"
 
@@ -69,9 +69,10 @@ test-annotations-common = { module = "org.jetbrains.kotlin:kotlin-test-annotatio
 ktor-server-tests-jvm = { module = "io.ktor:ktor-server-tests-jvm", version.ref = "ktor-version" }
 ktor-server-test-host = { module = "io.ktor:ktor-server-test-host", version.ref = "kotlin-version" }
 junit-jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version = "5.10.0" }
+kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest-version" }
+kotest-assertions = { module = "io.kotest:kotest-assertions-core-jvm", version.ref = "kotest-version" }
 kotest-property = { module = "io.kotest:kotest-property", version.ref = "kotest-version" }
 kotest-datatest = { module = "io.kotest:kotest-framework-datatest", version.ref = "kotest-version" }
-kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest-version" }
 mockk = { module = "io.mockk:mockk", version = "1.13.12" }
 
 [bundles]
@@ -79,6 +80,7 @@ eglib = ["bull-result", "kotlinx-cli", "kotlinx-coroutines-core", "kotlinx-datet
 egtest = ["test-common", "test-annotations-common", "kotlinx-coroutines-test", "kotest-runner", "kotest-property", "kotest-datatest"]
 jvmtest = ["junit-jupiter-params", "kotlin-test-junit5", "logback-classic", "mockk"]
 logging = ["oshai-logging", "logback-classic"]
+kotest = ["kotest-runner", "kotest-assertions", "kotest-property", "kotest-datatest"]
 
 ktor-server = [
     "ktor-server-core-jvm",

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,5 +2,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
+kotest.framework.parallelism=24
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/plots/build.gradle.kts
+++ b/plots/build.gradle.kts
@@ -18,9 +18,10 @@ dependencies {
 
     implementation(libs.lets.plot)
     testImplementation(kotlin("test"))
+    testImplementation(libs.bundles.kotest)
 }
 
-tasks.test {
+tasks.withType<Test>().configureEach {
     useJUnitPlatform()
     minHeapSize = "512m"
     maxHeapSize = "8g"
@@ -28,9 +29,9 @@ tasks.test {
 
     // Make tests run in parallel
     // More info: https://www.jvt.me/posts/2021/03/11/gradle-speed-parallel/
-    systemProperties["junit.jupiter.execution.parallel.enabled"] = "true"
-    systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
-    systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
+    // systemProperties["junit.jupiter.execution.parallel.enabled"] = "true"
+    // systemProperties["junit.jupiter.execution.parallel.mode.default"] = "concurrent"
+    // systemProperties["junit.jupiter.execution.parallel.mode.classes.default"] = "concurrent"
 }
 
 kotlin {

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/GenAdaptiveComparisonTable.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/GenAdaptiveComparisonTable.kt
@@ -1,11 +1,11 @@
 package org.cryptobiotic.rlauxe.cobra
 
+import org.cryptobiotic.rlauxe.comparison.makeCvrsByMargin
 import org.cryptobiotic.rlauxe.rlaplots.SRTcsvWriter
 import org.cryptobiotic.rlauxe.sim.BettingTask
 import org.cryptobiotic.rlauxe.sim.RepeatedTaskRunner
 import org.cryptobiotic.rlauxe.util.Stopwatch
 import org.cryptobiotic.rlauxe.util.makeCvrsByExactMean
-import org.cryptobiotic.rlauxe.util.makeCvrsByMargin
 import org.cryptobiotic.rlauxe.util.margin2mean
 import org.cryptobiotic.rlauxe.util.mean2margin
 import org.junit.jupiter.api.Test

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/comparison/Failures.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/comparison/Failures.kt
@@ -1,11 +1,12 @@
 package org.cryptobiotic.rlauxe.comparison
 
+import org.cryptobiotic.rlauxe.core.Cvr
 import org.cryptobiotic.rlauxe.util.makeCvrsByExactMean
 import org.cryptobiotic.rlauxe.rlaplots.SRTcsvWriter
 import org.cryptobiotic.rlauxe.sim.AlphaComparisonTask
 import org.cryptobiotic.rlauxe.sim.RepeatedTaskRunner
-import org.cryptobiotic.rlauxe.util.makeCvrsByMargin
 import org.cryptobiotic.rlauxe.util.mean2margin
+import org.cryptobiotic.rlauxe.util.secureRandom
 import org.junit.jupiter.api.Test
 
 class Failures {
@@ -87,4 +88,18 @@ class Failures {
         writer.close()
         println("${results.size} results written to ${writer.filename}")
     }
+}
+
+// default one contest, two candidates ("A" and "B"), no phantoms, plurality
+// margin = percent margin of victory of A over B (between += .5)
+fun makeCvrsByMargin(ncards: Int, margin: Double = 0.0) : List<Cvr> {
+    val result = mutableListOf<Cvr>()
+    repeat(ncards) {
+        val random = secureRandom.nextDouble(1.0)
+        val cand = if (random < .5 + margin/2.0) 0 else 1
+        val votes = mutableMapOf<Int, IntArray>()
+        votes[0] = intArrayOf(cand)
+        result.add(Cvr("card-$it", votes))
+    }
+    return result
 }

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/MakeSampleSizePlots.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/MakeSampleSizePlots.kt
@@ -290,7 +290,8 @@ class BettingTask(val name: String,
     override fun name() = name
     override fun run() : RunTestRepeatedResult {
         //  this uses auditConfig p1,,p4 to set apriori error rates. should be based on fuzzPct i think
-        return simulateSampleSizeBetaMart(finder.auditConfig, sampleFn, margin, noerror, upperBound, Nc, Nc, errorRates, moreParameters=otherParameters)
+        return simulateSampleSizeBetaMart(finder.auditConfig, sampleFn, margin, noerror, upperBound, Nc=Nc,
+            errorRates, maxSamples=Nc, moreParameters=otherParameters)
     }
 }
 
@@ -357,7 +358,7 @@ class ComparisonTask(val name: String,
 ): ConcurrentTask {
     override fun name() = name
     override fun run() : RunTestRepeatedResult {
-        return finder.simulateSampleSizeComparisonAssorter(contestUA, cassort, cvrs)
+        return finder.simulateSampleSizeComparisonAssorter(contestUA, cassort, cvrs, maxSamples=contestUA.ncvrs)
     }
 }
 

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/MakeSampleSizePlots.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/MakeSampleSizePlots.kt
@@ -12,7 +12,6 @@ class MakeSampleSizePlots {
     @Test
     fun plotComparisonVsPoll() {
         val auditConfig = AuditConfig(AuditType.POLLING, hasStyles=true, seed = 12356667890L, quantile=.80, fuzzPct=.01, ntrials = 1000)
-        val finder = EstimateSampleSize(auditConfig)
         val N = 100000
         println("ntrials = ${auditConfig.ntrials} quantile = ${auditConfig.quantile} N=${N}")
 
@@ -28,13 +27,13 @@ class MakeSampleSizePlots {
             // polling
             contestUA.makePollingAssertions()
             val assort = contestUA.minAssertion()!!.assorter
-            tasks.add( PollingTask("Polling: margin = $margin", finder, contestUA, assort, N))
+            tasks.add( PollingTask("Polling: margin = $margin", auditConfig, contestUA, assort, N))
 
             // comparison
             val cvrs = fcontest.makeCvrs()
             contestUA.makeComparisonAssertions(cvrs)
             val cassort = contestUA.minComparisonAssertion()!!.cassorter
-            tasks.add( ComparisonTask("Comparison: margin = $margin", finder, contestUA, cassort, cvrs))
+            tasks.add( ComparisonTask("Comparison: margin = $margin", auditConfig, contestUA, cassort, cvrs))
         }
         // run tasks concurrently
         val results: List<RunTestRepeatedResult> = ConcurrentTaskRunner().run(tasks)
@@ -68,12 +67,10 @@ class MakeSampleSizePlots {
             // polling
             contestUA.makePollingAssertions()
             val assort = contestUA.minAssertion()!!.assorter
-            val standardEstimator = EstimateSampleSize(auditConfig)
-            tasks.add( PollingTask("Polling (standard): margin = $margin", standardEstimator, contestUA, assort, N))
+            tasks.add( PollingTask("Polling (standard): margin = $margin", auditConfig, contestUA, assort, N))
 
             // alternative
-            val fuzzEstimator = EstimateSampleSize(auditConfig.copy(fuzzPct=.01))
-            tasks.add( PollingTask("Polling fuzz=.01: margin = $margin", fuzzEstimator, contestUA, assort, N))
+            tasks.add( PollingTask("Polling fuzz=.01: margin = $margin", auditConfig, contestUA, assort, N))
         }
         // run tasks concurrently
         val results: List<RunTestRepeatedResult> = ConcurrentTaskRunner().run(tasks)
@@ -109,14 +106,14 @@ class MakeSampleSizePlots {
             val cvrs = fcontest.makeCvrs()
             contestUA.makeComparisonAssertions(cvrs)
             val cassort = contestUA.minComparisonAssertion()!!.cassorter
-            tasks.add( ComparisonTask("Comparison (standard): margin = $margin", EstimateSampleSize(auditConfig), contestUA, cassort, cvrs))
+            tasks.add( ComparisonTask("Comparison (standard): margin = $margin", auditConfig, contestUA, cassort, cvrs))
 
             // alternative
             val configAlt1 = AuditConfig(AuditType.POLLING, hasStyles=true, seed = 12356667890L, quantile=.80, fuzzPct=.01, ntrials = 100)
-            tasks.add( ComparisonTask("Comparison fuzz=.01: margin = $margin", EstimateSampleSize(configAlt1), contestUA, cassort, cvrs))
+            tasks.add( ComparisonTask("Comparison fuzz=.01: margin = $margin", configAlt1, contestUA, cassort, cvrs))
 
             val configAlt2 = AuditConfig(AuditType.POLLING, hasStyles=true, seed = 12356667890L, quantile=.80, fuzzPct=.001, ntrials = 100)
-            tasks.add( ComparisonTask("Comparison fuzz=.001: margin = $margin", EstimateSampleSize(configAlt2),  contestUA, cassort, cvrs))
+            tasks.add( ComparisonTask("Comparison fuzz=.001: margin = $margin", configAlt2,  contestUA, cassort, cvrs))
         }
         // run tasks concurrently
         val results: List<RunTestRepeatedResult> = ConcurrentTaskRunner().run(tasks)
@@ -152,7 +149,6 @@ class MakeSampleSizePlots {
         val margins = listOf(.001, .002, .003, .004, .005, .006, .008, .01, .012, .016, .02, .03, .04, .05, .06, .07, .08, .10)
 
         val auditConfig = AuditConfig(AuditType.POLLING, hasStyles=true, seed = 12356667890L, quantile=.80, fuzzPct=.01, ntrials = 1000)
-        val finder = EstimateSampleSize(auditConfig)
         println("ntrials = ${auditConfig.ntrials} quantile = ${auditConfig.quantile} N=${N}")
 
         val tasks = mutableListOf<AlphaTask>()
@@ -170,7 +166,7 @@ class MakeSampleSizePlots {
                 val sampleFn = PollingFuzzSampler(fuzzPct, cvrs, contestUA, minAssort)
 
                 val otherParameters = mapOf("fuzzPct" to fuzzPct)
-                tasks.add( AlphaTask("fuzzPct = $fuzzPct, margin = $margin", finder,
+                tasks.add( AlphaTask("fuzzPct = $fuzzPct, margin = $margin", auditConfig,
                     sampleFn, margin, minAssort.upperBound(), N, N, otherParameters,
                 ))
             }
@@ -196,7 +192,6 @@ class MakeSampleSizePlots {
         val margins = listOf(.001, .002, .003, .004, .005, .006, .008, .01, .012, .016, .02, .03, .04, .05, .06, .07, .08, .10)
 
         val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles=true, seed = 12356667890L, quantile=.80, fuzzPct=.01, ntrials = 1000)
-        val finder = EstimateSampleSize(auditConfig)
         println("ntrials = ${auditConfig.ntrials} quantile = ${auditConfig.quantile} N=${N}")
 
         val tasks = mutableListOf<BettingTask>()
@@ -216,7 +211,7 @@ class MakeSampleSizePlots {
                 val sampleFn = ComparisonFuzzSampler(fuzzPct, cvrs, contestUA, minAssort)
 
                 val otherParameters = mapOf("fuzzPct" to fuzzPct)
-                tasks.add( BettingTask("fuzzPct = $fuzzPct, margin = $margin", finder,
+                tasks.add( BettingTask("fuzzPct = $fuzzPct, margin = $margin", auditConfig,
                     sampleFn, margin, minAssort.noerror, minAssort.upperBound(), N, N,
                     ComparisonErrorRates.getErrorRates(contestUA.ncandidates, fuzzPct),
                     otherParameters,
@@ -257,8 +252,7 @@ class MakeSampleSizePlots {
                 val contestUA = ContestUnderAudit(contest, Nc)
                 contestUA.makePollingAssertions()
                 val assort = contestUA.minAssertion()!!.assorter
-                val standardEstimator = EstimateSampleSize(auditConfig)
-                tasks.add( PollingNoStyleTask("Polling (no styles): margin=$margin N=$N", standardEstimator, contestUA, assort, Nc, N))
+                tasks.add( PollingNoStyleTask("Polling (no styles): margin=$margin N=$N", auditConfig, contestUA, assort, Nc, N))
             }
         }
         // run tasks concurrently
@@ -277,7 +271,7 @@ class MakeSampleSizePlots {
 }
 
 class BettingTask(val name: String,
-                  val finder: EstimateSampleSize,
+                  val auditConfig: AuditConfig,
                   val sampleFn: SampleGenerator,
                   val margin: Double,
                   val noerror: Double,
@@ -290,13 +284,13 @@ class BettingTask(val name: String,
     override fun name() = name
     override fun run() : RunTestRepeatedResult {
         //  this uses auditConfig p1,,p4 to set apriori error rates. should be based on fuzzPct i think
-        return simulateSampleSizeBetaMart(finder.auditConfig, sampleFn, margin, noerror, upperBound, Nc=Nc,
+        return simulateSampleSizeBetaMart(auditConfig, sampleFn, margin, noerror, upperBound, Nc=Nc,
             errorRates, maxSamples=Nc, moreParameters=otherParameters)
     }
 }
 
 class AlphaTask(val name: String,
-                val finder: EstimateSampleSize,
+                val auditConfig: AuditConfig,
                 val sampleFn: SampleGenerator,
                 val margin: Double,
                 val upperBound: Double,
@@ -313,12 +307,12 @@ class AlphaTask(val name: String,
         //        startingTestStatistic: Double = 1.0,
         //        Nc: Int,
         //        moreParameters: Map<String, Double> = emptyMap(),
-        return finder.simulateSampleSizeAlphaMart(sampleFn, margin, upperBound, maxSamples=Nc, Nc=Nc, moreParameters=otherParameters)
+        return simulateSampleSizeAlphaMart(auditConfig, sampleFn, margin, upperBound, maxSamples=Nc, Nc=Nc, moreParameters=otherParameters)
     }
 }
 
 class PollingTask(val name: String,
-                  val finder: EstimateSampleSize,
+                  val auditConfig: AuditConfig,
                   val contestUA: ContestUnderAudit,
                   val assort: AssorterFunction,
                   val Nc: Int,
@@ -332,12 +326,12 @@ class PollingTask(val name: String,
         //        startingTestStatistic: Double = 1.0,
         //        Nc: Int,
         //        moreParameters: Map<String, Double> = emptyMap(),
-        return finder.simulateSampleSizePollingAssorter(contestUA, assort, Nc)
+        return simulateSampleSizePollingAssorter(auditConfig, contestUA, assort, Nc)
     }
 }
 
 class PollingNoStyleTask(val name: String,
-                  val finder: EstimateSampleSize,
+                         val auditConfig: AuditConfig,
                   val contestUA: ContestUnderAudit,
                   val assort: AssorterFunction,
                   val Nc: Int,
@@ -346,19 +340,19 @@ class PollingNoStyleTask(val name: String,
     override fun name() = name
     override fun run() : RunTestRepeatedResult {
         // TODO
-        return finder.simulateSampleSizePollingAssorter(contestUA, assort, Nc)
+        return simulateSampleSizePollingAssorter(auditConfig, contestUA, assort, Nc)
     }
 }
 
 class ComparisonTask(val name: String,
-                     val finder: EstimateSampleSize,
+                     val auditConfig: AuditConfig,
                      val contestUA: ContestUnderAudit,
                      val cassort: ComparisonAssorter,
                      val cvrs: List<Cvr>,
 ): ConcurrentTask {
     override fun name() = name
     override fun run() : RunTestRepeatedResult {
-        return finder.simulateSampleSizeComparisonAssorter(contestUA, cassort, cvrs, maxSamples=contestUA.ncvrs)
+        return simulateSampleSizeComparisonAssorter(auditConfig, contestUA, cassort, cvrs, maxSamples=contestUA.ncvrs)
     }
 }
 


### PR DESCRIPTION
Refactor EstimateSampleSize for concurrency.
Fix minor bug in MultiContestTestData.kt
Upgrade kotest to 5.9.1
Use kotest.framework.parallelism=24 (not JUnit) for parellel testing. (not clear this works as well).