### PR TITLE
Fix workflowsFix Workflows, BallotCardsXXStart not correct

### DIFF
--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Contest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Contest.kt
@@ -205,7 +205,7 @@ open class ContestUnderAudit(
     open fun makePollingAssertions(): ContestUnderAudit {
         require(!isComparison) { "makePollingAssertions() can be called only on polling contest"}
         // val useVotes = if (votes != null) votes else (contest as Contest).votes
-        val useVotes = (contest as Contest).votes
+        val useVotes = (contest as Contest).votes // TODO assumes Contest ??
 
         this.pollingAssertions = when (choiceFunction) {
             SocialChoiceFunction.APPROVAL,
@@ -240,11 +240,11 @@ open class ContestUnderAudit(
     }
 
     // cvrs must be complete in order to get the margin right.
-    // open fun makeComparisonAssertions(cvrs : Iterable<Cvr>, votes: Map<Int, Int>? = null): ContestUnderAudit {
+    // TODO: only make one pass through the cvrs, and calcAssorterMargin for all assertions.
     open fun makeClcaAssertions(cvrs : Iterable<Cvr>): ContestUnderAudit {
         require(isComparison) { "makeComparisonAssertions() can be called only on comparison contest"}
         // val useVotes = if (votes != null) votes else (contest as Contest).votes
-        val useVotes = (contest as Contest).votes
+        val useVotes = (contest as Contest).votes // // TODO assumes Contest ??
         val assertions = when (contest.info.choiceFunction) {
             SocialChoiceFunction.APPROVAL,
             SocialChoiceFunction.PLURALITY, -> makePluralityAssertions(useVotes)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ClcaSimulation.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ClcaSimulation.kt
@@ -51,7 +51,7 @@ class ClcaSimulation(
         flippedVotesP2o = flipP2o(mmvrs, needToChange = (Nc * errorRates.p2o).toInt())
         flippedVotesP2u = flipP2u(mmvrs, needToChange = (Nc * errorRates.p2u).toInt())
         flippedVotesP1u = if (isIRV) flipP1uIRV(mmvrs, needToChange = (Nc * errorRates.p1u).toInt())
-                        else flipP1uP(mmvrs, ccvrs, needToChange = (Nc * errorRates.p1u).toInt())
+                          else flipP1uP(mmvrs, ccvrs, needToChange = (Nc * errorRates.p1u).toInt())
 
         mvrs = mmvrs.toList()
         cvrs = ccvrs.toList()
@@ -60,7 +60,6 @@ class ClcaSimulation(
         sampleMean = sampleCount / Nc
     }
 
-    fun sampleMean() = sampleMean
     fun sampleCount() = sampleCount
     override fun maxSamples() = maxSamples
     override fun maxSampleIndexUsed() = idx
@@ -114,7 +113,7 @@ class ClcaSimulation(
                 val alteredMvr = makeNewCvr(cvr, votes) // this is the altered mvr
                 mcvrs[cardIdx] = alteredMvr
                 if (show && cassorter.assorter().assort(alteredMvr) != 0.0) {
-                    println("  flip2votes ${cassorter.assorter().assort(alteredMvr)} != 0.0")
+                    println("  flipP2o ${cassorter.assorter().assort(alteredMvr)} != 0.0")
                     println("    cvr=${cvr}")
                     println("    alteredMvr=${alteredMvr}")
                 }
@@ -130,7 +129,7 @@ class ClcaSimulation(
         }
         val checkAvotes = mcvrs.filter { cassorter.assorter().assort(it) == 1.0 }.count()
         if (checkAvotes != startingAvotes - needToChange)
-            println("flip2votes could only flip $changed, wanted $needToChange")
+            println("flipP2o could only flip $changed, wanted $needToChange")
         // require(checkAvotes == startingAvotes - needToChange)
         return changed
     }
@@ -153,7 +152,7 @@ class ClcaSimulation(
                 val alteredMvr = makeNewCvr(cvr, votes)
                 mcvrs[cardIdx] = alteredMvr
                 if (show && cassorter.assorter().assort(alteredMvr) != 1.0) {
-                    println("  flip4votes ${cassorter.assorter().assort(alteredMvr)} != 1.0")
+                    println("  flipP2u ${cassorter.assorter().assort(alteredMvr)} != 1.0")
                     println("    cvr=${cvr}")
                     println("    alteredMvr=${alteredMvr}")
                 }
@@ -170,7 +169,7 @@ class ClcaSimulation(
 
         val checkAvotes = mcvrs.filter { cassorter.assorter().assort(it) == 0.0 }.count()
         if (checkAvotes != startingAvotes - needToChange)
-            println("flip4votes could only flip $changed, wanted $needToChange")
+            println("flipP2u could only flip $changed, wanted $needToChange")
         // require(checkAvotes == startingAvotes - needToChange)
         return changed
     }
@@ -193,7 +192,7 @@ class ClcaSimulation(
                 val alteredMvr = makeNewCvr(cvr, votes)
                 mcvrs[cardIdx] = alteredMvr
                 if (show && cassorter.assorter().assort(alteredMvr) != 0.5) {
-                    println("  flip1votes ${cassorter.assorter().assort(alteredMvr)} != 0.5")
+                    println("  flipP1o ${cassorter.assorter().assort(alteredMvr)} != 0.5")
                     println("    cvr=${cvr}")
                     println("    alteredMvr=${alteredMvr}")
                 }
@@ -209,7 +208,7 @@ class ClcaSimulation(
         }
         val checkAvotes = mcvrs.filter { cassorter.assorter().assort(it) == 1.0 }.count()
         if (checkAvotes != startingAvotes - needToChange)
-            println("flip1votes could only flip $changed, wanted $needToChange")
+            println("flipP1o could only flip $changed, wanted $needToChange")
         // require(checkAvotes == startingAvotes - needToChange)
 
         return changed
@@ -243,7 +242,7 @@ class ClcaSimulation(
         }
         val checkAvotes = mcvrs.filter { cassorter.assorter().assort(it) == 0.5 }.count()
         if (checkAvotes != startingAvotes - needToChange)
-            println("flip3votes could only flip $changed, wanted $needToChange")
+            println("flipP1uIRV could only flip $changed, wanted $needToChange")
         // require(checkAvotes == startingAvotes - needToChange)
 
         return changed
@@ -277,7 +276,7 @@ class ClcaSimulation(
         }
         val checkAvotes = cvrs.count { cassorter.assorter().assort(it) == 1.0 }
         if (checkAvotes != startingAvotes - needToChange)
-            println("flip3votesP could only flip $changed, wanted $needToChange")
+            println("flipP1uP could only flip $changed, wanted $needToChange")
        // require(checkAvotes == startingAvotes - needToChange)
 
         return changed

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ConsistentSampling.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ConsistentSampling.kt
@@ -63,7 +63,7 @@ fun createSampleIndices(
     } else {
         if (!quiet) println("\nuniformSampling round ${auditRound.roundIdx}")
         uniformSampling(auditRound, workflow.ballotCards(), previousSamples.size, auditConfig.samplePctCutoff, auditRound.roundIdx)
-        if (!quiet) println(" consistentSamplingSize= ${auditRound.sampleNumbers.size}")
+        if (!quiet) println(" uniformSamplingSize= ${auditRound.sampleNumbers.size}")
     }
 }
 
@@ -192,5 +192,74 @@ fun uniformSampling(
     auditRound.sampleNumbers = sampledCards.map { it.sampleNumber() } // list of ballot indexes sorted by sampleNum
     auditRound.sampledBorc = sampledCards
 }
+
+
+/////////////////////////////////////////////////////////////////////////////////
+// SHANGRLA computeSampleSize not needed, I think
+
+//4.a) Pick the (cumulative) sample sizes {𝑆_𝑐} for 𝑐 ∈ C to attain by the end of this round of sampling.
+//	    The software offers several options for picking {𝑆_𝑐}, including some based on simulation.
+//      The desired sampling fraction 𝑓_𝑐 := 𝑆_𝑐 /𝑁_𝑐 for contest 𝑐 is the sampling probability
+//	      for each card that contains contest 𝑘, treating cards already in the sample as having sampling probability 1.
+//	    The probability 𝑝_𝑖 that previously unsampled card 𝑖 is sampled in the next round is the largest of those probabilities:
+//	      𝑝_𝑖 := max (𝑓_𝑐), 𝑐 ∈ C ∩ C𝑖, where C_𝑖 denotes the contests on card 𝑖.
+//	b) Estimate the total sample size to be Sum(𝑝_𝑖), where the sum is across all cards 𝑖 except phantom cards.
+
+// given the contest.sampleSize, we can calculate the total number of ballots.
+// however, we get this from consistent sampling, which actually picks which ballots to sample.
+/* dont really need
+fun computeSampleSize(
+    rcontests: List<ContestUnderAudit>,
+    cvrs: List<CvrUnderAudit>,
+): Int {
+    // unless style information is being used, the sample size is the same for every contest.
+    val old_sizes: MutableMap<Int, Int> =
+        rcontests.associate { it.id to 0 }.toMutableMap()
+
+    // setting p toodoo whats this doing here? shouldnt it be in consistent sampling ?? MoreStyle section 3 ??
+    for (cvr in cvrs) {
+        if (cvr.sampled) {
+            cvr.p = 1.0
+        } else {
+            cvr.p = 0.0
+            for (con in rcontests) {
+                if (cvr.hasContest(con.id) && !cvr.sampled) {
+                    val p1 = con.estSampleSize.toDouble() / (con.Nc!! - old_sizes[con.id]!!)
+                    cvr.p = max(p1, cvr.p) // toodoo nullability
+                }
+            }
+        }
+    }
+
+    // when old_sizes == 0, total_size should be con.sample_size (61); python has roundoff to get 62
+    // total_size = ceil(np.sum([x.p for x in cvrs if !x.phantom))
+    // toodoo total size is the sum of the p's over the cvrs (!wtf)
+    val summ: Double = cvrs.filter { !it.phantom }.map { it.p }.sum()
+    val total_size = ceil(summ).toInt()
+    return total_size // toodoo what is this? doesnt consistent sampling decide this ??
+}
+
+// STYLISH 4 a,b. I think maybe only works when you use sampleThreshold ??
+fun computeSampleSizePolling(
+    rcontests: List<ContestUnderAudit>,
+    ballots: List<BallotUnderAudit>,
+): Int {
+    ballots.forEach { ballot ->
+        if (ballot.sampled) {
+            ballot.p = 1.0
+        } else {
+            ballot.p = 0.0
+            for (con in rcontests) {
+                if (ballot.hasContest(con.id) && !ballot.sampled) {
+                    val p1 = con.estSampleSize.toDouble() / con.Nc
+                    ballot.p = max(p1, ballot.p)
+                }
+            }
+        }
+    }
+    val summ: Double = ballots.filter { !it.phantom }.map { it.p }.sum()
+    return ceil(summ).toInt()
+}
+ */
 
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ContestSimulation.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ContestSimulation.kt
@@ -27,8 +27,10 @@ import kotlin.random.Random
 //    For auditing, I think we need to assume U_c is 0? So Np_c = N_c - V_c??
 //    I think we must have a ballot manifest, which means we have Nb, and ...
 
-/** Simulation of multicandidate Contest that reflects the exact votes and Nc, along with undervotes and phantoms,
- * as specified in Contest. TODO use for clca?? */
+/**
+ * Simulation of multicandidate Contest that reflects the exact votes and Nc, along with undervotes and phantoms,
+ * as specified in Contest.
+ */
 class ContestSimulation(val contest: Contest) {
     val info = contest.info
     val ncands = info.candidateIds.size

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireContest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireContest.kt
@@ -21,7 +21,7 @@ data class RaireContest(
     override val ncandidates = info.candidateIds.size
     override val id = info.id
     override val choiceFunction = info.choiceFunction
-    override val undervotes: Int = -1  // TODO get this nballots not voted on?
+    override val undervotes: Int = -1  // TODO get this; nballots not voted on?
 
     init {
         val mapIdToName: Map<Int, String> = info.candidateNames.toList().associate { Pair(it.second, it.first) }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Quantile.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Quantile.kt
@@ -37,7 +37,7 @@ fun showDeciles(data: List<Int>) = buildString {
     val deciles = makeDeciles(data)
     append(" deciles=[")
     deciles.forEach { append(" $it, ") };
-    appendLine("]")
+    append("]")
 }
 
 /**

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Welford.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Welford.kt
@@ -1,5 +1,7 @@
 package org.cryptobiotic.rlauxe.util
 
+import kotlin.math.sqrt
+
 /**
  * Welford's algorithm for running mean and variance.
  * see https://en.wikipedia.org/wiki/Algorithms_for_calculating_variance#Welford's_online_algorithm
@@ -30,6 +32,6 @@ class Welford(
     fun variance() = if (count == 0) 0.0 else M2 / count
 
     override fun toString(): String {
-        return "(mean, variance and sample) = ${this.result()}"
+        return "(mean, variance, sampleVariance, stddev) = ${this.result()}, ${sqrt(variance())}"
     }
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditRound.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditRound.kt
@@ -1,13 +1,14 @@
 package org.cryptobiotic.rlauxe.workflow
 
 import org.cryptobiotic.rlauxe.core.*
+import org.cryptobiotic.rlauxe.util.df
 import kotlin.math.max
 
 data class AuditRound(
     val roundIdx: Int,
     val contestRounds: List<ContestRound>,
 
-    val auditWasDone: Boolean = false,
+    var auditWasDone: Boolean = false,
     var auditIsComplete: Boolean = false,
     var sampleNumbers: List<Long>, // ballot indices to sample for this round
     var sampledBorc: List<BallotOrCvr> = emptyList(), // ballots to sample for this round
@@ -187,5 +188,5 @@ data class AuditRoundResult(
     val measuredRates: ClcaErrorRates? = null, // measured error rates (clca only)
 ) {
     override fun toString() = "round=$roundIdx nmvrs=$nmvrs maxBallotIndexUsed=$maxBallotIndexUsed " +
-            " pvalue=$pvalue samplesNeeded=$samplesNeeded samplesUsed=$samplesUsed status=$status"
+            " pvalue=${df(pvalue)} samplesNeeded=$samplesNeeded samplesUsed=$samplesUsed status=$status"
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/BallotCards.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/BallotCards.kt
@@ -60,7 +60,6 @@ class BallotCardsClcaStart(val cvrs: List<Cvr>, mvrs: List<Cvr>, seed: Long) : B
         setMvrs(sampledMvrs)
     }
 
-    // perhaps we want to set a limit on the sampler size ?
     override fun makeSampler(contestId: Int, cassorter: ClcaAssorterIF, allowReset: Boolean): Sampler {
         val sampleNumbers = mvrsForRound.map { it.sampleNum }
         val sampledCvrs = findSamples(sampleNumbers, cvrsUA)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/BallotCards.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/BallotCards.kt
@@ -15,6 +15,7 @@ interface BallotCards {
     fun nballotCards(): Int
     fun ballotCards() : Iterable<BallotOrCvr>
     fun setMvrs(mvrs: List<CvrUnderAudit>)
+    fun setMvrsBySampleNumber(sampleNumbers: List<Long>)
     fun takeFirst(nmvrs: Int): List<BallotOrCvr> = ballotCards().take(nmvrs).toList()
 }
 
@@ -31,6 +32,7 @@ interface BallotCardsPolling : BallotCards {
 class BallotCardsClcaStart(val cvrs: List<Cvr>, mvrs: List<Cvr>, seed: Long) : BallotCardsClca {
     val cvrsUA: List<CvrUnderAudit>
     val mvrsUA: List<CvrUnderAudit>
+    private var mvrsForRound: List<CvrUnderAudit> = emptyList()
 
     init {
         // the order of the cvrs cannot be changed.
@@ -42,13 +44,37 @@ class BallotCardsClcaStart(val cvrs: List<Cvr>, mvrs: List<Cvr>, seed: Long) : B
     override fun nballotCards() = cvrs.size
     override fun ballotCards() : Iterable<BallotOrCvr> = cvrsUA
     override fun setMvrs(mvrs: List<CvrUnderAudit>) {
-        TODO("Not used")
+        mvrsForRound = mvrs
+    }
+    override fun setMvrsBySampleNumber(sampleNumbers: List<Long>) {
+        val sampledMvrs = findSamples(sampleNumbers, mvrsUA)
+        require(sampledMvrs.size == sampleNumbers.size)
+
+        // debugging sanity check
+        var lastRN = 0L
+        sampledMvrs.forEach { mvr ->
+            require(mvr.sampleNumber() > lastRN)
+            lastRN = mvr.sampleNumber()
+        }
+
+        setMvrs(sampledMvrs)
     }
 
     // perhaps we want to set a limit on the sampler size ?
     override fun makeSampler(contestId: Int, cassorter: ClcaAssorterIF, allowReset: Boolean): Sampler {
+        val sampleNumbers = mvrsForRound.map { it.sampleNum }
+        val sampledCvrs = findSamples(sampleNumbers, cvrsUA)
+
+        // prove that sampledCvrs correspond to mvrs
+        require(sampledCvrs.size == mvrsForRound.size)
+        val cvruaPairs: List<Pair<CvrUnderAudit, CvrUnderAudit>> = mvrsForRound.zip(sampledCvrs)
+        cvruaPairs.forEach { (mvr, cvr) ->
+            require(mvr.id == cvr.id)
+            require(mvr.index == cvr.index)
+            require(mvr.sampleNumber() == cvr.sampleNumber())
+        }
         // why not List<Pair<CvrUnderAudit, CvrUnderAudit>> ??
-        val cvrPairs = mvrsUA.map{ it.cvr }.zip(cvrsUA.map{ it.cvr })
+        val cvrPairs = mvrsForRound.map{ it.cvr }.zip(sampledCvrs.map{ it.cvr })
         return ClcaWithoutReplacement(contestId, cvrPairs, cassorter, allowReset = false)
     }
 }
@@ -56,6 +82,7 @@ class BallotCardsClcaStart(val cvrs: List<Cvr>, mvrs: List<Cvr>, seed: Long) : B
 class BallotCardsPollingStart(val ballots: List<Ballot>, mvrs: List<Cvr>, seed: Long) : BallotCardsPolling {
     val ballotsUA: List<BallotUnderAudit>
     val mvrsUA: List<CvrUnderAudit>
+    var mvrsForRound: List<CvrUnderAudit> = emptyList()
 
     init {
         val prng = Prng(seed)
@@ -67,12 +94,25 @@ class BallotCardsPollingStart(val ballots: List<Ballot>, mvrs: List<Cvr>, seed: 
     override fun nballotCards() = ballots.size
     override fun ballotCards() : Iterable<BallotOrCvr> = ballotsUA
     override fun setMvrs(mvrs: List<CvrUnderAudit>) {
-        TODO("Not used")
+        mvrsForRound = mvrs
+    }
+    override fun setMvrsBySampleNumber(sampleNumbers: List<Long>) {
+        val sampledMvrs = findSamples(sampleNumbers, mvrsUA)
+        require(sampledMvrs.size == sampleNumbers.size)
+
+        // debugging sanity check
+        var lastRN = 0L
+        sampledMvrs.forEach { mvr ->
+            require(mvr.sampleNumber() > lastRN)
+            lastRN = mvr.sampleNumber()
+        }
+
+        setMvrs(sampledMvrs)
     }
 
     override fun makeSampler(contestId: Int, assorter: AssorterIF, allowReset: Boolean): Sampler {
         // why not List<CvrUnderAudit> ??
-        return PollWithoutReplacement(contestId, mvrsUA.map{ it.cvr }, assorter, allowReset=allowReset)
+        return PollWithoutReplacement(contestId, mvrsForRound.map { it.cvr } , assorter, allowReset=allowReset)
     }
 }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaWorkflow.kt
@@ -30,14 +30,17 @@ class ClcaWorkflow(
         // TODO filter out contests that are done... */
     }
 
-    override fun addMvrs(mvrs: List<CvrUnderAudit>)  {
-        ballotCards.setMvrs(mvrs)
+    override fun setMvrsBySampleNumber(sampleNumbers: List<Long>) {
+        ballotCards.setMvrsBySampleNumber(sampleNumbers)
     }
 
-    //  return allDone
+    //  return complete
     override fun runAudit(auditRound: AuditRound, quiet: Boolean): Boolean  {
-        return runClcaAudit(auditConfig, auditRound.contestRounds, ballotCards,
-            auditRound.roundIdx, auditor = AuditClcaAssertion())
+        val complete = runClcaAudit(auditConfig, auditRound.contestRounds, ballotCards, auditRound.roundIdx,
+            auditor = AuditClcaAssertion(quiet))
+        auditRound.auditWasDone = true
+        auditRound.auditIsComplete = complete
+        return complete
     }
 
     override fun auditConfig() =  this.auditConfig

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAuditWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAuditWorkflow.kt
@@ -12,7 +12,6 @@ class OneAuditWorkflow(
     val ballotCards: BallotCardsClcaStart, // mutable
 ): RlauxWorkflowIF {
     private val contestsUA: List<ContestUnderAudit>
-    // private val cvrsUA: List<CvrUnderAudit>
     private val auditRounds = mutableListOf<AuditRound>()
 
     init {
@@ -23,17 +22,19 @@ class OneAuditWorkflow(
         // check(auditConfig, contests)
     }
 
-    //  return allDone
     override fun runAudit(auditRound: AuditRound, quiet: Boolean): Boolean  {
-        return runClcaAudit(auditConfig, auditRound.contestRounds, ballotCards,
-            auditRound.roundIdx, auditor = OneAuditClcaAssertion())
+        val complete = runClcaAudit(auditConfig, auditRound.contestRounds, ballotCards, auditRound.roundIdx,
+            auditor = OneAuditClcaAssertion())
+        auditRound.auditWasDone = true
+        auditRound.auditIsComplete = complete
+        return complete
     }
 
     override fun auditConfig() =  this.auditConfig
     override fun auditRounds() = auditRounds
     override fun contestsUA(): List<ContestUnderAudit> = contestsUA
-    override fun addMvrs(mvrs: List<CvrUnderAudit>) {
-        ballotCards.setMvrs(mvrs)
+    override fun setMvrsBySampleNumber(sampleNumbers: List<Long>) {
+        ballotCards.setMvrsBySampleNumber(sampleNumbers)
     }
 
     override fun ballotCards() = ballotCards

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingWorkflow.kt
@@ -31,15 +31,18 @@ class PollingWorkflow(
         check(auditConfig, contests) */
     }
 
-    override fun runAudit(auditRound: AuditRound, quiet: Boolean): Boolean  { // return allDone
-        return runPollingAudit(auditConfig, auditRound.contestRounds, ballotCards, auditRound.roundIdx, quiet)
+    override fun runAudit(auditRound: AuditRound, quiet: Boolean): Boolean  {
+        val complete = runPollingAudit(auditConfig, auditRound.contestRounds, ballotCards, auditRound.roundIdx, quiet)
+        auditRound.auditWasDone = true
+        auditRound.auditIsComplete = complete
+        return complete
     }
 
     override fun auditConfig() =  this.auditConfig
     override fun auditRounds() = auditRounds
     override fun contestsUA(): List<ContestUnderAudit> = contestsUA
-    override fun addMvrs(mvrs: List<CvrUnderAudit>) {
-        ballotCards.setMvrs(mvrs)
+    override fun setMvrsBySampleNumber(sampleNumbers: List<Long>) {
+        ballotCards.setMvrsBySampleNumber(sampleNumbers)
     }
     override fun ballotCards() = ballotCards
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/RlauxWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/RlauxWorkflow.kt
@@ -15,6 +15,7 @@ interface RlauxWorkflowIF: RlauxWorkflowProxy {
     fun auditRounds(): MutableList<AuditRound>
     fun contestsUA(): List<ContestUnderAudit>
 
+    // start new round and create estimate
     fun startNewRound(quiet: Boolean = true): AuditRound {
         val auditRounds = auditRounds()
         val previousRound = if (auditRounds.isEmpty()) null else auditRounds.last()
@@ -28,16 +29,17 @@ interface RlauxWorkflowIF: RlauxWorkflowProxy {
         }
         auditRounds.add(auditRound)
 
+        if (!quiet) println("Estimate round ${roundIdx}")
         estimateSampleSizes(
             auditConfig(),
             auditRound,
-            show=!quiet,
         )
 
         sample(this, auditRound, auditRounds.previousSamples(roundIdx), quiet)
         return auditRound
     }
 
-    fun addMvrs(mvrs: List<CvrUnderAudit>)
+    // you have to set the mvrs before you run the audit
+    fun setMvrsBySampleNumber(sampleNumbers: List<Long>)
     fun runAudit(auditRound: AuditRound, quiet: Boolean = true): Boolean  // return allDone
 }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaSingleRoundAuditTask.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaSingleRoundAuditTask.kt
@@ -9,6 +9,7 @@ import org.cryptobiotic.rlauxe.util.Stopwatch
 import java.util.concurrent.TimeUnit
 import kotlin.math.max
 
+// Do the audit in a single round, dont use estimateSampleSizes
 class ClcaSingleRoundAuditTaskGenerator(
     val Nc: Int, // including undervotes but not phantoms
     val margin: Double,

--- a/docs/OneAudit.md
+++ b/docs/OneAudit.md
@@ -93,7 +93,7 @@ Assuming betj are constant = b, then
 
 TODO: show plot
 
-One possibility is that we can mofify the betting function to take into account these known "errors"?
+One possibility is that we can modify the betting function to take into account these known "errors"?
 
 ## Notes from the paper
 

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/CobraWorkflow.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/CobraWorkflow.kt
@@ -61,7 +61,6 @@ class CobraWorkflow(
     val p2prior: Double,
 ) : RlauxWorkflowIF {
     private val contestsUA: List<ContestUnderAudit>
-    // val cvrsUA: List<CvrUnderAudit>
     private val auditRounds = mutableListOf<AuditRound>()
 
     init {
@@ -71,23 +70,23 @@ class CobraWorkflow(
         contestsUA.forEach { contest ->
             contest.makeClcaAssertions(ballotCards.cvrs)
         }
-
-        //val prng = Prng(auditConfig.seed)
-        //cvrsUA = cvrs.mapIndexed { idx, it -> CvrUnderAudit(it, idx, prng.next()) }.sortedBy { it.sampleNumber() }
     }
 
     override fun runAudit(auditRound: AuditRound, quiet: Boolean): Boolean  {
-        return runClcaAudit(auditConfig, auditRound.contestRounds, ballotCards,
-            auditRound.roundIdx, auditor = AuditCobraAssertion(p2prior))
+        val complete = runClcaAudit(auditConfig, auditRound.contestRounds, ballotCards, auditRound.roundIdx,
+            auditor = AuditCobraAssertion(p2prior)
+        )
+        auditRound.auditWasDone = true
+        auditRound.auditIsComplete = complete
+        return complete
     }
 
     override fun auditConfig() = this.auditConfig
     override fun auditRounds() = auditRounds
     override fun contestsUA(): List<ContestUnderAudit> = contestsUA
-    override fun addMvrs(mvrs: List<CvrUnderAudit>) {
-        TODO("Not yet implemented")
+    override fun setMvrsBySampleNumber(sampleNumbers: List<Long>) {
+        ballotCards.setMvrsBySampleNumber(sampleNumbers)
     }
-
     override fun ballotCards() = ballotCards
 }
 

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaWorkflow.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaWorkflow.kt
@@ -1,12 +1,8 @@
 package org.cryptobiotic.rlauxe.corla
 
-import org.cryptobiotic.rlauxe.cobra.AuditCobraAssertion
 import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.core.ContestUnderAudit
-import org.cryptobiotic.rlauxe.core.CvrUnderAudit
 import org.cryptobiotic.rlauxe.estimate.*
-import org.cryptobiotic.rlauxe.raire.RaireContestUnderAudit
-import org.cryptobiotic.rlauxe.util.*
 import org.cryptobiotic.rlauxe.workflow.*
 
 class CorlaSingleRoundAuditTaskGenerator(
@@ -102,22 +98,21 @@ class CorlaWorkflow(
         contestsUA.forEach { contest ->
             contest.makeClcaAssertions(ballotCards.cvrs)
         }
-
-        //val prng = Prng(auditConfig.seed)
-        //cvrsUA = cvrs.mapIndexed { idx, it -> CvrUnderAudit(it, idx, prng.next()) }.sortedBy{ it.sampleNumber() }
     }
 
     override fun runAudit(auditRound: AuditRound, quiet: Boolean): Boolean  {
-        return runClcaAudit(auditConfig, auditRound.contestRounds, ballotCards,
-            auditRound.roundIdx, auditor = AuditCorlaAssertion()
-        )
+        val complete = runClcaAudit(auditConfig, auditRound.contestRounds, ballotCards, auditRound.roundIdx,
+            auditor = AuditCorlaAssertion())
+        auditRound.auditWasDone = true
+        auditRound.auditIsComplete = complete
+        return complete
     }
 
     override fun auditConfig() =  this.auditConfig
     override fun auditRounds() = auditRounds
     override fun contestsUA(): List<ContestUnderAudit> = contestsUA
-    override fun addMvrs(mvrs: List<CvrUnderAudit>) {
-        TODO("Not yet implemented")
+    override fun setMvrsBySampleNumber(sampleNumbers: List<Long>) {
+        ballotCards.setMvrsBySampleNumber(sampleNumbers)
     }
 
     override fun ballotCards() = ballotCards

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/PlotDistributions.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/PlotDistributions.kt
@@ -83,7 +83,6 @@ class PlotDistributions {
         return estimateSampleSizes(
             auditConfig,
             auditRound,
-            // workflow.cvrs,
         )
     }
 

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRecord.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRecord.kt
@@ -16,9 +16,9 @@ class AuditRecord(
 
     fun ballotCards(): BallotCards {
         return if (auditConfig.isClca) {
-            BallotCardsClcaRecord(cvrsUA)
+            BallotCardsClcaRecord(cvrsUA, cvrsUA.size)
         } else {
-            BallotCardsPollingRecord(ballotsUA)
+            BallotCardsPollingRecord(ballotsUA, ballotsUA.size)
         }
     }
 
@@ -99,13 +99,16 @@ class AuditRecord(
     }
 }
 
-class BallotCardsClcaRecord(private val cvrsUA: List<CvrUnderAudit>) : BallotCardsClca {
-    var mvrsForRound: List<CvrUnderAudit> = emptyList()
+class BallotCardsClcaRecord(private val cvrsUA: Iterable<CvrUnderAudit>, val nballotCards: Int) : BallotCardsClca {
+    private var mvrsForRound: List<CvrUnderAudit> = emptyList()
 
-    override fun nballotCards() = cvrsUA.size
+    override fun nballotCards() = nballotCards
     override fun ballotCards() : Iterable<BallotOrCvr> = cvrsUA
-    override fun setMvrs(mvrsUA: List<CvrUnderAudit>) {
-        mvrsForRound = mvrsUA
+    override fun setMvrs(mvrs: List<CvrUnderAudit>) {
+        mvrsForRound = mvrs
+    }
+    override fun setMvrsBySampleNumber(sampleNumbers: List<Long>) {
+        TODO("Unimplemented")
     }
 
     override fun makeSampler(contestId: Int, cassorter: ClcaAssorterIF, allowReset: Boolean): Sampler {
@@ -126,13 +129,16 @@ class BallotCardsClcaRecord(private val cvrsUA: List<CvrUnderAudit>) : BallotCar
     }
 }
 
-class BallotCardsPollingRecord(private val ballotsUA: List<BallotUnderAudit>) : BallotCardsPolling {
+class BallotCardsPollingRecord(private val ballotsUA: Iterable<BallotUnderAudit>, val nballotCards: Int) : BallotCardsPolling {
     var mvrsForRound: List<CvrUnderAudit> = emptyList()
 
-    override fun nballotCards() = ballotsUA.size
+    override fun nballotCards() = nballotCards
     override fun ballotCards() : Iterable<BallotOrCvr> = ballotsUA
-    override fun setMvrs(mvrsUA: List<CvrUnderAudit>) {
-        mvrsForRound = mvrsUA
+    override fun setMvrs(mvrs: List<CvrUnderAudit>) {
+        mvrsForRound = mvrs
+    }
+    override fun setMvrsBySampleNumber(sampleNumbers: List<Long>) {
+        TODO("Unimplemented")
     }
 
     override fun makeSampler(contestId: Int, assorter: AssorterIF, allowReset: Boolean): Sampler {

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/audit/PersistentWorkflow.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/audit/PersistentWorkflow.kt
@@ -38,8 +38,8 @@ class PersistentWorkflow(
     override fun auditConfig() =  this.auditConfig
     override fun auditRounds() = auditRounds
     override fun contestsUA(): List<ContestUnderAudit> = contestsUA
-    override fun addMvrs(mvrs: List<CvrUnderAudit>) {
-        ballotCards.setMvrs(mvrs)
+    override fun setMvrsBySampleNumber(sampleNumbers: List<Long>) {
+        ballotCards.setMvrsBySampleNumber(sampleNumbers)
     }
 
     override fun ballotCards() = ballotCards


### PR DESCRIPTION
Add setMvrsBySampleNumber() to BallotCards and WorkflowXXX.
BallotCardsXXRecord uses Iterable<Cvr>
Annotate EstimateSampleSize.kt
var AuditRound.auditWasDone.
improve TestClcaWorkflow, runWorkflow() and debug messages.
compareEstimationSimulation() before and after refactor.