### PR TITLE
phantoms create 1 vote overstatements, not 2 vote.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # rlauxe
-last update: 12/29/2024
+last update: 12/30/2024
 
 A port of Philip Stark's SHANGRLA framework and related code to kotlin, 
 for the purpose of making a reusable and maintainable library.
@@ -617,6 +617,8 @@ So for estimation, we could calculate the margin with usePhantoms=true, since th
 
 Ive convinced myself that one cant know Nc without knowing Np. Since Np has such a strong effect, we will keep it per 
 contest and use it in the estimation and also the betting strategy.
+
+Should use phantomPct for estimated 1-vote overstatement error rate estimate.
 
 ## Stratified audits using OneAudit (TODO)
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Assorter.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Assorter.kt
@@ -151,11 +151,7 @@ data class ComparisonAssorter(
 
         val overstatement = overstatementError(mvr, cvr, this.hasStyle) // ωi
         val tau = (1.0 - overstatement / this.assorter.upperBound())
-        val denom =  (2.0 - margin/this.assorter.upperBound())
-        val result1 =  tau * noerror
-        val result2 =  tau / denom
-        require(doubleIsClose(result1, result2))
-        return result1
+        return tau * noerror
     }
 
     //    overstatement error for a CVR compared to the human reading of the ballot.

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/SampleTracker.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/SampleTracker.kt
@@ -43,10 +43,10 @@ class PrevSamplesWithRates(val noerror: Double) : SampleTracker {
     private var sum = 0.0
     private val welford = Welford()
     private var countP0 = 0
-    private var countP1 = 0
-    private var countP2 = 0
-    private var countP3 = 0
-    private var countP4 = 0
+    private var countP1o = 0
+    private var countP2o = 0
+    private var countP1u = 0
+    private var countP2u = 0
 
     override fun last() = last
     override fun numberOfSamples() = welford.count
@@ -55,10 +55,10 @@ class PrevSamplesWithRates(val noerror: Double) : SampleTracker {
     override fun variance() = welford.variance()
 
     // these are the rates from the previous samples.
-    fun sampleP1count() = countP1
-    fun sampleP2count() = countP2
-    fun sampleP3count() = countP3
-    fun sampleP4count() = countP4
+    fun countP1o() = countP1o
+    fun countP2o() = countP2o
+    fun countP1u() = countP1u
+    fun countP2u() = countP2u
 
     fun addSample(sample : Double) {
         last = sample
@@ -67,22 +67,22 @@ class PrevSamplesWithRates(val noerror: Double) : SampleTracker {
 
         if (noerror != 0.0) {
             // or just say which overstatement it is?
+            if (doubleIsClose(sample, 0.0)) countP2o++
+            if (doubleIsClose(sample, noerror * 0.5)) countP1o++
             if (doubleIsClose(sample, noerror)) countP0++
-            if (doubleIsClose(sample, noerror * 0.5)) countP1++
-            if (doubleIsClose(sample, 0.0)) countP2++
-            if (doubleIsClose(sample, noerror * 1.5)) countP3++
-            if (doubleIsClose(sample, noerror * 2.0)) countP4++
+            if (doubleIsClose(sample, noerror * 1.5)) countP1u++
+            if (doubleIsClose(sample, noerror * 2.0)) countP2u++
         }
     }
 
-    fun samplingErrors() = listOf(countP0,countP1,countP2,countP3,countP4)
+    fun samplingErrors() = listOf(countP0,countP1o,countP2o,countP1u,countP2u)
 
     fun samplingErrors(denom:Double) = buildString {
         append("[${dfn(countP0/denom, 4)},")
-        append("${dfn(countP1/denom, 4)},")
-        append("${dfn(countP2/denom, 4)},")
-        append("${dfn(countP3/denom, 4)},")
-        append("${dfn(countP4/denom, 4)}]")
+        append("${dfn(countP1o/denom, 4)},")
+        append("${dfn(countP2o/denom, 4)},")
+        append("${dfn(countP1u/denom, 4)},")
+        append("${dfn(countP2u/denom, 4)}]")
     }
 }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireContestTestData.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireContestTestData.kt
@@ -151,7 +151,7 @@ fun findMinAssertion(testContest: RaireContestTestData, testCvrs: List<RaireCvr>
     val votes = Votes(cvotes, testContest.ncands)
     val result = votes.runElection(TimeOut.never())
     println(" runElection: possibleWinners=${result.possibleWinners.contentToString()} eliminationOrder=${result.eliminationOrder.contentToString()}")
-    require(1 == result.possibleWinners.size) // TODO
+    require(1 == result.possibleWinners.size) { "nwinners ${result.possibleWinners.size} must be 1" } // TODO
     val winner:Int = result.possibleWinners[0]
 
     // Map<String, Object> metadata,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/EstimateSampleSize.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/sampling/EstimateSampleSize.kt
@@ -324,10 +324,10 @@ fun simulateSampleSizeBetaMart(
         a = noerror,
         d1 = auditConfig.d1,
         d2 = auditConfig.d2,
-        p1 = errorRates[0],
-        p2 = errorRates[1],
-        p3 = errorRates[2],
-        p4 = errorRates[3],
+        p2o = errorRates[0],
+        p1o = errorRates[1],
+        p1u = errorRates[2],
+        p2u = errorRates[3],
     )
     val testFn = BettingMart(
         bettingFn = optimal,
@@ -342,10 +342,10 @@ fun simulateSampleSizeBetaMart(
         ntrials = auditConfig.ntrials,
         testFn = testFn,
         testParameters = mapOf(
-            "p1" to optimal.p1,
-            "p2" to optimal.p2,
-            "p3" to optimal.p3,
-            "p4" to optimal.p4
+            "p2o" to optimal.p2o,
+            "p1o" to optimal.p1o,
+            "p1u" to optimal.p1u,
+            "p2u" to optimal.p2u
         ) + moreParameters,
         showDetails = false,
         startingTestStatistic = startingTestStatistic,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ComparisonWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ComparisonWorkflow.kt
@@ -289,10 +289,10 @@ fun runOneAssertionAudit(
         a = cassorter.noerror,
         d1 = auditConfig.d1,
         d2 = auditConfig.d2,
-        p1 = errorRates[0],
-        p2 = errorRates[1],
-        p3 = errorRates[2],
-        p4 = errorRates[3],
+        p2o = errorRates[0],
+        p1o = errorRates[1],
+        p1u = errorRates[2],
+        p2u = errorRates[3],
     )
     val testFn = BettingMart(
         bettingFn = optimal,

--- a/core/src/main/proto/rlauxe.proto
+++ b/core/src/main/proto/rlauxe.proto
@@ -61,7 +61,7 @@ message AuditConfig {
 }
 
 message ContestBounds {
-  map<string, uint32> bounds = 1; // contest name -> bound. B7. trustworthy upper bound on number of ballots for this contest
+  map<string, uint32> bounds = 1; // contest name -> bound. B7. trustworthy upper bound on number of ballots/cards for this contest
 }
 
 message Contest {
@@ -75,7 +75,7 @@ message Contest {
 
 message Votes {
     string contest_id = 1;
-    repeated uint32 candidate_ids = 2; // candidate has 1 vote.for irv, the order of candidate_ids is their ranking
+    repeated uint32 candidate_ids = 2; // candidate has 1 vote. for irv, the order of candidate_ids is their ranking
 }
 
 message BallotManifest {

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestOptimalComparison.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestOptimalComparison.kt
@@ -16,7 +16,7 @@ class TestOptimalComparison {
             for (p2 in p2s) {
                 println("margin=$margin p2=$p2")
 
-                val kelly = OptimalLambda(a, p1 = 0.0, p2 = p2)
+                val kelly = OptimalLambda(a, p1o = 0.0, p2o = p2)
                 val lam = kelly.solve()
 
                 val optimal = OptimalComparisonNoP1(N = N, withoutReplacement = true, upperBound = 2 * a, p2 = p2)
@@ -40,7 +40,7 @@ class TestOptimalComparison {
             for (p2 in p2s) {
                 println("margin=$margin p2=$p2")
 
-                val kelly = OptimalLambda(a, p1 = 0.0, p2 = p2)
+                val kelly = OptimalLambda(a, p1o = 0.0, p2o = p2)
                 val lam = kelly.solve()
 
                 // these fail when upperBound * (1.0 - p2) <= 1.0

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaEstimate.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaEstimate.kt
@@ -13,24 +13,24 @@ import kotlin.math.max
  *   sample finds too many overstatements, especially two-vote overstatements.
  *   The larger γ is, the larger the initial sample needs to be, but the less additional counting will be required
  *   if the sample finds a two-vote overstatement or a large number of one-vote maximum overstatements. (paper has 1.1)
- * @param twoUnder the number of two-vote understatements
- * @param oneUnder the number of one-vote understatements
- * @param oneOver the number of one-vote overstatements
  * @param twoOver the number of two-vote overstatements
+ * @param oneOver the number of one-vote overstatements
+ * @param oneUnder the number of one-vote understatements
+ * @param twoUnder the number of two-vote understatements
  */
 fun estimateSampleSizeSimple(
     riskLimit: Double,
     dilutedMargin: Double,
     gamma: Double = 1.03,
-    oneOver: Int = 0,   // p1
-    twoOver: Int = 0,   // p2
-    oneUnder: Int = 0,  // p3
-    twoUnder: Int = 0,  // p4
+    twoOver: Int = 0,
+    oneOver: Int = 0,
+    oneUnder: Int = 0,
+    twoUnder: Int = 0,
 ): Int {
-    val two_under_term = twoUnder * ln( 1 + 1 / gamma) // log or ln ?
-    val one_under_term = oneUnder * ln( 1 + 1 / (2 * gamma)) // log or ln ?
-    val one_over_term = oneOver * ln( 1 - 1 / (2 * gamma)) // log or ln ?
-    val two_over_term = twoOver * ln( 1 - 1 / gamma) // log or ln ?
+    val two_under_term = twoUnder * ln( 1 + 1 / gamma)
+    val one_under_term = oneUnder * ln( 1 + 1 / (2 * gamma))
+    val one_over_term = oneOver * ln( 1 - 1 / (2 * gamma))
+    val two_over_term = twoOver * ln( 1 - 1 / gamma)
 
     // "sample-size multiplier" rho is independent of margin
     val rho: Double = -(2.0 * gamma) * (ln(riskLimit) + two_under_term + one_under_term + one_over_term + two_over_term)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestOptimalEstimate.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestOptimalEstimate.kt
@@ -46,7 +46,7 @@ fun compareCorlaAndOptimal(dilutedMargin: Double) {
     println()
 }
 
-fun compareCorlaAndOptimal(dilutedMargin: Double, twoUnder: Int, oneUnder: Int, oneOver: Int, twoOver: Int,) {
+fun compareCorlaAndOptimal(dilutedMargin: Double, twoOver: Int, oneOver: Int, oneUnder: Int, twoUnder: Int,) {
     val riskLimit = 0.05
     val gamma = 1.2
 
@@ -54,10 +54,10 @@ fun compareCorlaAndOptimal(dilutedMargin: Double, twoUnder: Int, oneUnder: Int, 
         riskLimit,
         dilutedMargin,
         gamma,
-        twoUnder = twoUnder,
-        oneUnder = oneUnder,
+        twoOver = twoOver,
         oneOver = oneOver,
-        twoOver = twoOver
+        oneUnder = oneUnder,
+        twoUnder = twoUnder,
     )
 
     // fun estimateSampleSizeOptimalLambda(
@@ -72,10 +72,10 @@ fun compareCorlaAndOptimal(dilutedMargin: Double, twoUnder: Int, oneUnder: Int, 
         riskLimit,
         dilutedMargin,
         1.0,
-        p1 = oneUnder/N,
-        p2 = twoUnder/N,
-        p3 = oneOver/N,
-        p4 = twoOver/N,
+        p1u = oneUnder/N,
+        p2u = twoUnder/N,
+        p1o = oneOver/N,
+        p2o = twoOver/N,
     )
 
     println("   [$twoOver, $oneOver, $oneUnder, $twoUnder] -> $optimal $corla")

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestMakeRaireContest.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestMakeRaireContest.kt
@@ -1,14 +1,6 @@
 package org.cryptobiotic.rlauxe.raire
 
-import au.org.democracydevelopers.raire.RaireProblem
-import au.org.democracydevelopers.raire.audittype.BallotComparisonOneOnDilutedMargin
-import au.org.democracydevelopers.raire.irv.Votes
-import au.org.democracydevelopers.raire.time.TimeOut
-import org.cryptobiotic.rlauxe.util.df
-import kotlin.collections.forEach
 import kotlin.test.Test
-import kotlin.test.assertNotNull
-import kotlin.test.assertEquals
 
 class TestMakeRaireContest {
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/AssertionRLAipynb.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/AssertionRLAipynb.kt
@@ -680,10 +680,10 @@ fun calc_sample_sizes(
         a = minAssorter.noerror,
         d1 = 100,
         d2 = 100,
-        p1 = .01,
-        p2 = .001,
-        p3 = 0.0,
-        p4 = 0.0,
+        p2o = .001,
+        p1o = .01,
+        p1u = 0.0,
+        p2u = 0.0,
     )
     val betta = BettingMart(bettingFn = optimal, Nc = N, noerror = minAssorter.noerror, upperBound = minAssorter.upperBound, withoutReplacement = false)
 
@@ -692,7 +692,7 @@ fun calc_sample_sizes(
         // maxSamples = N,
         ntrials = ntrials,
         testFn = betta,
-        testParameters = mapOf("p2" to optimal.p2),
+        testParameters = mapOf("p2o" to optimal.p2o),
         showDetails = false,
         margin = minAssorter.margin,
         Nc = N,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestComparisonWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestComparisonWorkflow.kt
@@ -52,7 +52,7 @@ class TestComparisonWorkflow {
     }
 
     @Test
-    fun p2ErrorsEqualPhantoms() {
+    fun p1ErrorsEqualPhantoms() {
         val N = 100000
         val ncontests = 42
         val nbs = 11
@@ -62,9 +62,8 @@ class TestComparisonWorkflow {
         val phantomRange= phantomPct ..< phantomPct
         val testData = MultiContestTestData(ncontests, nbs, N, marginRange=marginRange, underVotePct=underVotePct, phantomPct=phantomRange)
 
-        val errorRates = listOf(0.0, phantomPct, 0.0, 0.0, )
-        val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles=true, seed = 12356667890L, fuzzPct = null, ntrials=10,
-                errorRates=errorRates)
+        val errorRates = listOf(0.0, phantomPct, 0.0, 0.0, ) // TODO automatic
+        val auditConfig = AuditConfig(AuditType.CARD_COMPARISON, hasStyles=true, seed = 12356667890L, fuzzPct = null, ntrials=10, errorRates=errorRates)
         testComparisonWorkflow(auditConfig, testData)
     }
 
@@ -111,11 +110,9 @@ fun runComparisonWorkflow(workflow: ComparisonWorkflow, testMvrs: List<Cvr>, nas
         val currRound = Round(roundIdx, indices, previousSamples.toSet())
         rounds.add(currRound)
         previousSamples.addAll(indices)
-
         println("$roundIdx choose ${indices.size} samples, new=${currRound.newSamples} took ${roundStopwatch.elapsed(TimeUnit.MILLISECONDS)} ms\n")
 
         val sampledMvrs = indices.map { testMvrs[it] }
-
         done = workflow.runAudit(indices, sampledMvrs, roundIdx)
         println("runAudit $roundIdx done=$done took ${stopwatch.elapsed(TimeUnit.MILLISECONDS)} ms\n")
         prevMvrs = sampledMvrs

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/betting/GenBettingPayoff.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/betting/GenBettingPayoff.kt
@@ -32,10 +32,10 @@ class GenBettingPayoff {
                     a = noerror,
                     d1 = 10000,
                     d2 = 10000,
-                    p1 = error,
-                    p2 = error,
-                    p3 = error,
-                    p4 = error
+                    p2o = error,
+                    p1o = error,
+                    p1u = error,
+                    p2u = error
                 )
                 val samples = PrevSamplesWithRates(noerror)
                 repeat(100) { samples.addSample(noerror) }
@@ -59,10 +59,10 @@ class GenBettingPayoff {
                     a = noerror,
                     d1 = 10000,
                     d2 = 10000,
-                    p1 = error,
-                    p2 = error,
-                    p3 = error,
-                    p4 = error
+                    p2o = error,
+                    p1o = error,
+                    p1u = error,
+                    p2u = error
                 )
                 val samples = PrevSamplesWithRates(noerror)
                 repeat(100) { samples.addSample(noerror) }
@@ -100,10 +100,10 @@ class GenBettingPayoff {
                     a = noerror,
                     d1 = 10000,
                     d2 = 10000,
-                    p1 = error,
-                    p2 = error,
-                    p3 = error,
-                    p4 = error
+                    p2o = error,
+                    p1o = error,
+                    p1u = error,
+                    p2u = error
                 )
                 val samples = PrevSamplesWithRates(noerror)
                 repeat(10) { samples.addSample(noerror) }

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/ReproduceCobraResults.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/ReproduceCobraResults.kt
@@ -257,10 +257,10 @@ class ReproduceCobraResults {
                             a = compareAssorter.noerror,
                             d1 = d1,
                             d2 = d2,
-                            p1 = p1prior,
-                            p2 = p2prior,
-                            p3 = 0.0,
-                            p4 = 0.0,
+                            p2o = p2prior,
+                            p1o = p1prior,
+                            p1u = 0.0,
+                            p2u = 0.0,
                             eps=eps,
                         )
                         val betting =

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/Corla.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/Corla.kt
@@ -39,10 +39,10 @@ class Corla(val N: Int, val riskLimit: Double, val reportedMargin: Double, val n
                 sampleNumber,
                 reportedMargin,
                 gamma,
-                n1 = prevSamples.sampleP1count(),
-                n2 = prevSamples.sampleP2count(),
-                n3 = prevSamples.sampleP3count(),
-                n4 = prevSamples.sampleP4count(),
+                p2o = prevSamples.countP2o(),
+                p1o = prevSamples.countP1o(),
+                p1u = prevSamples.countP1u(),
+                p2u = prevSamples.countP2u(),
             )
             pvalues.add(pvalue)
 
@@ -87,10 +87,10 @@ class Corla(val N: Int, val riskLimit: Double, val reportedMargin: Double, val n
             sampleNumber,
             reportedMargin,
             gamma,
-            n1 = prevSamples.sampleP1count(),
-            n2 = prevSamples.sampleP2count(),
-            n3 = prevSamples.sampleP3count(),
-            n4 = prevSamples.sampleP4count(),
+            p2o = prevSamples.countP2o(),
+            p1o = prevSamples.countP1o(),
+            p1u = prevSamples.countP1u(),
+            p2u = prevSamples.countP2u(),
         )
 
         val status = if (p <= riskLimit) TestH0Status.StatRejectNull else TestH0Status.LimitReached
@@ -105,10 +105,10 @@ class Corla(val N: Int, val riskLimit: Double, val reportedMargin: Double, val n
         n: Int, // n is the sample size, not N total ballots
         dilutedMargin: Double, // V is the smallest reported margin = min_c { min w∈Wc ∈Lc (V_wl) } over contests c
         gamma: Double,  // use 1.01 or 1.10 ??
-        n1: Int, // oneOver
-        n2: Int, // twoOver
-        n3: Int = 0, // oneUnder
-        n4: Int = 0, // twoUnder
+        p2o: Int, // twoOver
+        p1o: Int, // oneOver
+        p1u: Int = 0, // oneUnder
+        p2u: Int = 0, // twoUnder
     ): Double {
 
         // Contest c appears on Nc of the N cast ballots
@@ -125,16 +125,16 @@ class Corla(val N: Int, val riskLimit: Double, val reportedMargin: Double, val n
         val termn = pow(term, n.toDouble())
 
         val term1 = (1.0 - 1.0/(2 * gamma))
-        val term1n = pow(term1, -n1.toDouble())
+        val term1n = pow(term1, -p1o.toDouble())
 
         val term2 = (1.0 - 1.0/gamma)
-        val term2n = pow(term2, -n2.toDouble())
+        val term2n = pow(term2, -p2o.toDouble())
 
         val term3 = (1.0 + 1.0/(2 * gamma))
-        val term3n = pow(term3, -n3.toDouble())
+        val term3n = pow(term3, -p1u.toDouble())
 
         val term4 = (1.0 + 1.0/gamma)
-        val term4n = pow(term4, -n4.toDouble())
+        val term4n = pow(term4, -p2u.toDouble())
 
         val result = termn * term1n * term2n * term3n * term4n
         return min(1.0, result)

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestCorla.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestCorla.kt
@@ -79,10 +79,10 @@ class TestCorla {
                             a = compareAssorter.noerror,
                             d1 = d1,
                             d2 = d1,
-                            p1 = p1prior,
-                            p2 = p2prior,
-                            p3 = 0.0,
-                            p4 = 0.0,
+                            p2o = p2prior,
+                            p1o = p1prior,
+                            p1u = 0.0,
+                            p2u = 0.0,
                             eps=eps,
                         )
                         val betting =

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sim/BettingTask.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/sim/BettingTask.kt
@@ -31,10 +31,10 @@ data class BettingTask(
             a = compareAssorter.noerror,
             d1 = 0,
             d2 = d2,
-            p1 = 0.0,
-            p2 = p2prior,
-            p3 = 0.0,
-            p4 = 0.0,
+            p2o = p2prior,
+            p1o = 0.0,
+            p1u = 0.0,
+            p2u = 0.0,
         )
         return BettingMart(
             bettingFn = adaptive, Nc = N, noerror = compareAssorter.noerror,


### PR DESCRIPTION
Canonicalize error rate names and parameter ordering.