### PR TITLE
Uniform handling of Ballots and Cvrs for sampling.

### DIFF
--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
@@ -1,5 +1,7 @@
 package org.cryptobiotic.rlauxe.core
 
+import org.cryptobiotic.rlauxe.workflow.BallotOrCard
+
 // immutable
 data class Cvr(
     val id: String,
@@ -59,17 +61,18 @@ data class Cvr(
 }
 
 /** Mutable version of Cvr. sampleNum >= 0  */
-class CvrUnderAudit (val cvr: Cvr, var sampleNum: Long = 0L) {
+class CvrUnderAudit (val cvr: Cvr, var sampleNum: Long = 0L): BallotOrCard {
     var sampled = false //  # is this CVR in the sample?
 
     val id = cvr.id
     val votes = cvr.votes
     val phantom = cvr.phantom
-    fun hasContest(contestId: Int) = cvr.hasContest(contestId)
-    fun hasMarkFor(contestId: Int, candidateId: Int) = cvr.hasMarkFor(contestId, candidateId)
-    fun hasOneVote(contestId: Int, candidates: List<Int>) = cvr.hasOneVote(contestId, candidates)
 
-    // constructor(id: String, contestIdx: Int) : this( Cvr(id, mapOf(contestIdx to IntArray(0)), false))
+    override fun hasContest(contestId: Int) = cvr.hasContest(contestId)
+    override fun sampleNumber() = sampleNum
+    override fun setIsSampled(isSampled: Boolean) {
+        this.sampled = isSampled
+    }
 
     override fun toString() = buildString {
         append("$id ($phantom)")

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/ConsistentSampling.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/ConsistentSampling.kt
@@ -2,101 +2,66 @@ package org.cryptobiotic.rlauxe.sampling
 
 import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.util.df
-import org.cryptobiotic.rlauxe.workflow.BallotUnderAudit
+import org.cryptobiotic.rlauxe.workflow.BallotOrCard
 
 //// Adapted from SHANGRLA Audit.py
 
 // TODO not clear yet how to limit the sample size. maxFirstRoundSampleSize? maxPercent? show pvalue, let user intervene?
 
-fun consistentCvrSampling(
+fun consistentSampling(
     contests: List<ContestUnderAudit>, // must have sampleSizes set
-    cvrList: List<CvrUnderAudit>, // must have sampleNums assigned
+    ballotOrCards: List<BallotOrCard>, // must have sampleNums assigned
 ): List<Int> {
-    if (cvrList.isEmpty()) return emptyList()
+    if (ballotOrCards.isEmpty()) return emptyList()
+
+    // set all sampled to false, so each round is independent
+    ballotOrCards.forEach{ it.setIsSampled(false)}
 
     val currentSizes = mutableMapOf<Int, Int>() // contestId -> ncvrs in sample
     fun contestInProgress(c: ContestUnderAudit) = (currentSizes[c.id] ?: 0) < c.estSampleSize
 
     // get list of cvr indexes sorted by sampleNum
-    val sortedCvrIndices = cvrList.indices.sortedBy { cvrList[it].sampleNum }
+    val sortedBocIndices = ballotOrCards.indices.sortedBy { ballotOrCards[it].sampleNumber() }
 
     val sampledIndices = mutableListOf<Int>()
     var inx = 0
     // while we need more samples
-    while (contests.any { contestInProgress(it) } && inx < sortedCvrIndices.size) {
+    while (contests.any { contestInProgress(it) } && inx < sortedBocIndices.size) {
         // get the next sorted cvr
-        val sidx = sortedCvrIndices[inx]
-        val cvr = cvrList[sidx]
-        // does this cvr contribute to one or more contests that need more samples?
-        if (contests.any { contestInProgress(it) && cvr.hasContest(it.id) }) {
+        val sidx = sortedBocIndices[inx]
+        val boc = ballotOrCards[sidx]
+        // does this contribute to one or more contests that need more samples?
+        if (contests.any { contestInProgress(it) && boc.hasContest(it.id) }) {
             // then use it
             sampledIndices.add(sidx)
-            cvr.sampled = true
+            boc.setIsSampled(true)
             contests.forEach { contest ->
-                if (cvr.hasContest(contest.id)) {
+                if (boc.hasContest(contest.id)) {
                     currentSizes[contest.id] = currentSizes[contest.id]?.plus(1) ?: 1
                 }
             }
         }
         inx++
     }
-    if (inx > sortedCvrIndices.size) {
+    if (inx > sortedBocIndices.size) {
         throw RuntimeException("ran out of samples!!")
     }
 
     return sampledIndices
 }
 
-fun consistentPollingSampling(
-    contests: List<ContestUnderAudit>, // all the contests you want to sample
-    ballots: List<BallotUnderAudit>, // all the ballots available to sample
-): List<Int> {
-    if (ballots.isEmpty()) return emptyList()
-
-    val currentSizes = mutableMapOf<Int, Int>()
-    fun contestInProgress(c: ContestUnderAudit) = (currentSizes[c.id] ?: 0) < c.estSampleSize
-
-    // get list of ballot indexes sorted by sampleNum
-    val sortedCvrIndices = ballots.indices.sortedBy { ballots[it].sampleNum }
-
-    val sampledIndices = mutableListOf<Int>()
-    var inx = 0
-    // while we need more samples
-    while (contests.any { contestInProgress(it) }  && (inx < sortedCvrIndices.size)) {
-        // get the next sorted cvr
-        val sidx = sortedCvrIndices[inx]
-        val ballot = ballots[sidx]
-        // does this cvr contribute to one or more contests that need more samples?
-        if (contests.any { contestInProgress(it) && ballot.hasContest(it.id) }) {
-            // then use it
-            sampledIndices.add(sidx)
-            ballot.sampled = true
-            ballot.contestIds().forEach { currentSizes[it] = currentSizes[it]?.plus(1) ?: 1 }
-        }
-        inx++
-    }
-    if (inx > sortedCvrIndices.size) {
-        throw RuntimeException("ran out of samples!!")
-    }
-    return sampledIndices
-}
-
-fun uniformPollingSampling(
+fun uniformSampling(
     contests: List<ContestUnderAudit>,
-    ballots: List<BallotUnderAudit>, // all the ballots available to sample
+    ballotOrCards: List<BallotOrCard>,
     samplePctCutoff: Double,
     N: Int,
     roundIdx: Int,
 ): List<Int> {
-    if (ballots.isEmpty()) return emptyList()
+    if (ballotOrCards.isEmpty()) return emptyList()
 
-    // est = rho / dilutedMargin
-    // dilutedMargin = (vw - vl)/ Nc
-    // est = rho * Nc / (vw - vl)
-    // totalEst = est * N / Nc = rho * N / (vw - vl) = rho / fullyDilutedMargin
-    // fullyDilutedMargin = (vw - vl)/ N
+    // set all sampled to false, so each round is independent
+    ballotOrCards.forEach{ it.setIsSampled(false)}
 
-    // TODO use rounds
     // scale by proportion of ballots that have this contest
     contests.forEach {
         val fac = N / it.Nc.toDouble()
@@ -116,7 +81,6 @@ fun uniformPollingSampling(
                 samplesUsed = -1,
                 pvalue = 0.0,
                 status = TestH0Status.LimitReached,
-                // calcAssortMargin=0.0,
             )
             minAssert.roundResults.add(roundResult)
         }
@@ -125,7 +89,7 @@ fun uniformPollingSampling(
     if (estTotalSampleSizes.isEmpty()) return emptyList()
 
     // get list of ballot indexes sorted by sampleNum
-    val sortedCvrIndices = ballots.indices.sortedBy { ballots[it].sampleNum }
+    val sortedCvrIndices = ballotOrCards.indices.sortedBy { ballotOrCards[it].sampleNumber() }
 
     // take the first estSampleSize of the sorted ballots
     // val simple = roundIdx * N / 10.0

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/BallotManifest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/BallotManifest.kt
@@ -27,6 +27,12 @@ data class BallotManifest(
     val ballotStyles: List<BallotStyle> // empty if style info not available, auditConfig.hasStyles = false
 )
 
+interface BallotOrCard {
+    fun hasContest(contestId: Int): Boolean
+    fun sampleNumber(): Long
+    fun setIsSampled(isSampled: Boolean)
+}
+
 data class Ballot(
     val id: String,
     val phantom: Boolean = false,
@@ -38,6 +44,7 @@ data class Ballot(
         if (contestIds != null) return contestIds.find{ it == contestId } != null
         return false
     }
+
     fun contestIds(): List<Int> {
         if (ballotStyle != null) return ballotStyle.contestIds
         if (contestIds != null) return contestIds
@@ -45,13 +52,16 @@ data class Ballot(
     }
 }
 
-class BallotUnderAudit (val ballot: Ballot, var sampleNum: Long = 0L) {
-    var sampled = false //  # is this CVR in the sample?
+class BallotUnderAudit (val ballot: Ballot, var sampleNum: Long = 0L) : BallotOrCard {
+    var sampled = false //  # is this in the sample?
     val id = ballot.id
     val phantom = ballot.phantom
 
-    fun hasContest(contestId: Int) = ballot.hasContest(contestId)
-    fun contestIds() = ballot.contestIds()
+    override fun hasContest(contestId: Int) = ballot.hasContest(contestId)
+    override fun sampleNumber() = sampleNum
+    override fun setIsSampled(isSampled: Boolean) {
+        this.sampled = isSampled
+    }
 }
 
 // The term ballot style generally refers to the set of contests on a given voter’s ballot. (Ballot

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ComparisonWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ComparisonWorkflow.kt
@@ -84,13 +84,20 @@ class ComparisonWorkflow(
         // TODO how to control the round's sampleSize?
 
         //	4.c) Choose thresholds {𝑡_𝑐} 𝑐 ∈ C so that 𝑆_𝑐 ballot cards containing contest 𝑐 have a sample number 𝑢_𝑖 less than or equal to 𝑡_𝑐 .
+        // draws random ballots and returns their locations to the auditors.
         val contestsNotDone = contestsUA.filter{ !it.done }
         if (contestsNotDone.size > 0) {
-            println("consistentCvrSampling round $roundIdx")
-            //  This draws random ballots by consistent sampling, and returns their locations to the auditors.
-            val sampleIndices = consistentCvrSampling(contestsNotDone, cvrsUA)
-            println(" ComparisonWithStyle.chooseSamples maxContestSize=$maxContestSize consistentSamplingSize= ${sampleIndices.size}")
-            return sampleIndices
+            return if (auditConfig.hasStyles) {
+                println("\nconsistentSampling round $roundIdx")
+                val sampleIndices = consistentSampling(contestsNotDone, cvrsUA)
+                println(" maxContestSize=$maxContestSize consistentSamplingSize= ${sampleIndices.size}")
+                sampleIndices
+            } else {
+                println("\nuniformSampling round $roundIdx")
+                val sampleIndices = uniformSampling(contestsNotDone, cvrsUA, auditConfig.samplePctCutoff, cvrs.size, roundIdx)
+                println(" maxContestSize=$maxContestSize consistentSamplingSize= ${sampleIndices.size}")
+                sampleIndices
+            }
         }
         return emptyList()
     }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingWorkflow.kt
@@ -43,20 +43,23 @@ class PollingWorkflow(
             show=show,
         )
 
-        // choose samples
-        val result = if (auditConfig.hasStyles) { // maybe should be in AuditConfig?
-            println("\nconsistentPollingSampling round $roundIdx")
-            val sampleIndices = consistentPollingSampling(contestsUA.filter { !it.done }, ballotsUA)
-            println(" PollingWithStyle.chooseSamples maxContestSize=$maxContestSize consistentSamplingSize= ${sampleIndices.size}")
-            sampleIndices
-        } else {
-            println("\nuniformPollingSampling round $roundIdx")
-            val sampleIndices = uniformPollingSampling(contestsUA.filter { !it.done }, ballotsUA, auditConfig.samplePctCutoff, N, roundIdx)
-            println("maxContestSize=$maxContestSize consistentSamplingSize= ${sampleIndices.size}")
-            sampleIndices
+        // choose indices to sample
+        val contestsNotDone = contestsUA.filter{ !it.done }
+        if (contestsNotDone.size > 0) {
+            return if (auditConfig.hasStyles) {
+                println("\nconsistentSampling round $roundIdx")
+                val sampleIndices = consistentSampling(contestsNotDone, ballotsUA)
+                println(" maxContestSize=$maxContestSize consistentSamplingSize= ${sampleIndices.size}")
+                sampleIndices
+            } else {
+                println("\nuniformSampling round $roundIdx")
+                val sampleIndices = uniformSampling(contestsNotDone, ballotsUA, auditConfig.samplePctCutoff, N, roundIdx)
+                println(" maxContestSize=$maxContestSize consistentSamplingSize= ${sampleIndices.size}")
+                sampleIndices
+            }
         }
 
-        return result
+        return emptyList()
     }
 
     fun showResults() {

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestCvr.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestCvr.kt
@@ -21,7 +21,7 @@ class TestCvr {
     fun testCvrUnderAudit() {
         val cvrUA = CvrUnderAudit(makeCvr(1), 12345L)
         assertEquals("card (false) 0: [1]", cvrUA.toString())
-        assertEquals(0, cvrUA.hasMarkFor(0, 0))
-        assertEquals(1, cvrUA.hasMarkFor(0, 1))
+        assertEquals(0, cvrUA.cvr.hasMarkFor(0, 0))
+        assertEquals(1, cvrUA.cvr.hasMarkFor(0, 1))
     }
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestConsistentSampling.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/sampling/TestConsistentSampling.kt
@@ -19,7 +19,7 @@ class TestConsistentSampling {
         val prng = Prng(secureRandom.nextLong())
         val cvrsUAP = test.makeCvrsFromContests().map { CvrUnderAudit( it, prng.next()) }
 
-        val sampleIndices = consistentCvrSampling(contestsUA, cvrsUAP)
+        val sampleIndices = consistentSampling(contestsUA, cvrsUAP)
         println("nsamples needed = ${sampleIndices.size}\n")
         sampleIndices.forEach {
             assertTrue(it < cvrsUAP.size)
@@ -54,7 +54,7 @@ class TestConsistentSampling {
         val prng = Prng(secureRandom.nextLong())
         val ballotsUA = ballotManifest.ballots.map { BallotUnderAudit(it, prng.next()) }
 
-        val sampleIndices = consistentPollingSampling(contestsUA, ballotsUA)
+        val sampleIndices = consistentSampling(contestsUA, ballotsUA)
         println("nsamples needed = ${sampleIndices.size}\n")
         sampleIndices.forEach {
             assertTrue(it < ballotsUA.size)
@@ -97,7 +97,7 @@ class TestConsistentSampling {
         //    N: Int,
         //    roundIdx: Int,
         val estPctCutoff = .50
-        val sampleIndices = uniformPollingSampling(contestsUA, ballotsUA, estPctCutoff, N, 0)
+        val sampleIndices = uniformSampling(contestsUA, ballotsUA, estPctCutoff, N, 0)
         println("nsamples needed = ${sampleIndices.size}\n")
         sampleIndices.forEach {
             assertTrue(it < ballotsUA.size)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/AssertionRLAipynb.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/AssertionRLAipynb.kt
@@ -449,7 +449,7 @@ class AssertionRLA {
             it.estSampleSize = sampleSize
             it
         }
-        val sampled_cvr_indices = consistentCvrSampling(contestUA, cvras)
+        val sampled_cvr_indices = consistentSampling(contestUA, cvras)
         println("sampled = ${sampled_cvr_indices.size}")
 
 //n_sampled_phantoms = np.sum(sampled_cvr_indices > manifest_cards)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/TestConsistentSamplingFromShangrla.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/TestConsistentSamplingFromShangrla.kt
@@ -1,7 +1,7 @@
 package org.cryptobiotic.rlauxe.shangrla
 
 import org.cryptobiotic.rlauxe.core.*
-import org.cryptobiotic.rlauxe.sampling.consistentCvrSampling
+import org.cryptobiotic.rlauxe.sampling.consistentSampling
 import org.cryptobiotic.rlauxe.sampling.makeContestsFromCvrs
 import org.cryptobiotic.rlauxe.sampling.makePhantomCvrs
 import org.cryptobiotic.rlauxe.util.*
@@ -45,7 +45,7 @@ class TestConsistentSamplingFromShangrla {
         contestsUA[0].estSampleSize = 3
         contestsUA[1].estSampleSize = 4
 
-        val sample_cvr_indices = consistentCvrSampling(contestsUA, cvrsUA)
+        val sample_cvr_indices = consistentSampling(contestsUA, cvrsUA)
         assertEquals(5, sample_cvr_indices.size)
 
         assertEquals(listOf(3, 2, 1, 5, 0), sample_cvr_indices)
@@ -90,7 +90,7 @@ class TestConsistentSamplingFromShangrla {
         val cvrsUAP = (cvrs + phantomCVRs).map { CvrUnderAudit( it, prng.next()) }
         assertEquals(9, cvrsUAP.size)
 
-        val sample_cvr_indices = consistentCvrSampling(contestsUA, cvrsUAP)
+        val sample_cvr_indices = consistentSampling(contestsUA, cvrsUAP)
         assertEquals(6, sample_cvr_indices.size)
         assertEquals(listOf(7, 2, 8, 3, 5, 1), sample_cvr_indices)
     }


### PR DESCRIPTION
Create interface BallotOrCard that both BallotUnderAudit and CvrUnderAudit implement. 
consistentSampling() and uniformSampling() use this.