### PR TITLE
Support for rlauxe viewer.

### DIFF
--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -32,19 +32,3 @@ tasks.test {
 kotlin {
     jvmToolchain(21)
 }
-
-tasks.register<Jar>("uberJar") {
-    archiveClassifier = "uber"
-    duplicatesStrategy = DuplicatesStrategy.EXCLUDE
-
-    manifest {
-        attributes("Main-Class" to "org.cryptobiotic.eg.cli.RunShowSystem")
-    }
-
-    from(sourceSets.main.get().output)
-
-    dependsOn(configurations.runtimeClasspath)
-    from({
-        configurations.runtimeClasspath.get().filter { it.name.endsWith("jar") }.map { zipTree(it) }
-    })
-}

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Assorter.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Assorter.kt
@@ -214,18 +214,31 @@ data class ClcaAssorter(
 }
 
 ///////////////////////////////////////////////////////////////////
+data class EstimationRoundResult(
+    val roundIdx: Int,
+    val strategy: String,
+    val fuzzPct: Double,
+    val startingTestStatistic: Double,
+    val startingRates: ClcaErrorRates? = null, // aprioti error rates (clca only)
+    val sampleDeciles: List<Int>,   // distribution of estimated sample size as deciles
+) {
+    override fun toString() = "round=$roundIdx sampleDeciles=$sampleDeciles fuzzPct=$fuzzPct " +
+            " startingRates=$startingRates"
+}
 
 data class AuditRoundResult(
     val roundIdx: Int,
     val estSampleSize: Int,   // estimated sample size
-    val maxBallotsUsed: Int,  // maximum ballot index (for multicontest audits)
+    val maxBallotIndexUsed: Int,  // maximum ballot index (for multicontest audits)
     val pvalue: Double,       // last pvalue when testH0 terminates
     val samplesNeeded: Int,   // first sample when pvalue < riskLimit
     val samplesUsed: Int,     // sample count when testH0 terminates
     val status: TestH0Status, // testH0 status
-    val errorRates: ClcaErrorRates? = null, // measured error rates (clca only)
+    val measuredMean: Double, // measured population mean
+    val startingRates: ClcaErrorRates? = null, // aprioti error rates (clca only)
+    val measuredRates: ClcaErrorRates? = null, // measured error rates (clca only)
 ) {
-    override fun toString() = "round=$roundIdx estSampleSize=$estSampleSize maxBallotsUsed=$maxBallotsUsed " +
+    override fun toString() = "round=$roundIdx estSampleSize=$estSampleSize maxBallotIndexUsed=$maxBallotIndexUsed " +
             " pvalue=$pvalue samplesNeeded=$samplesNeeded samplesUsed=$samplesUsed status=$status"
 }
 
@@ -238,6 +251,7 @@ open class Assertion(
 
     // these values are set during estimateSampleSizes()
     var estSampleSize = 0   // estimated sample size for current round
+    val estRoundResults = mutableListOf<EstimationRoundResult>()
 
     // these values are set during runAudit()
     val roundResults = mutableListOf<AuditRoundResult>()

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ClcaErrorRates.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ClcaErrorRates.kt
@@ -14,6 +14,9 @@ data class ClcaErrorRates(val p2o: Double, val p1o: Double, val p1u: Double, val
     }
     fun toList() = listOf(p2o, p1o, p1u, p2u)
     fun areZero() = (p2o == 0.0 && p1o == 0.0 && p1u == 0.0 && p2u == 0.0)
+    fun add(other: ClcaErrorRates): ClcaErrorRates {
+        return ClcaErrorRates(p2o + other.p2o, p1o + other.p1o, p1u + other.p1u, p2u + other.p2u)
+    }
 
     companion object {
         fun fromList(list: List<Double>): ClcaErrorRates {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/RiskTestingFn.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/RiskTestingFn.kt
@@ -11,8 +11,8 @@ enum class TestH0Status(val rank: Int, val complete: Boolean, val success: Boole
     FailMaxSamplesAllowed(4,true, false),  // estimated samples greater than maximum samples allowed
 
     // possible returns from RiskTestingFn
-    StatRejectNull(10,true, true), // statistical rejection of H0
-    LimitReached(11,false, false),  // cant tell from the number of samples available
+    LimitReached(10,false, false),  // cant tell from the number of samples available
+    StatRejectNull(11,true, true), // statistical rejection of H0
     //// only when sampling without replacement all the way close to Nc
     SampleSumRejectNull(12,true, false), // SampleSum > Nc / 2, so we know H0 is false
     AcceptNull(13,true, false), // SampleSum + (all remaining ballots == 1) < Nc / 2, so we know that H0 is true.

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ConsistentSampling.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ConsistentSampling.kt
@@ -5,16 +5,17 @@ import org.cryptobiotic.rlauxe.util.roundToInt
 import org.cryptobiotic.rlauxe.workflow.BallotOrCvr
 import org.cryptobiotic.rlauxe.workflow.RlauxWorkflowIF
 
-private val debug = true
+private val debug = false
 
-/** must have sampleSizes set. must have sampleNums assigned */
+/** must have contest.estSampleSize set. must have borc.sampleNumber assigned. */
 fun sample(workflow: RlauxWorkflowIF, roundIdx: Int, quiet: Boolean): List<Int> {
     val auditConfig = workflow.auditConfig()
     val borc = workflow.getBallotsOrCvrs()
 
     // count the number of cvrs that have at least one contest under audit.
+    // TODO this is wrong for samplePctCutoff, except maybe the first round ??
     val N = if (!auditConfig.hasStyles) borc.size
-                else workflow.getBallotsOrCvrs().filter { it.hasOneOrMoreContest(workflow.getContests()) }.count()
+                  else borc.filter { it.hasOneOrMoreContest(workflow.getContests()) }.count()
 
     var sampleIndices: List<Int> = emptyList()
     val contestsNotDone = workflow.getContests().filter { !it.done }.toMutableList()
@@ -22,7 +23,7 @@ fun sample(workflow: RlauxWorkflowIF, roundIdx: Int, quiet: Boolean): List<Int> 
     while (contestsNotDone.isNotEmpty()) {
         sampleIndices = createSampleIndices(workflow, roundIdx, quiet)
         val pct = sampleIndices.size / N.toDouble()
-        if (debug) println(" createSampleIndices size = ${sampleIndices.size}, pct= $pct max=${auditConfig.samplePctCutoff}")
+        if (debug) println(" createSampleIndices size = ${sampleIndices.size} N=$N pct= $pct max=${auditConfig.samplePctCutoff}")
         if (pct <= auditConfig.samplePctCutoff) {
             break
         }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/RunRepeated.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/RunRepeated.kt
@@ -70,17 +70,16 @@ data class RunTestRepeatedResult(
     val nsuccess: Int,           // number of successful trials
     val ntrials: Int,            // total number of trials
     val variance: Double,        // variance over ntrials of samples needed
-    val percentHist: Deciles? = null, // histogram of successful sample size as percentage of N, count trials in 10% bins
+    val percentHist: Deciles? = null, // TODO remove
     val status: Map<TestH0Status, Int>? = null, // count of the trial status
     val sampleCount: List<Int> = emptyList(),
-    val margin: Double?,
+    val margin: Double?, // TODO needed?
 ) {
 
     fun successPct(): Double = 100.0 * nsuccess / (if (ntrials == 0) 1 else ntrials)
     fun failPct(): Double  = if (nsuccess == 0) 100.0 else 100.0 * (ntrials - nsuccess) / (if (ntrials == 0) 1 else ntrials)
     fun avgSamplesNeeded(): Int  = totalSamplesNeeded / (if (nsuccess == 0) 1 else nsuccess)
     fun pctSamplesNeeded(): Double  = 100.0 * avgSamplesNeeded().toDouble() / (if (Nc == 0) 1 else Nc)
-    // fun errorRates() = buildString { errorRate.forEach{ append("${df(it)},") } }
 
     override fun toString() = buildString {
         appendLine("RunTestRepeatedResult: testParameters=$testParameters Nc=$Nc successPct=${successPct()} in ntrials=$ntrials")

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Utils.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Utils.kt
@@ -1,6 +1,7 @@
 package org.cryptobiotic.rlauxe.util
 
 import java.security.SecureRandom
+import kotlin.enums.EnumEntries
 import kotlin.math.abs
 import kotlin.math.ceil
 import kotlin.math.min
@@ -88,25 +89,16 @@ fun showDeciles(data: List<Int>) = buildString {
     appendLine("]")
 }
 
-/**
- * Normally, Kotlin's `Enum.valueOf` or [enumValueOf] method will throw an exception for an invalid
- * input. This method will instead return `null` if the string doesn't map to a valid value of the enum.
- */
-inline fun <reified T : Enum<T>> safeEnumValueOf(name: String?): T? {
-    if (name == null) {
-        return null
-    }
-
-    return try {
-        enumValueOf<T>(name)
-    } catch (e: IllegalArgumentException) {
-        null
-    }
-}
-
 fun MutableMap<Int, Int>.mergeReduce(others: List<Map<Int, Int>>) =
     others.forEach { other -> other.forEach { merge(it.key, it.value) { a, b -> a + b } } }
 
 fun MutableMap<String, Int>.mergeReduceS(others: List<Map<String, Int>>) =
     others.forEach { other -> other.forEach { merge(it.key, it.value) { a, b -> a + b } } }
+
+fun <T : Enum<T>> enumValueOf(name: String, entries: EnumEntries<T>): T? {
+    for (status in entries) {
+        if (status.name.lowercase() == name.lowercase()) return status
+    }
+    return null
+}
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditConfig.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditConfig.kt
@@ -32,6 +32,13 @@ data class AuditConfig(
             AuditType.ONEAUDIT -> appendLine("  $oaConfig, ")
         }
     }
+    fun strategy() : String {
+        return when (auditType) {
+            AuditType.POLLING -> "polling"
+            AuditType.CLCA -> clcaConfig.strategy.toString()
+            AuditType.ONEAUDIT -> "oneaudit"
+        }
+    }
 }
 
 data class PollingConfig(
@@ -44,11 +51,11 @@ data class PollingConfig(
 // fuzzPct: model errors with fuzz simulation, with adaptation
 // apriori: pass in apriori errorRates, with adaptation
 // phantoms: use phantom rates for apriori
-enum class ClcaStrategyType { oracle, noerror, fuzzPct, apriori, phantoms }
+enum class ClcaStrategyType { oracle, noerror, fuzzPct, apriori, phantoms, previous }
 data class ClcaConfig(
     val strategy: ClcaStrategyType,
     val simFuzzPct: Double? = null, // use to generate apriori errorRates for simulation
-    val errorRates: ClcaErrorRates? = null, // use as apriori
+    val errorRates: ClcaErrorRates? = null, // use as apriori errorRates for simulation and audit
     val d: Int = 100,  // shrinkTrunc weight for error rates
 )
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAuditWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAuditWorkflow.kt
@@ -135,12 +135,12 @@ fun runOneAuditAssertionAlpha(
 
     val roundResult = AuditRoundResult(roundIdx,
         estSampleSize=cassertion.estSampleSize,
-        maxBallotsUsed = sampler.maxSamplesUsed(),
+        maxBallotIndexUsed = sampler.maxSampleIndexUsed(),
         pvalue = testH0Result.pvalueLast,
         samplesNeeded = testH0Result.sampleFirstUnderLimit, // one based
         samplesUsed = testH0Result.sampleCount,
         status = testH0Result.status,
-        errorRates = testH0Result.tracker.errorRates()
+        measuredMean = testH0Result.tracker.mean(),
     )
     cassertion.roundResults.add(roundResult)
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistentWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistentWorkflow.kt
@@ -66,7 +66,7 @@ fun RlauxWorkflowIF.showResults(estSampleSize: Int) {
     this.getContests().forEach { contest ->
         contest.assertions().filter { it.roundResults.isNotEmpty() }.forEach { assertion ->
             val lastRound = assertion.roundResults.last()
-            maxBallotsUsed = max(maxBallotsUsed, lastRound.maxBallotsUsed)
+            maxBallotsUsed = max(maxBallotsUsed, lastRound.maxBallotIndexUsed)
         }
     }
     println("$estSampleSize - $maxBallotsUsed = extra ballots = ${estSampleSize - maxBallotsUsed}\n")

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingWorkflow.kt
@@ -120,17 +120,16 @@ fun auditPollingAssertion(
         upperBound = assorter.upperBound(),
     )
 
-    // do not terminate on null reject, continue to use all available samples
     val testH0Result = testFn.testH0(sampler.maxSamples(), terminateOnNullReject=true) { sampler.sample() }
 
     val roundResult = AuditRoundResult(roundIdx,
         estSampleSize=assertion.estSampleSize,
-        maxBallotsUsed = sampler.maxSamplesUsed(),
+        maxBallotIndexUsed = sampler.maxSampleIndexUsed(),
         pvalue = testH0Result.pvalueLast,
         samplesNeeded = testH0Result.sampleFirstUnderLimit, // one based
         samplesUsed = testH0Result.sampleCount,
         status = testH0Result.status,
-        errorRates = testH0Result.tracker.errorRates()
+        measuredMean = testH0Result.tracker.mean(),
     )
     assertion.roundResults.add(roundResult)
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/Sampler.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/Sampler.kt
@@ -46,14 +46,13 @@ class PollWithoutReplacement(
     }
 
     override fun maxSamples() = maxSamples
-    fun maxSamplesUsed() = count
+    fun maxSampleIndexUsed() = idx
 
     override fun hasNext() = (count < maxSamples)
     override fun next() = sample()
 }
 
 //// For clca audits
-// the values produced here are the B assort values, SHANGRLA section 3.2.
 class ClcaWithoutReplacement(
     val contestUA: ContestIF,
     val cvrPairs: List<Pair<Cvr, Cvr>>, // (mvr, cvr)
@@ -92,7 +91,7 @@ class ClcaWithoutReplacement(
     }
 
     override fun maxSamples() = maxSamples
-    fun maxSamplesUsed() = count
+    fun maxSampleIndexUsed() = idx
 
     override fun hasNext() = (count < maxSamples)
     override fun next() = sample()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMultiContestTestData.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMultiContestTestData.kt
@@ -95,7 +95,7 @@ class TestMultiContestTestData {
             val phantomPct = nphantom/ Nc.toDouble()
             println("  nphantom=$nphantom pct= $phantomPct =~ ${fcontest.phantomPct} abs=${abs(phantomPct - fcontest.phantomPct)} " +
                     " rel=${abs(phantomPct - fcontest.phantomPct)/phantomPct}")
-            if (nphantom > 5) assertEquals(fcontest.phantomPct, phantomPct, .001)
+            if (nphantom > 5) assertEquals(fcontest.phantomPct, phantomPct, 3.0/Nc)
 
             val nunder = testCvrs.count { it.hasContest(contest.id) && !it.phantom && it.votes[contest.id]!!.isEmpty() }
             assertEquals(fcontest.underCount, nunder)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestUtils.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestUtils.kt
@@ -1,8 +1,11 @@
 package org.cryptobiotic.rlauxe.util
 
+import org.cryptobiotic.rlauxe.core.TestH0Status
+import org.junit.jupiter.api.assertThrows
 import kotlin.math.abs
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class TestUtils {
 
@@ -26,6 +29,17 @@ class TestUtils {
         assertEquals("1234567890", sfn("1234567890", 5))
         assertEquals("1234567890", sfn("1234567890", -5))
         assertEquals("1234567890     ", sfn("1234567890", -15))
+    }
+
+    @Test
+    fun testEnums() {
+        assertEquals(TestH0Status.LimitReached, enumValueOf("LimitReached"))
+        assertEquals(TestH0Status.LimitReached, enumValueOf("LimitReacHED", TestH0Status.entries))
+
+        assertNull(enumValueOf("bad", TestH0Status.entries))
+        assertThrows<IllegalArgumentException> {
+            assertEquals(TestH0Status.InProgress, enumValueOf("bad"))
+        }
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12.1-bin.zip
 kotest.framework.classpath.scanning.autoscan.disable=true
 kotest.framework.parallelism=48
 networkTimeout=10000

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaWorkflow.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaWorkflow.kt
@@ -167,12 +167,13 @@ fun runCorlaAudit(
 
     val roundResult = AuditRoundResult(roundIdx,
         estSampleSize=cassertion.estSampleSize,
-        maxBallotsUsed = sampler.maxSamplesUsed(),
+        maxBallotIndexUsed = sampler.maxSampleIndexUsed(),
         pvalue = testH0Result.pvalueLast,
         samplesNeeded = testH0Result.sampleFirstUnderLimit, // one based
         samplesUsed = testH0Result.sampleCount,
         status = testH0Result.status,
-        errorRates = testH0Result.tracker.errorRates()
+        measuredMean = testH0Result.tracker.mean(),
+        measuredRates = testH0Result.tracker.errorRates(),
     )
     cassertion.roundResults.add(roundResult)
 

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/GenPollingNoStylesOrg.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/GenPollingNoStylesOrg.kt
@@ -34,6 +34,7 @@ class GenPollingNoStylesOrg {
                 val moreParameters = mapOf("N" to N.toDouble(), "reportedMargin" to margin)
 
                 val task = SimulateSampleSizeTask(
+                    1,
                     auditConfig,
                     contestUA,
                     assertion,

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/rlaplots/WorkflowResultsIO.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/rlaplots/WorkflowResultsIO.kt
@@ -75,7 +75,7 @@ class WorkflowResultsIO(val filename: String) {
         val stddev = if (tokens.size > 9) ttokens[idx++].toDouble() else 0.0
         val mvrMargin = if (tokens.size > 10) ttokens[idx++].toDouble() else 0.0
 
-        val status = safeEnumValueOf(statusS) ?: TestH0Status.InProgress
+        val status = enumValueOf(statusS, TestH0Status.entries) ?: TestH0Status.InProgress
         return WorkflowResult(N, margin, status, nrounds, samplesUsed, samplesNeeded, nmvrs, readParameters(parameters), failPct, stddev, mvrMargin)
     }
 

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/strategy/GenVsMarginByStrategy2.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/strategy/GenVsMarginByStrategy2.kt
@@ -7,13 +7,13 @@ import org.cryptobiotic.rlauxe.workflow.*
 import kotlin.test.Test
 
 class GenVsMarginByStrategy2 {
-    var name = "clcaVsMarginByStrategy0"
-    val dirName = "/home/stormy/temp/strategy2"
+    var name = "clcaVsMarginByStrategy1"
+    val dirName = "/home/stormy/temp/strategy3"
 
     val N = 50000
-    val nruns = 100  // number of times to run workflow
+    val nruns = 10  // number of times to run workflow
     val fuzzPct = .01
-    var phantomPct = .00
+    var phantomPct = .01
 
     @Test
     fun genSamplesVsMarginByStrategy() {
@@ -21,7 +21,7 @@ class GenVsMarginByStrategy2 {
         val margins = allMargins.filter { it > phantomPct }
         val stopwatch = Stopwatch()
 
-        val config = AuditConfig(AuditType.CLCA, true, nsimEst = 100, minMargin = 0.0, samplePctCutoff = 1.0)
+        val config = AuditConfig(AuditType.CLCA, true, nsimEst = 10, minMargin = 0.0, samplePctCutoff = 1.0)
 
         val tasks = mutableListOf<RepeatedWorkflowRunner>()
         margins.forEach { margin ->
@@ -42,6 +42,11 @@ class GenVsMarginByStrategy2 {
                 auditConfig = config.copy(clcaConfig = ClcaConfig(ClcaStrategyType.fuzzPct, fuzzPct))
             )
             tasks.add(RepeatedWorkflowRunner(nruns, clcaGenerator3))
+
+            val clcaGenerator4 = ClcaWorkflowTaskGenerator(N, margin, 0.0, phantomPct, fuzzPct,
+                parameters= mapOf("nruns" to nruns, "cat" to "previous", "fuzzPct" to fuzzPct),
+                auditConfig = config.copy(clcaConfig = ClcaConfig(ClcaStrategyType.previous)))
+            tasks.add(RepeatedWorkflowRunner(nruns, clcaGenerator4))
 
             val clcaGenerator5 = ClcaWorkflowTaskGenerator(N, margin, 0.0, phantomPct, fuzzPct,
                 parameters= mapOf("nruns" to nruns, "cat" to "phantoms", "fuzzPct" to fuzzPct),

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestClcaFuzzSampler.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestClcaFuzzSampler.kt
@@ -70,6 +70,7 @@ fun runWithComparisonFuzzSampler(
     )
 
     return simulateSampleSizeBetaMart(
+        1,
         auditConfig,
         sampler,
         optimal,

--- a/rla/build.gradle.kts
+++ b/rla/build.gradle.kts
@@ -45,7 +45,7 @@ tasks.register<Jar>("uberJar") {
     duplicatesStrategy = DuplicatesStrategy.EXCLUDE
 
     manifest {
-        attributes("Main-Class" to "org.cryptobiotic.eg.cli.RunShowSystem")
+        attributes("Main-Class" to "org.cryptobiotic.rlauxe.cli.verifier.RunVerifier")
     }
 
     from(sourceSets.main.get().output)

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaStartTest.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaStartTest.kt
@@ -80,7 +80,9 @@ object RunRlaStartTest {
     ): Int {
         println("Start startTestElectionClca")
         val publish = Publisher(topdir)
-        val auditConfig = AuditConfig(AuditType.CLCA, hasStyles = true, nsimEst = 10, samplePctCutoff=.42, minMargin=.005, removeTooManyPhantoms=true)
+        val auditConfig = AuditConfig(AuditType.CLCA, hasStyles = true, nsimEst = 10, samplePctCutoff=.42, minMargin=.005,
+            removeTooManyPhantoms=true, clcaConfig = ClcaConfig(strategy = ClcaStrategyType.previous)
+        )
         writeAuditConfigJsonFile(auditConfig, publish.auditConfigFile())
 
         val maxMargin = .05
@@ -142,7 +144,7 @@ object RunRlaStartTest {
         mvrFile: String,
     ): Int {
         val publish = Publisher(topdir)
-        val auditConfig = AuditConfig(AuditType.POLLING, hasStyles = true, nsimEst = 10)
+        val auditConfig = AuditConfig(AuditType.POLLING, hasStyles = true, nsimEst = 10, samplePctCutoff=.42, minMargin=.005, removeTooManyPhantoms=true, )
         writeAuditConfigJsonFile(auditConfig, publish.auditConfigFile())
         println("   writeAuditConfigJsonFile ${publish.auditConfigFile()}")
 

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AuditConfigJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AuditConfigJson.kt
@@ -11,7 +11,7 @@ import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
 import org.cryptobiotic.rlauxe.core.ClcaErrorRates
 import org.cryptobiotic.rlauxe.util.ErrorMessages
-import org.cryptobiotic.rlauxe.util.safeEnumValueOf
+import org.cryptobiotic.rlauxe.util.enumValueOf
 import org.cryptobiotic.rlauxe.workflow.*
 
 import java.io.FileOutputStream
@@ -93,7 +93,7 @@ fun AuditConfig.publishJson() : AuditConfigJson {
 }
 
 fun AuditConfigJson.import(): AuditConfig {
-    val auditType = safeEnumValueOf(this.auditType) ?: AuditType.CLCA
+    val auditType = enumValueOf(this.auditType, AuditType.entries) ?: AuditType.CLCA
     return AuditConfig(
         auditType,
         this.hasStyles,
@@ -160,7 +160,7 @@ fun ClcaConfig.publishJson() : ClcaConfigJson {
 }
 
 fun ClcaConfigJson.import(): ClcaConfig {
-    val strategy = safeEnumValueOf(this.strategy) ?: ClcaStrategyType.noerror
+    val strategy = enumValueOf(this.strategy, ClcaStrategyType.entries) ?: ClcaStrategyType.noerror
     return ClcaConfig(
         strategy,
         this.simFuzzPct,
@@ -191,7 +191,7 @@ fun OneAuditConfig.publishJson() : OneAuditConfigJson {
 }
 
 fun OneAuditConfigJson.import(): OneAuditConfig {
-    val strategy = safeEnumValueOf(this.strategy) ?: OneAuditStrategyType.default
+    val strategy = enumValueOf(this.strategy, OneAuditStrategyType.entries) ?: OneAuditStrategyType.default
     return OneAuditConfig(
         strategy,
         this.simFuzzPct,

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/ContestJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/ContestJson.kt
@@ -1,22 +1,11 @@
 @file:OptIn(ExperimentalSerializationApi::class)
 package org.cryptobiotic.rlauxe.persist.json
 
-import com.github.michaelbull.result.Err
-import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.Result
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.decodeFromStream
-import kotlinx.serialization.json.encodeToStream
 import org.cryptobiotic.rlauxe.core.*
-import org.cryptobiotic.rlauxe.util.ErrorMessages
-import org.cryptobiotic.rlauxe.util.safeEnumValueOf
+import org.cryptobiotic.rlauxe.util.enumValueOf
 
-import java.io.FileOutputStream
-import java.nio.file.Files
-import java.nio.file.Path
-import java.nio.file.StandardOpenOption
 
 // data class ContestInfo(
 //    val name: String,
@@ -48,7 +37,7 @@ fun ContestInfo.publishJson() : ContestInfoJson {
 }
 
 fun ContestInfoJson.import(): ContestInfo {
-    val choiceFunction = safeEnumValueOf(this.choiceFunction) ?: SocialChoiceFunction.PLURALITY
+    val choiceFunction = enumValueOf(this.choiceFunction, SocialChoiceFunction.entries) ?: SocialChoiceFunction.PLURALITY
     return ContestInfo(
         this.name,
         this.id,

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/CvrsJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/CvrsJson.kt
@@ -9,12 +9,9 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.decodeFromStream
 import kotlinx.serialization.json.encodeToStream
-import org.cryptobiotic.rlauxe.core.ContestInfo
 import org.cryptobiotic.rlauxe.core.Cvr
 import org.cryptobiotic.rlauxe.core.CvrUnderAudit
-import org.cryptobiotic.rlauxe.core.SocialChoiceFunction
 import org.cryptobiotic.rlauxe.util.ErrorMessages
-import org.cryptobiotic.rlauxe.util.safeEnumValueOf
 
 import java.io.FileOutputStream
 import java.nio.file.Files

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/verifier/ShowPersistantStateResults.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/verifier/ShowPersistantStateResults.kt
@@ -82,13 +82,12 @@ class ShowPersistantStateResults(val publish: Publisher, val show: Boolean = fal
             result = false
         }
 
-        val indices = readSampleIndicesJsonFile(publish.sampleIndicesFile(roundIdx)).unwrap()
-        if (indices.size != state.nmvrs) {
-            println("  *** nmvrs = ${state.nmvrs} should be = ${indices.size} ")
-            result = false
-        }
-
         if (state.auditWasDone) {
+            val indices = readSampleIndicesJsonFile(publish.sampleIndicesFile(roundIdx)).unwrap()
+            if (indices.size != state.nmvrs) {
+                println("  *** nmvrs = ${state.nmvrs} should be = ${indices.size} ")
+                result = false
+            }
             val mvrs = readCvrsJsonFile(publish.sampleMvrsFile(roundIdx)).unwrap()
             if (indices.size != mvrs.size) {
                 println("*** indices = ${indices.size} NOT EQUAL mvrs = ${mvrs.size}")

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunCli.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunCli.kt
@@ -17,7 +17,7 @@ class TestRunCli {
                 "-pctPhantoms", "0.001",
                 "-mvrs", mvrs,
                 "-ncards", "5000",
-                "-ncontests", "5",
+                "-ncontests", "15",
             )
         )
 
@@ -31,7 +31,8 @@ class TestRunCli {
 
     @Test
     fun testCliRoundPolling() {
-        val topdir = kotlin.io.path.createTempDirectory().toString()
+        val topdir = "/home/stormy/temp/persist/testRunCli2"
+        // val topdir = kotlin.io.path.createTempDirectory().toString()
         val mvrs =  "$topdir/testMvrs.json"
         RunRlaStartTest.main(
             arrayOf(
@@ -39,6 +40,7 @@ class TestRunCli {
                 "-isPolling",
                 "-fuzzMvrs", ".0123",
                 "-mvrs", mvrs,
+                "-ncards", "20000",
             )
         )
 

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestCorlaEstimateSampleSize.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestCorlaEstimateSampleSize.kt
@@ -58,7 +58,7 @@ class TestCorlaEstimateSampleSize {
             val cn = contestUA.Nc
             val estSizes = mutableListOf<Int>()
             val sampleSizes = contestUA.clcaAssertions.map { assert ->
-                val result = simulateSampleSizeClcaAssorter(auditConfig, contestUA.contest as Contest, assert, cvrs)
+                val result = simulateSampleSizeClcaAssorter(1, auditConfig, contestUA.contest as Contest, assert, cvrs)
                 val simSize = result.findQuantile(auditConfig.quantile)
                 val estSize = estimateSampleSizeSimple(auditConfig.riskLimit, assert.assorter.reportedMargin(), gamma,
                     oneOver = roundUp(cn*p1), // p1


### PR DESCRIPTION
Add EstimationRoundResult to Assertion.
Add measuredMean, measuredRates, maxBallotIndexUsed to AuditRoundResult. 
Add ClcaStrategyType.previous.
Redo simulateSampleSizeClcaAssorter strategies.
Build rla uber jar.
Redo enumValueOf() for Java.
ExtraVsMarginByStrategy plots