### PR TITLE
Add index field to BallotOrCvr.

### DIFF
--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
@@ -2,10 +2,10 @@ package org.cryptobiotic.rlauxe.core
 
 import org.cryptobiotic.rlauxe.workflow.BallotOrCvr
 
-// immutable, TODO except for the IntArray!
+// TODO immutable except for the IntArray (!)
 data class Cvr(
     val id: String,
-    val votes: Map<Int, IntArray>, // contest : list of candidates voted for; for IRV, ranked hi to lo
+    val votes: Map<Int, IntArray>, // contest : list of candidates voted for; for IRV, ranked first to last
     val phantom: Boolean = false,
 ) {
     fun hasContest(contestId: Int): Boolean = votes[contestId] != null
@@ -33,6 +33,7 @@ data class Cvr(
         votes.forEach { (key, value) -> append(" $key: ${value.contentToString()}")}
     }
 
+    //// overriding because of IntArray ??
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
@@ -60,24 +61,18 @@ data class Cvr(
     }
 }
 
-/** Mutable version of Cvr. */
-data class CvrUnderAudit (val cvr: Cvr, val sampleNum: Long): BallotOrCvr {
-    var sampled = false // is this CVR in the sample TODO needed?
-
+/** Cvr that has been assigned a sampleNum. */
+data class CvrUnderAudit (val cvr: Cvr, val index: Int, val sampleNum: Long): BallotOrCvr {
     val id = cvr.id
     val votes = cvr.votes
     val phantom = cvr.phantom
 
     override fun hasContest(contestId: Int) = cvr.hasContest(contestId)
     override fun sampleNumber() = sampleNum
-    override fun isSampled() = sampled
-    override fun setIsSampled(isSampled: Boolean): CvrUnderAudit {
-        this.sampled = isSampled
-        return this
-    }
+    override fun index() = index
 
     override fun toString() = buildString {
-        append("$id ($phantom)")
+        append("$id $index ($phantom)")
         votes.forEach { (key, value) -> append(" $key: ${value.contentToString()}")}
     }
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditConfig.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditConfig.kt
@@ -9,7 +9,7 @@ data class AuditConfig(
     val auditType: AuditType,
     val hasStyles: Boolean,
     val riskLimit: Double = 0.05,
-    val seed: Long = secureRandom.nextLong(), // determines smaple order. set carefully to ensure truly random.
+    val seed: Long = secureRandom.nextLong(), // determines sample order. set carefully to ensure truly random.
 
     // simulation control
     val nsimEst: Int = 100, // number of simulation estimations
@@ -62,7 +62,7 @@ data class ClcaConfig(
 
 enum class OneAuditStrategyType { default, max99 }
 data class OneAuditConfig(
-    val strategy: OneAuditStrategyType,
+    val strategy: OneAuditStrategyType = OneAuditStrategyType.default,
     val simFuzzPct: Double? = null, // for the estimation
     val d: Int = 100,  // shrinkTrunc weight
 )

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/BallotManifest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/BallotManifest.kt
@@ -1,7 +1,5 @@
 package org.cryptobiotic.rlauxe.workflow
 
-import org.cryptobiotic.rlauxe.core.ContestUnderAudit
-
 // The id must uniquely identify the paper ballot. Here it may be some simple thing (seq number) that points to
 // the paper ballot location. Its necessary that the system publically commit to that mapping before the Audit,
 // as well as to sampleNum.
@@ -37,8 +35,7 @@ data class BallotManifestUnderAudit(
 interface BallotOrCvr {
     fun hasContest(contestId: Int): Boolean
     fun sampleNumber(): Long
-    fun isSampled(): Boolean
-    fun setIsSampled(isSampled: Boolean): BallotOrCvr
+    fun index(): Int
 
     fun hasOneOrMoreContest(contests: List<ContestRound>): Boolean {
         for (contest in contests) {
@@ -61,18 +58,13 @@ data class Ballot(
     }
 }
 
-data class BallotUnderAudit (val ballot: Ballot, val sampleNum: Long) : BallotOrCvr {
-    var sampled = false //  # is this in the sample?
+data class BallotUnderAudit (val ballot: Ballot, val index: Int, val sampleNum: Long) : BallotOrCvr {
     val id = ballot.id
     val phantom = ballot.phantom
 
     override fun hasContest(contestId: Int) = ballot.hasContest(contestId)
     override fun sampleNumber() = sampleNum
-    override fun setIsSampled(isSampled: Boolean): BallotUnderAudit {
-        this.sampled = isSampled
-        return this
-    }
-    override fun isSampled() = sampled
+    override fun index() = index
 }
 
 // The term ballot style generally refers to the set of contests on a given voter’s ballot. (Ballot

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaWorkflow.kt
@@ -11,9 +11,9 @@ class ClcaWorkflow(
     contestsToAudit: List<Contest>, // the contests you want to audit
     raireContests: List<RaireContestUnderAudit>, // TODO or call raire from here ??
     val cvrs: List<Cvr>, // includes undervotes and phantoms.
-): RlauxWorkflowClca {
+): RlauxWorkflowIF {
     private val contestsUA: List<ContestUnderAudit>
-    val cvrsUA: List<CvrUnderAudit>
+    private val cvrsUA: List<CvrUnderAudit>
     private val auditRounds = mutableListOf<AuditRound>()
 
     init {
@@ -30,8 +30,9 @@ class ClcaWorkflow(
         check(auditConfig, contests)
         // TODO filter out contests that are done... */
 
+        // the order of the cvrs cannot be changed.
         val prng = Prng(auditConfig.seed)
-        cvrsUA = cvrs.map { CvrUnderAudit(it, prng.next()) }
+        cvrsUA = cvrs.mapIndexed { idx, it -> CvrUnderAudit(it, idx, prng.next()) }.sortedBy { it.sampleNumber() }
     }
 
     //  return allDone
@@ -44,8 +45,7 @@ class ClcaWorkflow(
     override fun auditRounds() = auditRounds
     override fun contestUA(): List<ContestUnderAudit> = contestsUA
     override fun cvrs() = cvrs
-    override fun cvrsUA() = cvrsUA
-    override fun getBallotsOrCvrs() : List<BallotOrCvr> = cvrsUA
+    override fun sortedBallotsOrCvrs() : List<BallotOrCvr> = cvrsUA // sorted by sampleNum
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAuditWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAuditWorkflow.kt
@@ -11,7 +11,7 @@ class OneAuditWorkflow(
     val auditConfig: AuditConfig,
     contestsToAudit: List<OneAuditContest>, // the contests you want to audit
     val cvrs: List<Cvr>, // includes undervotes and phantoms.
-): RlauxWorkflowClca {
+): RlauxWorkflowIF {
     private val contestsUA: List<ContestUnderAudit>
     private val cvrsUA: List<CvrUnderAudit>
     private val auditRounds = mutableListOf<AuditRound>()
@@ -25,7 +25,7 @@ class OneAuditWorkflow(
 
         // must be done once and for all rounds
         val prng = Prng(auditConfig.seed)
-        cvrsUA = cvrs.map { CvrUnderAudit(it, prng.next()) }
+        cvrsUA = cvrs.mapIndexed { idx, it -> CvrUnderAudit(it, idx, prng.next()) }.sortedBy { it.sampleNumber() }
     }
 
     //  return allDone
@@ -38,8 +38,8 @@ class OneAuditWorkflow(
     override fun auditRounds() = auditRounds
     override fun contestUA(): List<ContestUnderAudit> = contestsUA
     override fun cvrs() = cvrs
-    override fun cvrsUA() = cvrsUA
-    override fun getBallotsOrCvrs() : List<BallotOrCvr> = cvrsUA
+    // override fun cvrsUA() = cvrsUA
+    override fun sortedBallotsOrCvrs() : List<BallotOrCvr> = cvrsUA
 }
 
 class OneAuditClcaAssertion(val quiet: Boolean = true) : ClcaAssertionAuditor {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingWorkflow.kt
@@ -12,7 +12,7 @@ class PollingWorkflow(
     val Nb: Int, // total number of ballots/cards TODO same as ballots.size ??
 ): RlauxWorkflowIF {
     private val contestsUA: List<ContestUnderAudit> = contestsToAudit.map { ContestUnderAudit(it, isComparison=false, auditConfig.hasStyles) }
-    val ballotsUA: List<BallotUnderAudit>
+    private val ballotsUA: List<BallotUnderAudit>
     private val auditRounds = mutableListOf<AuditRound>()
 
     init {
@@ -36,7 +36,7 @@ class PollingWorkflow(
 
         // must be done once and for all rounds
         val prng = Prng(auditConfig.seed)
-        ballotsUA = ballotManifest.ballots.map { BallotUnderAudit(it, prng.next()) }
+        ballotsUA = ballotManifest.ballots.mapIndexed { idx, it -> BallotUnderAudit(it, idx, prng.next()) }.sortedBy{ it.sampleNumber() }
     }
 
     override fun runAudit(auditRound: AuditRound, mvrs: List<Cvr>, quiet: Boolean): Boolean  { // return allDone
@@ -47,7 +47,7 @@ class PollingWorkflow(
     override fun auditRounds() = auditRounds
     override fun contestUA(): List<ContestUnderAudit> = contestsUA
     override fun cvrs() = emptyList<Cvr>()
-    override fun getBallotsOrCvrs() : List<BallotOrCvr> = ballotsUA
+    override fun sortedBallotsOrCvrs() : List<BallotOrCvr> = ballotsUA
 }
 
 fun runPollingAudit(

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/RlauxWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/RlauxWorkflow.kt
@@ -2,14 +2,13 @@ package org.cryptobiotic.rlauxe.workflow
 
 import org.cryptobiotic.rlauxe.core.ContestUnderAudit
 import org.cryptobiotic.rlauxe.core.Cvr
-import org.cryptobiotic.rlauxe.core.CvrUnderAudit
 import org.cryptobiotic.rlauxe.estimate.estimateSampleSizes
 import org.cryptobiotic.rlauxe.estimate.sample
 
 // used in ConsistentSampling
 interface RlauxWorkflowProxy {
     fun auditConfig() : AuditConfig
-    fun getBallotsOrCvrs() : List<BallotOrCvr>
+    fun sortedBallotsOrCvrs() : List<BallotOrCvr>
 }
 
 interface RlauxWorkflowIF: RlauxWorkflowProxy {
@@ -44,6 +43,7 @@ interface RlauxWorkflowIF: RlauxWorkflowProxy {
     fun runAudit(auditRound: AuditRound, mvrs: List<Cvr>, quiet: Boolean = true): Boolean  // return allDone
 }
 
+/*
 interface RlauxWorkflowClca: RlauxWorkflowIF {
     fun cvrsUA(): List<CvrUnderAudit>
-}
+} */

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestCvr.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestCvr.kt
@@ -19,8 +19,8 @@ class TestCvr {
 
     @Test
     fun testCvrUnderAudit() {
-        val cvrUA = CvrUnderAudit(makeCvr(1), 12345L)
-        assertEquals("card (false) 0: [1]", cvrUA.toString())
+        val cvrUA = CvrUnderAudit(makeCvr(1), 99, 12345L)
+        assertEquals("card 99 (false) 0: [1]", cvrUA.toString())
         assertEquals(0, cvrUA.cvr.hasMarkFor(0, 0))
         assertEquals(1, cvrUA.cvr.hasMarkFor(0, 1))
     }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
@@ -21,7 +21,7 @@ class TestConsistentSampling {
         contestRounds.forEach { it.estSampleSize = it.Nc / 11 } // random
 
         val prng = Prng(Random.nextLong())
-        val cvrsUAP = test.makeCvrsFromContests().map { CvrUnderAudit( it, prng.next()) }
+        val cvrsUAP = test.makeCvrsFromContests().mapIndexed { idx, it -> CvrUnderAudit( it, idx, prng.next()) }
 
         val auditRound = AuditRound(1, contestRounds, sampledIndices = emptyList())
         val sampleIndices = consistentSampling(auditRound, cvrsUAP)
@@ -41,12 +41,7 @@ class TestConsistentSampling {
         println("contest.name (id) == sampleSize")
         contestRounds.forEach { contest ->
             val cvrs = cvrsUAP.filter { it.hasContest(contest.id) }
-            var count = 0
-            cvrs.forEachIndexed { idx, it ->
-                if (it.sampled) count++
-            }
             assertTrue(contest.estSampleSize <= cvrs.size)
-            assertTrue(contest.estSampleSize <= count)
             // TODO what else can we check ??
         }
     }
@@ -61,7 +56,7 @@ class TestConsistentSampling {
         val ballotManifest = test.makeBallotManifest(true)
 
         val prng = Prng(Random.nextLong())
-        val ballotsUA = ballotManifest.ballots.map { BallotUnderAudit(it, prng.next()) }
+        val ballotsUA = ballotManifest.ballots.mapIndexed { idx, it -> BallotUnderAudit( it, idx, prng.next()) }
 
         val auditRound = AuditRound(1, contestRounds, sampledIndices = emptyList())
         val sampleIndices = consistentSampling(auditRound, ballotsUA)
@@ -79,12 +74,7 @@ class TestConsistentSampling {
             val ballotsForContest = ballotsUA.filter {
                 it.ballot.hasContest(contest.id)
             }
-            var count = 0
-            ballotsUA.forEachIndexed { idx, it ->
-                if (it.sampled) count++
-            }
             assertTrue(contest.estSampleSize <= ballotsForContest.size)
-            assertTrue(contest.estSampleSize <= count)
         }
     }
 
@@ -98,7 +88,7 @@ class TestConsistentSampling {
 
         val ballotManifest = test.makeBallotManifest(false)
         val prng = Prng(Random.nextLong())
-        val ballotsUA = ballotManifest.ballots.map { BallotUnderAudit(it, prng.next()) }
+        val ballotsUA = ballotManifest.ballots.mapIndexed { idx, it -> BallotUnderAudit( it, idx, prng.next()) }
 
         //    contests: List<ContestUnderAudit>,
         //    ballots: List<BallotUnderAudit>, // all the ballots available to sample

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/TestConsistentSamplingFromShangrla.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/TestConsistentSamplingFromShangrla.kt
@@ -36,9 +36,11 @@ class TestConsistentSamplingFromShangrla {
             .build()
 
         val prng = Prng(12345678901L)
-        val cvrsUA = cvrs.mapIndexed { idx, it ->
-            CvrUnderAudit( it, prng.next()) // here we assign sample number deterministically
+        var cvrsUA = cvrs.mapIndexed { idx, it ->
+            CvrUnderAudit( it, idx, prng.next()) // here we assign sample number deterministically
         }
+        cvrsUA = cvrsUA.sortedBy { it.sampleNumber() }
+
         val contestsUA = contestInfos.mapIndexed { idx, it ->
             makeContestUAfromCvrs( it, cvrs)
         }
@@ -90,9 +92,9 @@ class TestConsistentSamplingFromShangrla {
         val phantomCVRs = makePhantomCvrs(contests, ncvrs)
 
         val prng = Prng(123456789012L)
-        val cvrsUAP = (cvrs + phantomCVRs).map { CvrUnderAudit( it, prng.next()) }
+        var cvrsUAP = (cvrs + phantomCVRs).mapIndexed { idx, it -> CvrUnderAudit( it, idx, prng.next()) }
         assertEquals(9, cvrsUAP.size)
-
+        cvrsUAP = cvrsUAP.sortedBy { it.sampleNumber() }
         val auditRound = AuditRound(1, contestRounds, sampledIndices = emptyList())
         val sample_cvr_indices = consistentSampling(auditRound, cvrsUAP)
         assertEquals(6, sample_cvr_indices.size)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestOneAuditWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestOneAuditWorkflow.kt
@@ -75,6 +75,6 @@ class TestOneAuditWorkflow {
 
         val workflow = OneAuditWorkflow(auditConfig, contests, testCvrs)
         val contestRounds = workflow.contestUA().map { ContestRound(it, 1) }
-        runClcaSingleRoundAudit("testOneAuditSingleRoundAudit", workflow, contestRounds, testMvrs, auditor = OneAuditClcaAssertion())
+        runClcaSingleRoundAudit(workflow, contestRounds, testMvrs, auditor = OneAuditClcaAssertion())
     }
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestOneRoundClcaWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestOneRoundClcaWorkflow.kt
@@ -33,7 +33,7 @@ class TestOneRoundClcaWorkflow {
 
         val workflow = ClcaWorkflow(auditConfig, contests, emptyList(), testCvrs)
         val contestRounds = workflow.contestUA().map { ContestRound(it, 1) }
-        runClcaSingleRoundAudit("testOneRoundClcaWorkflow", workflow, contestRounds, testMvrs, auditor = AuditClcaAssertion())
+        runClcaSingleRoundAudit(workflow, contestRounds, testMvrs, auditor = AuditClcaAssertion())
     }
 
 }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/WorkflowTasks.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/WorkflowTasks.kt
@@ -85,7 +85,7 @@ class ClcaWorkflowTaskGenerator(
 
     override fun generateNewTask(): WorkflowTask {
         val useConfig = auditConfig ?:
-            AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst, samplePctCutoff=1.0,
+            AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst,
                 clcaConfig = clcaConfigIn ?: ClcaConfig(ClcaStrategyType.noerror))
 
         val sim = ContestSimulation.make2wayTestContest(Nc=Nc, margin, undervotePct=underVotePct, phantomPct=phantomPct)
@@ -126,7 +126,7 @@ class PollingWorkflowTaskGenerator(
 
     override fun generateNewTask(): ConcurrentTaskG<WorkflowResult> {
         val useConfig = auditConfig ?: AuditConfig(
-            AuditType.POLLING, true, nsimEst = nsimEst,  samplePctCutoff=1.0,
+            AuditType.POLLING, true, nsimEst = nsimEst,
             pollingConfig = PollingConfig(simFuzzPct = mvrsFuzzPct)
         )
 
@@ -170,7 +170,7 @@ class OneAuditWorkflowTaskGenerator(
 
     override fun generateNewTask(): WorkflowTask {
         val auditConfig = auditConfigIn ?: AuditConfig(
-            AuditType.ONEAUDIT, true, nsimEst = nsimEst,  samplePctCutoff=1.0,
+            AuditType.ONEAUDIT, true, nsimEst = nsimEst,
             oaConfig = OneAuditConfig(strategy=OneAuditStrategyType.default, simFuzzPct = mvrsFuzzPct)
         )
 
@@ -203,7 +203,7 @@ class RaireWorkflowTaskGenerator(
 
     override fun generateNewTask(): WorkflowTask {
         val useConfig = auditConfig ?:
-        AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst, samplePctCutoff=1.0,
+        AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst,
             clcaConfig = clcaConfigIn ?: ClcaConfig(ClcaStrategyType.noerror))
 
         val (rcontest, testCvrs) = makeRaireContest(N=Nc, ncands=4, minMargin=margin, undervotePct=underVotePct, phantomPct=phantomPct, quiet = true)

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaWorkflow.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaWorkflow.kt
@@ -25,13 +25,13 @@ class CorlaSingleRoundAuditTaskGenerator(
 
     override fun generateNewTask(): ClcaSingleRoundAuditTask {
         val useConfig = auditConfig ?: AuditConfig(
-            AuditType.CLCA, true, nsimEst = nsimEst, samplePctCutoff = 1.0,
+            AuditType.CLCA, true, nsimEst = nsimEst,
             clcaConfig = clcaConfigIn ?: ClcaConfig(ClcaStrategyType.noerror)
         )
 
         val sim =
             ContestSimulation.make2wayTestContest(Nc = Nc, margin, undervotePct = underVotePct, phantomPct = phantomPct)
-        var testCvrs = sim.makeCvrs() // includes undervotes and phantoms
+        val testCvrs = sim.makeCvrs() // includes undervotes and phantoms
         val testMvrs = if (p2flips != null || p1flips != null) makeFlippedMvrs(testCvrs, Nc, p2flips, p1flips) else
             makeFuzzedCvrsFrom(listOf(sim.contest), testCvrs, mvrsFuzzPct)
 
@@ -102,7 +102,7 @@ class CorlaWorkflow(
         }
 
         val prng = Prng(auditConfig.seed)
-        cvrsUA = cvrs.map { CvrUnderAudit(it, prng.next()) }
+        cvrsUA = cvrs.mapIndexed { idx, it -> CvrUnderAudit(it, idx, prng.next()) }.sortedBy{ it.sampleNumber() }
     }
 
     override fun runAudit(auditRound: AuditRound, mvrs: List<Cvr>, quiet: Boolean): Boolean  {
@@ -114,7 +114,7 @@ class CorlaWorkflow(
     override fun auditRounds() = auditRounds
     override fun contestUA(): List<ContestUnderAudit> = contestsUA
     override fun cvrs() = cvrs
-    override fun getBallotsOrCvrs() : List<BallotOrCvr> = cvrsUA
+    override fun sortedBallotsOrCvrs() : List<BallotOrCvr> = cvrsUA
 }
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/ExtraVsMarginByFuzzDiff.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/ExtraVsMarginByFuzzDiff.kt
@@ -27,7 +27,7 @@ class ExtraVsMarginByFuzzDiff {
         val tasks = mutableListOf<ConcurrentTaskG<List<WorkflowResult>>>()
         fuzzDiffs.forEach { fuzzDiff ->
             val simFuzzPct = fuzzMvrs+fuzzDiff
-            val auditConfig = AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst, samplePctCutoff=1.0, minMargin = 0.0,
+            val auditConfig = AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst,
                 clcaConfig = ClcaConfig(ClcaStrategyType.fuzzPct, simFuzzPct))
 
             margins.forEach { margin ->

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/ExtraVsMarginByStrategy.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/ExtraVsMarginByStrategy.kt
@@ -22,7 +22,7 @@ class ExtraVsMarginByStrategy {
         val margins = listOf(.005, .0075, .01, .015, .02, .03, .04, .05, .06, .07, .08, .09, .10)
         val stopwatch = Stopwatch()
 
-        val config = AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst, samplePctCutoff=1.0, minMargin = 0.0)
+        val config = AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst)
 
         val tasks = mutableListOf<ConcurrentTaskG<List<WorkflowResult>>>()
         margins.forEach { margin ->

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/PlotDistributions.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/PlotDistributions.kt
@@ -2,6 +2,7 @@ package org.cryptobiotic.rlauxe.estimate
 
 import org.cryptobiotic.rlauxe.core.ClcaErrorTable
 import org.cryptobiotic.rlauxe.core.Cvr
+import org.cryptobiotic.rlauxe.core.CvrUnderAudit
 import org.cryptobiotic.rlauxe.rlaplots.genericPlotter
 import org.cryptobiotic.rlauxe.workflow.*
 import kotlin.test.Test
@@ -25,7 +26,6 @@ class PlotDistributions {
         val auditConfig = AuditConfig(
             AuditType.CLCA,
             true,
-            samplePctCutoff = 1.0,
             nsimEst = nsimEst,
             clcaConfig = ClcaConfig(ClcaStrategyType.fuzzPct, simFuzzPct),
         )
@@ -107,7 +107,8 @@ class PlotDistributions {
             val workflow = ClcaWorkflow(auditConfig, listOf(sim.contest), emptyList(), testCvrs)
 
             // heres the ConsistentSample permutation
-            val cvrsUA = workflow.cvrsUA
+            val cvrsUA = workflow.sortedBallotsOrCvrs().map{ it as CvrUnderAudit }
+
             val sortedIndices = cvrsUA.indices.sortedBy { cvrsUA[it].sampleNumber() }
             val sortedCvrs = sortedIndices.map { testCvrs[it] }
             val sortedMvrs = sortedIndices.map { testMvrs[it] }

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/fuzz/PlotClcaFuzz.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/fuzz/PlotClcaFuzz.kt
@@ -22,7 +22,7 @@ class PlotClcaFuzz {
         val margins = listOf(.001, .002, .003, .004, .005, .006, .008, .01, .012, .016, .02, .03, .04, .05, .06, .07, .08, .10)
 
         // do all margins and sample sizes
-        val config = AuditConfig(AuditType.CLCA, true, nsimEst = 100, minMargin = 0.0, samplePctCutoff = 1.0)
+        val config = AuditConfig(AuditType.CLCA, true, nsimEst = 100)
 
         val stopwatch = Stopwatch()
         val tasks = mutableListOf<RepeatedWorkflowRunner>()

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/fuzz/PlotPollingFuzz.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/fuzz/PlotPollingFuzz.kt
@@ -20,7 +20,7 @@ class PlotPollingFuzz {
         val margins =
             listOf(.001, .002, .003, .004, .005, .006, .008, .01, .012, .016, .02, .03, .04, .05, .06, .07, .08, .10)
 
-        val config = AuditConfig(AuditType.POLLING, true, nsimEst = 100, minMargin = 0.0, samplePctCutoff = 1.0)
+        val config = AuditConfig(AuditType.POLLING, true, nsimEst = 100)
 
         val stopwatch = Stopwatch()
         val tasks = mutableListOf<RepeatedWorkflowRunner>()

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/raire/GenRaireNoErrorsPlots.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/raire/GenRaireNoErrorsPlots.kt
@@ -21,7 +21,7 @@ class GenRaireNoErrorsPlots {
         val margins =
             listOf(.005, .006, .008, .01, .012, .016, .02, .03, .04, .05)
 
-        val config = AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst, minMargin = 0.0, samplePctCutoff = 1.0)
+        val config = AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst)
 
         val stopwatch = Stopwatch()
         val tasks = mutableListOf<ConcurrentTaskG<List<WorkflowResult>>>()

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/strategy/GenVsFuzzByStrategy.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/strategy/GenVsFuzzByStrategy.kt
@@ -23,7 +23,7 @@ class GenVsFuzzByStrategy {
 
         val tasks = mutableListOf<RepeatedWorkflowRunner>()
 
-        val config = AuditConfig(AuditType.CLCA, true, nsimEst = 100, minMargin = 0.0, samplePctCutoff = 1.0)
+        val config = AuditConfig(AuditType.CLCA, true, nsimEst = 100)
 
         fuzzPcts.forEach { fuzzPct ->
             val clcaGenerator1 = ClcaWorkflowTaskGenerator(N, margin, 0.0, 0.0, fuzzPct,

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/strategy/GenVsMarginByStrategy.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/strategy/GenVsMarginByStrategy.kt
@@ -22,7 +22,7 @@ class GenVsMarginByStrategy {
 
         val tasks = mutableListOf<RepeatedWorkflowRunner>()
 
-        val config = AuditConfig(AuditType.CLCA, true, nsimEst = 100, minMargin = 0.0, samplePctCutoff = 1.0)
+        val config = AuditConfig(AuditType.CLCA, true, nsimEst = 100)
 
         margins.forEach { margin ->
             val clcaGenerator1 = ClcaWorkflowTaskGenerator(N, margin, 0.0, 0.0, fuzzPct,

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/strategy/GenVsMarginByStrategy2.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/strategy/GenVsMarginByStrategy2.kt
@@ -21,7 +21,7 @@ class GenVsMarginByStrategy2 {
         val margins = allMargins.filter { it > phantomPct }
         val stopwatch = Stopwatch()
 
-        val config = AuditConfig(AuditType.CLCA, true, nsimEst = 10, minMargin = 0.0, samplePctCutoff = 1.0)
+        val config = AuditConfig(AuditType.CLCA, true, nsimEst = 10)
 
         val tasks = mutableListOf<RepeatedWorkflowRunner>()
         margins.forEach { margin ->

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/CompareAuditVariance.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/CompareAuditVariance.kt
@@ -17,7 +17,7 @@ class CompareAuditVariance {
         val margins =
             listOf(.02, .03, .04, .05, .06, .07, .08, .10)
 
-        val pollConfig = AuditConfig(AuditType.POLLING, true, nsimEst = nsimEst, samplePctCutoff = 1.0, minMargin = 0.0)
+        val pollConfig = AuditConfig(AuditType.POLLING, true, nsimEst = nsimEst)
         val stopwatch = Stopwatch()
         val tasks = mutableListOf<ConcurrentTaskG<List<WorkflowResult>>>()
         margins.forEach { margin ->
@@ -56,7 +56,7 @@ class CompareAuditVariance {
         val margins =
             listOf(.006, .008, .01, .012, .016, .02, .03, .04, .05, .06, .07, .08, .10)
 
-        val clcaConfig = AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst, samplePctCutoff = 1.0, minMargin = 0.0,
+        val clcaConfig = AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst,
             clcaConfig =ClcaConfig(ClcaStrategyType.fuzzPct, fuzzPct))
 
         val stopwatch = Stopwatch()

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/CompareAuditsByStyles.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/CompareAuditsByStyles.kt
@@ -24,7 +24,7 @@ class CompareAuditsByStyles {
         val stopwatch = Stopwatch()
         val tasks = mutableListOf<ConcurrentTaskG<List<WorkflowResult>>>()
         margins.forEach { margin ->
-            val pollingConfigNS = AuditConfig(AuditType.POLLING, false, samplePctCutoff=1.0, nsimEst = nsimEst)
+            val pollingConfigNS = AuditConfig(AuditType.POLLING, false, nsimEst = nsimEst)
             val pollingGeneratorNS = PollingWorkflowTaskGenerator(
                 Nc, margin, 0.0, 0.0, 0.0,
                 mapOf("nruns" to nruns.toDouble(), "Nb" to Nb.toDouble(), "cat" to "pollingNoStyles"),
@@ -32,7 +32,7 @@ class CompareAuditsByStyles {
                 Nb=Nb)
             tasks.add(RepeatedWorkflowRunner(nruns, pollingGeneratorNS))
 
-            val pollingConfig = AuditConfig(AuditType.POLLING, true, samplePctCutoff=1.0, nsimEst = nsimEst)
+            val pollingConfig = AuditConfig(AuditType.POLLING, true, nsimEst = nsimEst)
             val pollingGenerator = PollingWorkflowTaskGenerator(
                 Nc, margin, 0.0, 0.0, 0.0,
                 mapOf("nruns" to nruns.toDouble(), "Nb" to Nb.toDouble(), "cat" to "pollingWithStyles"),
@@ -40,7 +40,7 @@ class CompareAuditsByStyles {
                 Nb=Nc)
             tasks.add(RepeatedWorkflowRunner(nruns, pollingGenerator))
 
-            val clcaConfigNS = AuditConfig(AuditType.CLCA, false, samplePctCutoff=1.0, nsimEst = nsimEst,
+            val clcaConfigNS = AuditConfig(AuditType.CLCA, false, nsimEst = nsimEst,
                 clcaConfig = ClcaConfig(ClcaStrategyType.noerror))
             val clcaGeneratorNS = ClcaWorkflowTaskGenerator(Nc, margin, 0.0, 0.0, 0.0,
                 mapOf("nruns" to nruns.toDouble(), "cat" to "clcaNoStyles"),
@@ -49,7 +49,7 @@ class CompareAuditsByStyles {
             )
             tasks.add(RepeatedWorkflowRunner(nruns, clcaGeneratorNS))
 
-            val clcaConfig = AuditConfig(AuditType.CLCA, true, samplePctCutoff=1.0, nsimEst = nsimEst,
+            val clcaConfig = AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst,
                 clcaConfig = ClcaConfig(ClcaStrategyType.noerror))
             val clcaGenerator = ClcaWorkflowTaskGenerator(Nc, margin, 0.0, 0.0, 0.0,
                 mapOf("nruns" to nruns.toDouble(), "cat" to "clcaWithStyles"),

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/CompareAuditsWithPhantoms.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/CompareAuditsWithPhantoms.kt
@@ -86,7 +86,7 @@ class CompareAuditsWithPhantoms {
         val phantoms = listOf(.00, .005, .01, .02, .03, .035, .04, .0425)
         val stopwatch = Stopwatch()
 
-        val auditConfig = AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst, samplePctCutoff = 1.0, minMargin = 0.0,
+        val auditConfig = AuditConfig(AuditType.CLCA, true, nsimEst = nsimEst,
             clcaConfig = ClcaConfig(ClcaStrategyType.noerror))
 
         val tasks = mutableListOf<ConcurrentTaskG<List<WorkflowResult>>>()

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRecord.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRecord.kt
@@ -10,7 +10,8 @@ class AuditRecord(
     val location: String,
     val auditConfig: AuditConfig,
     val rounds: List<AuditRound>,
-    val cvrs: List<CvrUnderAudit>,
+    val cvrs: List<Cvr>, // in the original order
+    val bcUA: List<BallotOrCvr>,
     val mvrs: Set<CvrUnderAudit>,
 ) {
     val nrounds = rounds.size
@@ -23,7 +24,8 @@ class AuditRecord(
             val auditConfig = auditConfigResult.unwrap()
 
             val cvrResult = readCvrsJsonFile(publisher.cvrsFile())
-            val cvrs = if (cvrResult is Ok) cvrResult.unwrap() else emptyList()
+            val cvrsUA = if (cvrResult is Ok) cvrResult.unwrap() else emptyList()
+            val cvrs = cvrsUA.sortedBy { it.index() }.map { it.cvr }
 
             val contestsResults = readContestsJsonFile(publisher.contestsFile())
             val contests = if (contestsResults is Ok) contestsResults.unwrap()
@@ -44,7 +46,7 @@ class AuditRecord(
 
                 rounds.add(auditRound)
             }
-            return AuditRecord(location, auditConfig, rounds, cvrs, mvrs)
+            return AuditRecord(location, auditConfig, rounds, cvrs, cvrsUA, mvrs)
         }
     }
 }

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/audit/PersistentWorkflow.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/audit/PersistentWorkflow.kt
@@ -8,6 +8,7 @@ import org.cryptobiotic.rlauxe.estimate.*
 class PersistentWorkflow(
     val inputDir: String,
 ): RlauxWorkflowIF {
+
     private val auditConfig: AuditConfig
     private val bcUA: List<BallotOrCvr>
     private val cvrs: List<Cvr>
@@ -22,8 +23,8 @@ class PersistentWorkflow(
 
         // TODO other auditTypes
         // bcUA = if (auditConfig.auditType == AuditType.POLLING) auditRecord.ballots else auditRecord.cvrs
-        bcUA = auditRecord.cvrs
-        cvrs = auditRecord.cvrs.map { it.cvr }
+        bcUA = auditRecord.bcUA // sorted by sampleNum
+        cvrs = auditRecord.cvrs // original order
         contestsUA = auditRounds.last().contestRounds.map { it.contestUA } // TODO
     }
 
@@ -42,7 +43,7 @@ class PersistentWorkflow(
     override fun auditRounds() = auditRounds
     override fun contestUA(): List<ContestUnderAudit> = contestsUA
     override fun cvrs() = cvrs
-    override fun getBallotsOrCvrs() : List<BallotOrCvr> = bcUA
+    override fun sortedBallotsOrCvrs() : List<BallotOrCvr> = bcUA
 }
 
 fun RlauxWorkflowIF.showResults(estSampleSize: Int) {

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/BallotManifestJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/BallotManifestJson.kt
@@ -61,6 +61,7 @@ data class BallotJson(
     val phantom: Boolean,
     val ballotStyle: BallotStyleJson?,
     val contestIds: List<Int>?,
+    val index: Int,
     val sampleNumber: Long,
 )
 
@@ -70,6 +71,7 @@ fun BallotUnderAudit.publishJson() : BallotJson {
         this.phantom,
         this.ballot.ballotStyle?.publishJson(),
         this.ballot.contestIds,
+        this.index,
         this.sampleNum,
     )
 }
@@ -82,6 +84,7 @@ fun BallotJson.import(): BallotUnderAudit {
             this.ballotStyle?.import(),
             this.contestIds,
         ),
+        this.index,
         this.sampleNumber)
 }
 

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/CvrsJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/CvrsJson.kt
@@ -29,6 +29,7 @@ data class CvrJson(
     val id: String,
     val votes: List<VoteJson>,
     val phantom: Boolean,
+    val index: Int,
     val sampleNumber: Long,
 )
 
@@ -38,6 +39,7 @@ fun CvrUnderAudit.publishJson() : CvrJson {
         this.id,
         votes,
         this.cvr.phantom,
+        this.index,
         this.sampleNum,
     )
 }
@@ -50,6 +52,7 @@ fun CvrJson.import(): CvrUnderAudit {
             votes,
             this.phantom,
         ),
+        this.index,
         this.sampleNumber)
 }
 

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/Publisher.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/Publisher.kt
@@ -4,6 +4,23 @@ import org.cryptobiotic.rlauxe.util.ErrorMessages
 import java.nio.file.Files
 import java.nio.file.Path
 
+/*
+    topdir/
+      auditConfig.json      // AuditConfigJson
+      contests.json         // ContestsUnderAuditJson
+      cvrs.json             // CvrsJson (or)
+      ballotManifest.json   // BallotManifestJson
+      roundX/
+        auditState.json     // AuditRoundJson
+        sampleIndices.json  // SampleIndicesJson // choose the sample indices to be audited
+        sampleMvrs.json     // CvrsJson // get the mvrs needed for the audit
+
+      altRoundX/
+        estRound.json       // EstimationRoundJson, includes SampleIndices ??
+        sampleMvrs.json     // CvrsJson // get the mvrs needed for the audit  // check agree with SampleIndices
+        auditResult.json     // AuditResultJson
+ */
+
 class Publisher(val topdir: String) {
     val errs =  ErrorMessages("Publisher");
     init {

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunCli.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunCli.kt
@@ -6,8 +6,8 @@ class TestRunCli {
 
     @Test
     fun testCliRoundClca() {
-        val topdir = "/home/stormy/temp/persist/testRunCli"
-        // val topdir = kotlin.io.path.createTempDirectory().toString()
+        // val topdir = "/home/stormy/temp/persist/testRunCli"
+        val topdir = kotlin.io.path.createTempDirectory().toString()
         val mvrs =  "$topdir/private/testMvrs.json"
         RunRlaStartTest.main(
             arrayOf(
@@ -30,8 +30,8 @@ class TestRunCli {
 
     @Test
     fun testCliRoundPolling() {
-        val topdir = "/home/stormy/temp/persist/testCliRoundPolling"
-        // val topdir = kotlin.io.path.createTempDirectory().toString()
+        // val topdir = "/home/stormy/temp/persist/testCliRoundPolling"
+        val topdir = kotlin.io.path.createTempDirectory().toString()
         val mvrs =  "$topdir/private/testMvrs.json"
         RunRlaStartTest.main(
             arrayOf(

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
@@ -26,7 +26,7 @@ class TestConsistentSampling {
 
         val previousSamples = auditRecord.rounds.previousSamples(auditRound.roundIdx)
 
-        consistentSampling(auditRound, workflow.getBallotsOrCvrs(), previousSamples)
+        consistentSampling(auditRound, workflow.sortedBallotsOrCvrs(), previousSamples)
         val actualNewMvrs = auditRound.contestRounds.map { it.actualNewMvrs}
         println("actualNewMvrs = $actualNewMvrs")
     }

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestBallotManifestJson.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestBallotManifestJson.kt
@@ -19,7 +19,7 @@ class TestBallotManifestJson {
     fun testRoundtripWithStyle() {
         val testData = MultiContestTestData(11, 4, 1000)
         val (_, ballotManifest) = testData.makeCvrsAndBallotManifest(true)
-        val ballotsUA = ballotManifest.ballots.map { BallotUnderAudit(it, Random.nextLong()) }
+        val ballotsUA = ballotManifest.ballots.mapIndexed { idx, it -> BallotUnderAudit(it, idx, Random.nextLong()) }
         val target = BallotManifestUnderAudit(ballotsUA, ballotManifest.ballotStyles)
 
         val json = target.publishJson()
@@ -32,7 +32,8 @@ class TestBallotManifestJson {
     fun testRoundtripWithNoStyle() {
         val testData = MultiContestTestData(11, 4, 1000)
         val (_, ballotManifest) = testData.makeCvrsAndBallotManifest(false)
-        val ballotsUA = ballotManifest.ballots.map { BallotUnderAudit(it, Random.nextLong()) }
+        val ballotsUA = ballotManifest.ballots.mapIndexed { idx, it -> BallotUnderAudit(it, idx, Random.nextLong()) }
+
         val target = BallotManifestUnderAudit(ballotsUA, ballotManifest.ballotStyles)
 
         val json = target.publishJson()
@@ -45,7 +46,7 @@ class TestBallotManifestJson {
     fun testRoundtripIO() {
         val testData = MultiContestTestData(11, 4, 1000)
         val (_, ballotManifest) = testData.makeCvrsAndBallotManifest(true)
-        val ballotsUA = ballotManifest.ballots.map { BallotUnderAudit(it, Random.nextLong()) }
+        val ballotsUA = ballotManifest.ballots.mapIndexed { idx, it -> BallotUnderAudit(it, idx, Random.nextLong()) }
         val target = BallotManifestUnderAudit(ballotsUA, ballotManifest.ballotStyles)
 
         writeBallotManifestJsonFile(target, filename)

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestCvrsJson.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestCvrsJson.kt
@@ -18,7 +18,7 @@ class TestCvrsJson {
     fun testRoundtrip() {
         val testData = MultiContestTestData(11, 4, 1000)
         val cvrs = testData.makeCvrsFromContests()
-        val target = cvrs.map { CvrUnderAudit(it, Random.nextLong())}
+        val target = cvrs.mapIndexed { idx, it -> CvrUnderAudit(it, idx, Random.nextLong())}
 
         val json = target.publishJson()
         val roundtrip = json.import()
@@ -34,7 +34,7 @@ class TestCvrsJson {
     fun testRoundtripIO() {
         val testData = MultiContestTestData(11, 4, 1000)
         val cvrs = testData.makeCvrsFromContests()
-        val target = cvrs.map { CvrUnderAudit(it, Random.nextLong())}
+        val target = cvrs.mapIndexed { idx, it -> CvrUnderAudit(it, idx, Random.nextLong())}
 
         writeCvrsJsonFile(target, filename)
         val result = readCvrsJsonFile(filename)

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/AssertionRLAipynb.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/AssertionRLAipynb.kt
@@ -11,6 +11,7 @@ import org.cryptobiotic.rlauxe.raire.*
 import org.cryptobiotic.rlauxe.workflow.AuditRound
 import org.cryptobiotic.rlauxe.workflow.ContestRound
 import org.cryptobiotic.rlauxe.workflow.Sampler
+import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -441,8 +442,8 @@ class AssertionRLA {
 //prng = SHA256(audit.seed)
 //CVR.assign_sample_nums(cvr_list, prng)
         // TODO evaluate secureRandom for production, also needs to be deterministic, ie seeded
-        val prng = Prng(secureRandom.nextLong())
-        val cvras = rcvrs.map { CvrUnderAudit(it, prng.next()) }
+        val cvras = rcvrs.mapIndexed { idx, it -> CvrUnderAudit(it, idx, Random.nextLong())}
+
         println("calc_sample_sizes = $results")
 
 //#%%

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistentWorkflowClca.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistentWorkflowClca.kt
@@ -36,7 +36,9 @@ class TestPersistentWorkflowClca {
             else makeFuzzedCvrsFrom(contests, testCvrs, fuzzMvrs)
 
         var clcaWorkflow = ClcaWorkflow(auditConfig, contests, emptyList(), testCvrs)
-        writeCvrsJsonFile(clcaWorkflow.cvrsUA, publish.cvrsFile())
+        val cvrsUA = clcaWorkflow.sortedBallotsOrCvrs().map{ it as CvrUnderAudit }
+
+        writeCvrsJsonFile(cvrsUA, publish.cvrsFile())
 
         writeContestsJsonFile(clcaWorkflow.contestUA(), publish.contestsFile())
 
@@ -44,7 +46,7 @@ class TestPersistentWorkflowClca {
         var done = false
         var workflow : RlauxWorkflowIF = clcaWorkflow
         while (!done) {
-            done = runPersistentWorkflowStage(round, workflow, clcaWorkflow.cvrsUA, testMvrs, publish)
+            done = runPersistentWorkflowStage(round, workflow, cvrsUA, testMvrs, publish)
             workflow = PersistentWorkflow(topdir)
             round++
         }
@@ -73,7 +75,7 @@ fun runPersistentWorkflowStage(roundIdx: Int, workflow: RlauxWorkflowIF, bcUA: L
 
         val sampledMvrus = nextRound.sampledIndices.map {
             val cvr = bcUA[it]
-            CvrUnderAudit(testMvrs[it], cvr.sampleNumber())
+            CvrUnderAudit(testMvrs[it], it, cvr.sampleNumber())
         }
         writeCvrsJsonFile(sampledMvrus, publish.sampleMvrsFile(roundIdx))
 

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistentWorkflowPolling.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistentWorkflowPolling.kt
@@ -30,8 +30,9 @@ class TestPersistentWorkflowPolling {
         val (testCvrs, ballotManifest) = testData.makeCvrsAndBallotManifest(auditConfig.hasStyles)
         val testMvrs = makeFuzzedCvrsFrom(contests, testCvrs, fuzzMvrs)
         val pollingWorkflow = PollingWorkflow(auditConfig, contests, ballotManifest, testCvrs.size)
+        val ballotsUA = pollingWorkflow.sortedBallotsOrCvrs().map{ it as BallotUnderAudit }
 
-        val ballotManifestUA = BallotManifestUnderAudit(pollingWorkflow.ballotsUA, ballotManifest.ballotStyles)
+        val ballotManifestUA = BallotManifestUnderAudit(ballotsUA, ballotManifest.ballotStyles)
         writeBallotManifestJsonFile(ballotManifestUA, publish.ballotManifestFile())
 
         writeContestsJsonFile(pollingWorkflow.contestUA(), publish.contestsFile())
@@ -40,7 +41,7 @@ class TestPersistentWorkflowPolling {
         var done = false
         var workflow : RlauxWorkflowIF = pollingWorkflow
         while (!done) {
-            done = runPersistentWorkflowStage(round, workflow, pollingWorkflow.ballotsUA, testMvrs, publish)
+            done = runPersistentWorkflowStage(round, workflow, ballotsUA, testMvrs, publish)
             workflow = PersistentWorkflow(topdir)
             round++
         }


### PR DESCRIPTION
RlauxWorkflowIF has sortedBallotsOrCvrs, sorted by sampleNum. 
AuditRecord has cvrs: List<Cvr>, // in the original order. 
Remove isSampled(), add index() to BallotOrCvr.
Remove setting minMargin = 0.0, samplePctCutoff = 1.0 on AuditConfig, since thats default.