### PR TITLE
Measure concurrency, profile.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rlauxe
-last update: 12/26/2024
+last update: 12/27/2024
 
 A port of Philip Stark's SHANGRLA framework and related code to kotlin, 
 for the purpose of making a reusable and maintainable library.
@@ -37,6 +37,7 @@ Table of Contents
   * [Differences with SHANGRLA](#differences-with-shangrla)
     * [Limit audit to estimated samples](#limit-audit-to-estimated-samples)
     * [compute sample size](#compute-sample-size)
+    * [generation of phantoms](#generation-of-phantoms)
     * [estimate comparison error rates](#estimate-comparison-error-rates)
     * [use of previous round's sampled_cvr_indices](#use-of-previous-rounds-sampled_cvr_indices)
   * [Other Notes](#other-notes)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/ComparisonSimulation.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/ComparisonSimulation.kt
@@ -2,8 +2,8 @@ package org.cryptobiotic.rlauxe.sampling
 
 import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.util.df
-import org.cryptobiotic.rlauxe.util.secureRandom
 import kotlin.math.max
+import kotlin.random.Random
 
 private val show = true
 
@@ -65,7 +65,7 @@ class ComparisonSimulation(
     override fun maxSamples() = maxSamples
 
     override fun reset() {
-        permutedIndex.shuffle(secureRandom)
+        permutedIndex.shuffle(Random)
         idx = 0
     }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/EstimateSampleSize.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/EstimateSampleSize.kt
@@ -24,13 +24,14 @@ fun estimateSampleSizes(
     prevMvrs: List<Cvr>,
     roundIdx: Int,
     show: Boolean = false,
+    nthreads: Int = 14,
 ): Int? {
     val tasks = mutableListOf<EstimationTask>()
     contestsUA.filter { !it.done }.forEach { contestUA ->
         tasks.addAll(makeEstimationTasks(auditConfig, contestUA, cvrs, prevMvrs, roundIdx))
     }
     // run tasks concurrently
-    val estResults: List<EstimationResult> = EstimationTaskRunner().run(tasks)
+    val estResults: List<EstimationResult> = EstimationTaskRunner(show).run(tasks, nthreads)
 
     // cant change contestUA until out of the concurrent task running
     estResults.forEach { estResult ->
@@ -139,7 +140,6 @@ class SimulateSampleSizeTask(
                 moreParameters=moreParameters,
             )
         }
-
         return EstimationResult(this, result, result.failPct() > 80.0) // TODO 80% ??
     }
 }
@@ -249,8 +249,8 @@ fun simulateSampleSizeComparisonAssorter(
     // at the beginning
     sampler.reset()
 
-    val calcMargin = cassorter.calcAssorterMargin(cvrs.zip( cvrs)) // TODO
-    println("  ** simulateSampleSizeComparisonAssorter ${contest.info.name} calcMargin=$calcMargin ")
+    // val calcMargin = cassorter.calcAssorterMargin(cvrs.zip( cvrs)) // TODO
+    // println("  ** simulateSampleSizeComparisonAssorter ${contest.info.name} calcMargin=$calcMargin ")
 
     val errorRates = auditConfig.errorRates ?: ComparisonErrorRates.getErrorRates(contest.ncandidates, auditConfig.fuzzPct)
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/FuzzSampler.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/FuzzSampler.kt
@@ -2,6 +2,7 @@ package org.cryptobiotic.rlauxe.sampling
 
 import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.util.*
+import kotlin.random.Random
 
 // this takes a list of cvrs and fuzzes them
 class ComparisonFuzzSampler(
@@ -39,7 +40,7 @@ class ComparisonFuzzSampler(
     override fun reset() {
         val mvrs = remakeFuzzed()
         cvrPairs = mvrs.zip(cvrs)
-        permutedIndex.shuffle(secureRandom)
+        permutedIndex.shuffle(Random)
         idx = 0
     }
 
@@ -87,7 +88,7 @@ class PollingFuzzSampler(
 
     override fun reset() {
         mvrs = remakeFuzzed()
-        permutedIndex.shuffle(secureRandom)
+        permutedIndex.shuffle(Random)
         idx = 0
     }
 
@@ -103,7 +104,7 @@ fun makeFuzzedCvrsFrom(contests: List<Contest>, cvrs: List<Cvr>, fuzzPct: Double
     var count = 0
     val cvrbs = CvrBuilders.convertCvrs(contests.map { it.info }, cvrs)
     cvrbs.filter { !it.phantom }.forEach { cvrb: CvrBuilder ->
-        val r = secureRandom.nextDouble(1.0)
+        val r = Random.nextDouble(1.0)
         cvrb.contests.forEach { (_, cvb) ->
             if (r < fuzzPct) {
                 val ccontest: CvrContest = cvb.contest
@@ -125,7 +126,7 @@ fun makeFuzzedCvrsFrom(contests: List<Contest>, cvrs: List<Cvr>, fuzzPct: Double
 fun chooseNewCandidate(currId: Int?, candidateIds: List<Int>): Int? {
     val size = candidateIds.size
     while (true) {
-        val ncandIdx = secureRandom.nextInt(size + 1)
+        val ncandIdx = Random.nextInt(size + 1)
         if (ncandIdx == size) return null // choose none
         val candId = candidateIds[ncandIdx]
         if (candId != currId) {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/MultiContestTestData.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/MultiContestTestData.kt
@@ -18,7 +18,7 @@ data class MultiContestTestData(
     val totalBallots: Int, // including undervotes but not phantoms
     val marginRange: OpenEndRange<Double> = 0.01..< 0.03,
     val underVotePct: OpenEndRange<Double> = 0.01..< 0.30, // needed to set Nc
-    val phantomPct: OpenEndRange<Double> = 0.00..< 0.01, // needed to set Nc
+    val phantomPct: OpenEndRange<Double> = 0.00..< 0.005, // needed to set Nc
 ) {
     // generate with ballotStyles; but if hasStyles = false, then these are not visible
     val ballotStylePartition = partition(totalBallots, nballotStyles).toMap() // Map bsidx -> ncards in each ballot style (bs)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/SampleGenerator.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/SampleGenerator.kt
@@ -1,7 +1,6 @@
 package org.cryptobiotic.rlauxe.sampling
 
 import org.cryptobiotic.rlauxe.core.*
-import org.cryptobiotic.rlauxe.util.secureRandom
 import kotlin.random.Random
 
 // TODO move as much as possible into testing
@@ -20,7 +19,7 @@ class PollWithReplacement(val contest: Contest, val mvrs : List<Cvr>, val assort
 
     override fun sample(): Double {
         while (true) {
-            val idx = secureRandom.nextInt(mvrs.size) // with Replacement
+            val idx = Random.nextInt(mvrs.size) // with Replacement
             val cvr = mvrs[idx]
             if (cvr.hasContest(contest.id)) return assorter.assort(cvr, usePhantoms = true)
         }
@@ -57,7 +56,7 @@ class PollWithoutReplacement(
 
     override fun reset() {
         if (!allowReset) throw RuntimeException("PollWithoutReplacement reset not allowed")
-        permutedIndex.shuffle(secureRandom)
+        permutedIndex.shuffle(Random)
         idx = 0
     }
 
@@ -96,7 +95,7 @@ class ComparisonWithoutReplacement(
 
     override fun reset() {
         if (!allowReset) throw RuntimeException("ComparisonWithoutReplacement reset not allowed")
-        permutedIndex.shuffle(secureRandom)
+        permutedIndex.shuffle(Random)
         idx = 0
     }
 
@@ -124,7 +123,7 @@ class ComparisonNoErrors(val cvrs : List<Cvr>, val cassorter: ComparisonAssorter
     }
 
     override fun reset() {
-        permutedIndex.shuffle(secureRandom)
+        permutedIndex.shuffle(Random)
         idx = 0
     }
 
@@ -153,7 +152,7 @@ fun add2voteOverstatements(cvrs: MutableList<Cvr>, needToChangeVotesFromA: Int):
     // we need more A votes, needToChangeVotesFromA < 0>
     if (needToChangeVotesFromA < 0) {
         while (changed > needToChangeVotesFromA) {
-            val cvrIdx = secureRandom.nextInt(ncards)
+            val cvrIdx = Random.nextInt(ncards)
             val cvr = cvrs[cvrIdx]
             if (cvr.hasMarkFor(0, 1) == 1) {
                 val votes = mutableMapOf<Int, IntArray>()
@@ -165,7 +164,7 @@ fun add2voteOverstatements(cvrs: MutableList<Cvr>, needToChangeVotesFromA: Int):
     } else {
         // we need more B votes, needToChangeVotesFromA > 0
         while (changed < needToChangeVotesFromA) {
-            val cvrIdx = secureRandom.nextInt(ncards)
+            val cvrIdx = Random.nextInt(ncards)
             val cvr = cvrs[cvrIdx]
             if (cvr.hasMarkFor(0, 0) == 1) {
                 val votes = mutableMapOf<Int, IntArray>()

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ComparisonWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ComparisonWorkflow.kt
@@ -24,7 +24,6 @@ class ComparisonWorkflow(
     val cvrs: List<Cvr>, // includes undervotes and phantoms.
 ) {
     val contestsUA: List<ContestUnderAudit>
-    // val cvrsUA: List<CvrUnderAudit>
     val prng = Prng(auditConfig.seed)
 
     init {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/EstimationTaskRunner.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/EstimationTaskRunner.kt
@@ -34,14 +34,13 @@ data class EstimationResult(
 
 // runs set of EstimationTask concurrently, which return EstimationResult
 // the task itself typically calls runTestRepeated
-class EstimationTaskRunner {
-    private val showTime = false
+class EstimationTaskRunner(val showTime: Boolean = false) {
     private val showTaskResult = false
     private val mutex = Mutex()
     private val results = mutableListOf<EstimationResult>()
 
-    // run all the tasks concurrently
-    fun run(tasks: List<EstimationTask>, nthreads: Int = 30): List<EstimationResult> {
+    // run the tasks concurrently
+    fun run(tasks: List<EstimationTask>, nthreads: Int = 14): List<EstimationResult> {
         val stopwatch = Stopwatch()
         if (showTime) println("\nEstimationTaskRunner run ${tasks.size} concurrent tasks with $nthreads threads")
         runBlocking {
@@ -64,8 +63,9 @@ class EstimationTaskRunner {
         task: EstimationTask,
     ): EstimationResult {
         val stopwatch = Stopwatch()
-        val result =  task.estimate()
-        if (showTaskResult) println(" ${task.name()} (${results.size}): took ${stopwatch.elapsed(TimeUnit.SECONDS)} secs")
+        if (showTaskResult) println(" starting ${task.name()} on thread ${Thread.currentThread().name}")
+        val result = task.estimate()
+        if (showTaskResult) println(" ${task.name()} (${results.size}): took ${stopwatch.elapsed(TimeUnit.MILLISECONDS)} msecs")
         return result
     }
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/MeasureEstimationTaskConcurrency.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/MeasureEstimationTaskConcurrency.kt
@@ -1,0 +1,97 @@
+package org.cryptobiotic.rlauxe.sampling
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.yield
+import org.cryptobiotic.rlauxe.core.ContestUnderAudit
+import org.cryptobiotic.rlauxe.util.Stopwatch
+import org.cryptobiotic.rlauxe.workflow.AuditConfig
+import org.cryptobiotic.rlauxe.workflow.AuditType
+import org.cryptobiotic.rlauxe.workflow.EstimationResult
+import org.cryptobiotic.rlauxe.workflow.EstimationTask
+
+fun main() {
+    val test = MultiContestTestData(15, 1, 20000)
+    val cvrs = test.makeCvrsFromContests()
+    val contestsUA: List<ContestUnderAudit> = test.contests.map { ContestUnderAudit( it ).makeComparisonAssertions(cvrs) }
+    val nassertions = contestsUA.sumOf { it.assertions().size }
+    println("ncontests=${contestsUA.size} nassertions=${nassertions} ncvrs=${cvrs.size}")
+
+    val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles = true, seed = 1234567890L, fuzzPct = null, ntrials = 10)
+    val tasks = mutableListOf<EstimationTask>()
+    contestsUA.filter { !it.done }.forEach { contestUA ->
+        tasks.addAll(makeEstimationTasks(auditConfig, contestUA, cvrs, emptyList(), 1))
+    }
+
+    val one = runWest(1, tasks, 0.0).toDouble()
+    runWest(2, tasks, one)
+    runWest(4, tasks, one)
+    runWest(6, tasks, one)
+    runWest(8, tasks, one)
+    runWest(10, tasks, one)
+    runWest(12, tasks, one)
+    runWest(14, tasks, one)
+    runWest(16, tasks, one)
+}
+
+fun runWest(nthreads: Int, tasks: List<EstimationTask>, one: Double): Long {
+    val runner = EstimationWTaskRunner()
+    return runner.calc(nthreads, tasks, one)
+}
+
+class EstimationWTaskRunner() {
+    private val mutex = Mutex()
+    private val results = mutableListOf<EstimationResult>()
+
+    fun calc(nthreads: Int, tasks: List<EstimationTask>, one: Double): Long {
+        val stopWatch = Stopwatch()
+        runBlocking {
+            val jobs = mutableListOf<Job>()
+            val producer = producer(tasks)
+            repeat(nthreads) {
+                jobs.add(launchCalculations(producer) { task -> task.estimate() })
+            }
+            // wait for all calculations to be done, then close everything
+            joinAll(*jobs.toTypedArray())
+        }
+        print("$nthreads ${stopWatch.tookPer(tasks.size, "tasks")}")
+        val elapsed =  stopWatch.elapsed()
+        println(" speedup = ${one/elapsed} scale = ${one/elapsed/nthreads}")
+        return elapsed
+    }
+
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun CoroutineScope.producer(producer: Iterable<EstimationTask>): ReceiveChannel<EstimationTask> =
+        produce {
+            for (task in producer) {
+                send(task)
+                yield()
+            }
+            channel.close()
+        }
+
+    private fun CoroutineScope.launchCalculations(
+        input: ReceiveChannel<EstimationTask>,
+        taskRunner: (EstimationTask) -> EstimationResult?,
+    ) = launch(Dispatchers.Default) {
+        for (task in input) {
+            val result = taskRunner(task) // not inside the mutex!!
+            if (result != null) {
+                mutex.withLock {
+                    results.add(result)
+                }
+            }
+            yield()
+        }
+    }
+}

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestEstimateSampleSize.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestEstimateSampleSize.kt
@@ -4,7 +4,6 @@ import org.cryptobiotic.rlauxe.core.Contest
 import org.cryptobiotic.rlauxe.workflow.AuditConfig
 import org.cryptobiotic.rlauxe.workflow.AuditType
 import org.cryptobiotic.rlauxe.core.ContestUnderAudit
-import org.cryptobiotic.rlauxe.core.CvrUnderAudit
 import org.cryptobiotic.rlauxe.corla.estimateSampleSizeSimple
 import org.cryptobiotic.rlauxe.util.df
 import kotlin.math.ceil
@@ -75,12 +74,3 @@ class TestEstimateSampleSize {
         }
     }
 }
-
-// fun simulateSampleSizeComparisonAssorter(
-//    auditConfig: AuditConfig,
-//    contestUA: ContestUnderAudit,
-//    cassorter: ComparisonAssorter,
-//    cvrs: List<Cvr>,
-//    maxSamples: Int,
-//    startingTestStatistic: Double = 1.0,
-//): RunTestRepeatedResult {

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/MeasureConcurrency.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/MeasureConcurrency.kt
@@ -1,0 +1,104 @@
+package org.cryptobiotic.rlauxe.util
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.channels.ReceiveChannel
+import kotlinx.coroutines.channels.produce
+import kotlinx.coroutines.joinAll
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.sync.Mutex
+import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.yield
+import java.math.BigInteger
+import kotlin.random.Random
+
+/////////////////////////////////////////////////
+
+fun main() {
+    val wtf = Dispatchers.Default
+    println("CoroutineDispatcher: ${wtf}") // corePoolSize = 48. could use reflection to get at it
+    val one = runVest(1, 100, 0.0).toDouble()
+    runVest(2, 100, one)
+    runVest(4, 100, one)
+    runVest(6, 100, one)
+    runVest(8, 100, one)
+    runVest(12, 100, one)
+    runVest(16, 100, one)
+    runVest(20, 100, one)
+    runVest(24, 100, one)
+    runVest(28, 100, one)
+}
+
+fun runVest(nthreads: Int, ntasks: Int, one: Double): Long {
+    val tasks: List<EstimationVTask> = List(ntasks) { EstimationVTask() }
+    val runner = EstimationVTaskRunner()
+    return runner.calc(nthreads, tasks, one)
+}
+
+class EstimationVTaskRunner() {
+    private val mutex = Mutex()
+    private val results = mutableListOf<EstimationVResult>()
+
+    fun calc(nthreads: Int, tasks: List<EstimationVTask>, one: Double): Long {
+        val stopWatch = Stopwatch()
+        runBlocking {
+            val jobs = mutableListOf<Job>()
+            val producer = producer(tasks)
+            repeat(nthreads) {
+                jobs.add(launchCalculations(producer) { task -> task.estimate() })
+            }
+            // wait for all calculations to be done, then close everything
+            joinAll(*jobs.toTypedArray())
+        }
+        print("$nthreads ${stopWatch.tookPer(tasks.size, "tasks")}")
+        val elapsed =  stopWatch.elapsed()
+        println(" speedup = ${one/elapsed} scale = ${one/elapsed/nthreads}")
+        return elapsed
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    private fun CoroutineScope.producer(producer: Iterable<EstimationVTask>): ReceiveChannel<EstimationVTask> =
+        produce {
+            for (task in producer) {
+                send(task)
+                yield()
+            }
+            channel.close()
+        }
+
+    private fun CoroutineScope.launchCalculations(
+        input: ReceiveChannel<EstimationVTask>,
+        taskRunner: (EstimationVTask) -> EstimationVResult?,
+    ) = launch(Dispatchers.Default) {
+        for (task in input) {
+            val result = taskRunner(task) // not inside the mutex!!
+            if (result != null) {
+                mutex.withLock {
+                    results.add(result)
+                }
+            }
+            yield()
+        }
+    }
+
+}
+
+data class EstimationVResult(val sum: BigInteger)
+
+class EstimationVTask() {
+    fun estimate(): EstimationVResult {
+        var sum = BigInteger.ONE
+        val bytes = ByteArray(1000)
+        Random.nextBytes(bytes)
+        val q = BigInteger(1, bytes)
+        Random.nextBytes(bytes)
+        val p = BigInteger(1, bytes)
+        repeat(1000) {
+            sum = (sum * p).mod(q)
+        }
+        return EstimationVResult(sum)
+    }
+}

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/sampling/Cvrs.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/sampling/Cvrs.kt
@@ -3,7 +3,6 @@ package org.cryptobiotic.rlauxe.sampling
 import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.util.cardsPerContest
 import org.cryptobiotic.rlauxe.util.makeContestFromCvrs
-import org.cryptobiotic.rlauxe.util.secureRandom
 import org.cryptobiotic.rlauxe.util.tabulateVotes
 import kotlin.collections.iterator
 import kotlin.random.Random
@@ -20,7 +19,7 @@ fun makeCvrsByExactCount(counts : List<Int>) : List<Cvr> {
             total++
         }
     }
-    cvrs.shuffle( secureRandom )
+    cvrs.shuffle( Random )
     return cvrs
 }
 
@@ -34,7 +33,7 @@ fun makeCvr(idx: Int): Cvr {
 fun makeCvrsByExactMean(ncards: Int, mean: Double) : List<Cvr> {
     val randomCvrs = mutableListOf<Cvr>()
     repeat(ncards) {
-        val random = secureRandom.nextDouble(1.0)
+        val random = Random.nextDouble(1.0)
         val cand = if (random < mean) 0 else 1
         val votes = mutableMapOf<Int, IntArray>()
         votes[0] = intArrayOf(cand)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ letsPlot = "4.7.3"
 letsPlotImage = "4.3.3"
 mockk = "1.13.10"
 
+# coroutines-version = "1.8.0-RC2"
 coroutines-version = "1.9.0"
 kotest-version = "5.9.1"
 ktor-version = "2.3.4"

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,6 +2,7 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
 kotest.framework.classpath.scanning.autoscan.disable=true
+kotest.framework.parallelism=48
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/CompareAlphaPaperUsingMasses.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/CompareAlphaPaperUsingMasses.kt
@@ -7,9 +7,9 @@ import org.cryptobiotic.rlauxe.sampling.makeCvrsByExactMean
 import org.cryptobiotic.rlauxe.doublePrecision
 import org.cryptobiotic.rlauxe.sampling.SampleGenerator
 import org.cryptobiotic.rlauxe.sampling.makeContestsFromCvrs
-import org.cryptobiotic.rlauxe.util.secureRandom
 import kotlin.test.Test
 import kotlin.math.abs
+import kotlin.random.Random
 import kotlin.test.assertEquals
 
 class CompareAlphaPaperUsingMasses {
@@ -152,7 +152,7 @@ class SampleFromArrayWithoutReplacement(val assortValues : DoubleArray): SampleG
     }
 
     override fun reset() {
-        permutedIndex.shuffle(secureRandom)
+        permutedIndex.shuffle(Random)
         idx = 0
     }
 

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/GenBravoResults.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/GenBravoResults.kt
@@ -9,7 +9,7 @@ import org.cryptobiotic.rlauxe.workflow.runTestRepeated
 import org.cryptobiotic.rlauxe.rlaplots.makeSRT
 import org.cryptobiotic.rlauxe.sampling.SampleGenerator
 import org.cryptobiotic.rlauxe.util.mean2margin
-import org.cryptobiotic.rlauxe.util.secureRandom
+import kotlin.random.Random
 import kotlin.test.Test
 
 // Test Alpha running BRAVO. Compare against UnifiedEvaluation tables (with replacement only)
@@ -104,7 +104,7 @@ class FixedMean(val eta0: Double): EstimFn {
 class GenSampleMeanWithReplacement(val N: Int, ratio: Double): SampleGenerator {
     val samples = generateSampleWithMean(N, ratio)
     override fun sample(): Double {
-        val idx = secureRandom.nextInt(N) // with Replacement
+        val idx = Random.nextInt(N) // with Replacement
         return samples[idx]
     }
     override fun reset() {
@@ -130,14 +130,14 @@ class GenSampleMeanWithoutReplacement(val N: Int, val ratio: Double): SampleGene
 // generate a sample thats approximately mean = theta
 fun generateUniformSample(N: Int) : DoubleArray {
     return DoubleArray(N) {
-        secureRandom.nextDouble(1.0)
+        Random.nextDouble(1.0)
     }
 }
 
 // generate a sample thats approximately mean = theta
 fun generateSampleWithMean(N: Int, ratio: Double) : DoubleArray {
     return DoubleArray(N) {
-        val r = secureRandom.nextDouble(1.0)
+        val r = Random.nextDouble(1.0)
         if (r < ratio) 1.0 else 0.0
     }
 }

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/comparison/Failures.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/comparison/Failures.kt
@@ -5,7 +5,7 @@ import org.cryptobiotic.rlauxe.sampling.makeCvrsByExactMean
 import org.cryptobiotic.rlauxe.rlaplots.SRTcsvWriter
 import org.cryptobiotic.rlauxe.sim.RepeatedTaskRunner
 import org.cryptobiotic.rlauxe.util.mean2margin
-import org.cryptobiotic.rlauxe.util.secureRandom
+import kotlin.random.Random
 import kotlin.test.Test
 
 // CANDIDATE FOR REMOVAL
@@ -96,7 +96,7 @@ class Failures {
 fun makeCvrsByMargin(ncards: Int, margin: Double = 0.0) : List<Cvr> {
     val result = mutableListOf<Cvr>()
     repeat(ncards) {
-        val random = secureRandom.nextDouble(1.0)
+        val random = Random.nextDouble(1.0)
         val cand = if (random < .5 + margin/2.0) 0 else 1
         val votes = mutableMapOf<Int, IntArray>()
         votes[0] = intArrayOf(cand)

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestSampleGenerator.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestSampleGenerator.kt
@@ -8,6 +8,7 @@ import org.cryptobiotic.rlauxe.sampling.add2voteOverstatements
 import org.cryptobiotic.rlauxe.sampling.makeContestsFromCvrs
 import org.cryptobiotic.rlauxe.sampling.makeCvrsByExactMean
 import org.cryptobiotic.rlauxe.util.*
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
@@ -185,7 +186,7 @@ data class ComparisonWithErrors(val cvrs : List<Cvr>, val cassorter: ComparisonA
             idx++
             cassorter.bassort(mvr, cvr)
         } else {
-            val chooseIdx = secureRandom.nextInt(cvrs.size) // with Replacement
+            val chooseIdx = Random.nextInt(cvrs.size) // with Replacement
             val cvr = cvrs[chooseIdx]
             val mvr = mvrs[chooseIdx]
             cassorter.bassort(mvr, cvr)
@@ -194,7 +195,7 @@ data class ComparisonWithErrors(val cvrs : List<Cvr>, val cassorter: ComparisonA
     }
 
     override fun reset() {
-        permutedIndex.shuffle(secureRandom)
+        permutedIndex.shuffle(Random)
         idx = 0
     }
 
@@ -243,7 +244,7 @@ data class ComparisonWithErrorRates(val cvrs : List<Cvr>, val cassorter: Compari
             idx++
             cassorter.bassort(mvr, cvr)
         } else {
-            val chooseIdx = secureRandom.nextInt(N) // with Replacement
+            val chooseIdx = Random.nextInt(N) // with Replacement
             val cvr = cvrs[chooseIdx]
             val mvr = mvrs[chooseIdx]
             cassorter.bassort(mvr, cvr)
@@ -252,7 +253,7 @@ data class ComparisonWithErrorRates(val cvrs : List<Cvr>, val cassorter: Compari
     }
 
     override fun reset() {
-        permutedIndex.shuffle(secureRandom)
+        permutedIndex.shuffle(Random)
         idx = 0
     }
 
@@ -271,7 +272,7 @@ private fun add1voteOverstatements(cvrs: MutableList<Cvr>, needToChangeVotesFrom
     val startingAvotes = cvrs.sumOf { it.hasMarkFor(0, 0) }
     var changed = 0
     while (changed < needToChangeVotesFromA) {
-        val cvrIdx = secureRandom.nextInt(ncards)
+        val cvrIdx = Random.nextInt(ncards)
         val cvr = cvrs[cvrIdx]
         if (cvr.hasMarkFor(0, 0) == 1) {
             val votes = mutableMapOf<Int, IntArray>()


### PR DESCRIPTION
Stop using SecureRandom in the simulations, only use where needed (Prng seed).