### PR TITLE
SanFrancisco 2024 primary one audit preparation

### DIFF
--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Contest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Contest.kt
@@ -296,7 +296,7 @@ open class ContestUnderAudit(
     }
 
     open fun recountMargin(): Double {
-        var pct = 1.0
+        var pct = -1.0
         val minAssertion: Assertion = minAssertion() ?: return pct
         if (contest is Contest) {
             val votes = contest.votes

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
@@ -81,3 +81,8 @@ data class CvrUnderAudit (val cvr: Cvr, val index: Int, val sampleNum: Long): Ba
         votes.forEach { (key, value) -> append(" $key: ${value.contentToString()}")}
     }
 }
+
+class CvrIteratorAdapter(val cvrIterator: Iterator<CvrUnderAudit>) : Iterator<Cvr> {
+    override fun hasNext() = cvrIterator.hasNext()
+    override fun next() = cvrIterator.next().cvr
+}

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/IrvContestVotes.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/IrvContestVotes.kt
@@ -1,0 +1,81 @@
+package org.cryptobiotic.rlauxe.raire
+
+import org.cryptobiotic.rlauxe.core.*
+
+data class IrvContestVotes(val irvContestInfo: ContestInfo) {
+    // The candidate Ids must from 0 ... ncandidates-1, for Raire; use the ordering from ContestInfo.candidateIds
+    val candidateIdMap = irvContestInfo.candidateIds.mapIndexed { idx, candidateId -> Pair(candidateId, idx) }.toMap()
+    val vc = VoteConsolidator()
+    var countBallots = 0
+
+    init {
+        require(irvContestInfo.choiceFunction == SocialChoiceFunction.IRV)
+    }
+
+    fun addVote(votes: IntArray) {
+        val mappedVotes = votes.map { candidateIdMap[it]!! }
+        vc.addVote(mappedVotes.toIntArray())
+    }
+}
+
+fun makeIrvContestVotes(irvContests: Map<Int, ContestInfo>, cvrIter: Iterator<Cvr>): Map<Int, IrvContestVotes> {
+    val irvVotes = mutableMapOf<Int, IrvContestVotes>()
+
+    println("makeIrvContestVotes")
+    var count = 0
+    while (cvrIter.hasNext()) {
+        val cvr: Cvr = cvrIter.next()
+        cvr.votes.forEach { (contestId, choiceIds) ->
+            if (irvContests.contains(contestId)) {
+                val irvContest = irvContests[contestId]!!
+                val irvVote = irvVotes.getOrPut(contestId) { IrvContestVotes(irvContest) }
+                irvVote.countBallots++
+                if (!choiceIds.isEmpty()) {
+                    irvVote.addVote(choiceIds)
+                }
+                count++
+                if (count % 10000 == 0) print("$count ")
+                if (count % 100000 == 0) println()
+            }
+        }
+    }
+    println(" read ${count} cvrs")
+    return irvVotes
+}
+
+fun makeIrvContests(contestInfos: List<ContestInfo>, contestVotes: Map<Int, IrvContestVotes>): List<RaireContestUnderAudit> {
+    val contests = mutableListOf<RaireContestUnderAudit>()
+    contestInfos.forEach { info: ContestInfo ->
+        val irvContestVotes = contestVotes[info.id]
+        if (irvContestVotes == null) {
+            println("*** Cant find contest '${info.id}' in irvContestVotes")
+        } else {
+            // TODO undervotes
+            val rcontestUA = makeRaireContestUA(
+                info,
+                irvContestVotes.vc,
+                Nc = irvContestVotes.countBallots, // TODO get this elsewhere?
+                Np = 0,
+            )
+            contests.add(rcontestUA)
+
+            //// annotate RaireContest with IrvRounds
+
+            // The candidate Ids go from 0 ... ncandidates-1 because of Raire; use the ordering from ContestInfo.candidateIds
+            // this just makes the candidateIds the sequential indexes (0..ncandidates-1)
+            val candidateIdxs = info.candidateIds.mapIndexed { idx, candidateId -> idx }
+            val cvotes = irvContestVotes.vc.makeVotes()
+            val irvCount = IrvCount(cvotes, candidateIdxs)
+            val roundResultByIdx = irvCount.runRounds()
+
+            // now convert results back to using the real Ids:
+            val candidateIndexToId = info.candidateIds.mapIndexed { idx, candidateId -> Pair(idx, candidateId) }.toMap()
+            val roundPathsById = roundResultByIdx.ivrRoundsPaths.map { roundPath ->
+                val roundsById = roundPath.rounds.map { round -> round.convert(candidateIndexToId) }
+                IrvRoundsPath(roundsById, roundPath.irvWinner.convert(candidateIndexToId))
+            }
+            (rcontestUA.contest as RaireContest).roundsPaths.addAll(roundPathsById)
+        }
+    }
+    return contests
+}

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/IrvCountOld.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/IrvCountOld.kt
@@ -9,7 +9,7 @@ class IrvCountOld(val votes: Array<Vote>, val candidates: List<Int>) {
     val rootPath = EliminationPathOld(round, emptyList(), candidates.toSet(), votes)
 
     // return winner?
-    fun nextRoundCount(): RoundWinner {
+    fun nextRoundCount(): IrvWinners {
         round++
         return rootPath.nextRoundCount()
     }
@@ -23,7 +23,7 @@ class EliminationPathOld(startingRound: Int, startingElimination: List<Int>, sta
     val isRoot = startingElimination.isEmpty()
 
     var subpaths: List<EliminationPathOld> = emptyList()
-    var roundWinner = RoundWinner()
+    var roundWinner = IrvWinners()
 
     fun name() = if (elimination.isEmpty()) "root" else "elimPath=${elimination}"
 
@@ -65,7 +65,7 @@ class EliminationPathOld(startingRound: Int, startingElimination: List<Int>, sta
     }
 
     // return winning candidate when done
-    fun nextRoundCount(): RoundWinner {
+    fun nextRoundCount(): IrvWinners {
         if (this.roundWinner.done) return this.roundWinner
         round++
 
@@ -80,17 +80,17 @@ class EliminationPathOld(startingRound: Int, startingElimination: List<Int>, sta
             if (done) {
                 val winnerSet = mutableSetOf<Int>()
                 roundWinners.forEach { winnerSet.addAll(it.winners) }
-                return RoundWinner(true, winnerSet)
+                return IrvWinners(true, winnerSet)
             }
-            return RoundWinner()
+            return IrvWinners()
         }
     }
 
-    fun checkForWinner(): RoundWinner {
+    fun checkForWinner(): IrvWinners {
         if (subpaths.isEmpty()) {
             val down2two = viable.size == 2
             if (down2two) {
-                this.roundWinner = RoundWinner(true, findWinningCandidates())
+                this.roundWinner = IrvWinners(true, findWinningCandidates())
             }
             return this.roundWinner
 
@@ -102,7 +102,7 @@ class EliminationPathOld(startingRound: Int, startingElimination: List<Int>, sta
             if (done) {
                 val winnerSet = mutableSetOf<Int>()
                 roundWinners.forEach { winnerSet.addAll(it.winners) }
-                this.roundWinner = RoundWinner(true, winnerSet)
+                this.roundWinner = IrvWinners(true, winnerSet)
             }
             return this.roundWinner
         }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/MakeRaireContest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/MakeRaireContest.kt
@@ -13,7 +13,7 @@ import org.cryptobiotic.rlauxe.core.ContestInfo
 
 private val quiet = true
 
-fun makeRaireContest(info: ContestInfo, voteConsolidator: VoteConsolidator, Nc: Int, Np: Int): RaireContestUnderAudit {
+fun makeRaireContestUA(info: ContestInfo, voteConsolidator: VoteConsolidator, Nc: Int, Np: Int): RaireContestUnderAudit {
     val startingVotes = voteConsolidator.makeVoteList()
     val cvotes = voteConsolidator.makeVotes()
     val votes = Votes(cvotes, info.candidateIds.size)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/SimulateRaireTestData.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/SimulateRaireTestData.kt
@@ -13,7 +13,7 @@ data class SimulateRaireTestData(
     val quiet: Boolean = true
 ) {
     val ncands = contest.ncandidates
-    val ncards = min(contest.Nc, sampleLimits)
+    val ncards = if (sampleLimits > 0) min(contest.Nc, sampleLimits) else contest.Nc
 
     fun makeCvrs(): List<Cvr> {
         var count = 0

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestCompareIrvCountWithRaire.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestCompareIrvCountWithRaire.kt
@@ -14,29 +14,29 @@ import org.cryptobiotic.rlauxe.util.df
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
-class TestIrvCountOld {
+class TestCompareIrvCountWithRaire {
 
     // Need a lot of tries to be sure to get some ties
-    // @Test
+    @Test
     fun testRepeat() {
         var idx = 0
         repeat(111) {
             println("\n$idx ===================================")
-            testIrvCount()
+            testCompareIrvCountWithRaire()
             idx++
         }
     }
 
     @Test
-    fun testIrvCount() {
+    fun testCompareIrvCountWithRaire() {
         for (ncands in 3..7) {
             println("\n====================================\n")
             println("ncands=$ncands")
-            testIrvCount(ncands)
+            testCompareIrvCountWithRaire(ncands)
         }
     }
 
-    fun testIrvCount(ncands: Int) {
+    fun testCompareIrvCountWithRaire(ncands: Int) {
         val N = 20000
         val minMargin = .05
         val undervotePct = 0.0
@@ -66,18 +66,20 @@ class TestIrvCountOld {
         val cvotes = vc.makeVotes()
         val votes = Votes(cvotes, testContest.ncands)
 
-        val irvCount = IrvCountOld(cvotes, candidateIds)
+        val irvCount = IrvCount(cvotes, candidateIds)
         val rootPath = irvCount.rootPath
 
         val raireCount = candidateIds.map { votes.firstPreferenceOnlyTally(it) }
         val rlauxeCount = candidateIds.map { rootPath.candVotes[it] }
         assertEquals(raireCount, rlauxeCount)
         // println(" raireCount round $round = ${raireCount}")
-        var roundWinner = RoundWinner()
+
+        /*
+        var roundWinner = IrvWinners()
         while (!roundWinner.done) {
             round++
             println("Round $round")
-            roundWinner = irvCount.nextRoundCount()
+            roundWinner = irvCount.runRound()
 
             if (!roundWinner.done) {
                 val continuing = rootPath.viable.toIntArray()
@@ -148,5 +150,7 @@ class TestIrvCountOld {
             println("    rassertion=${rassertion}")
             rassertions.add(rassertion)
         }
+
+         */
      }
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestIrvCount.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestIrvCount.kt
@@ -1,0 +1,61 @@
+package org.cryptobiotic.rlauxe.raire
+
+import kotlin.test.Test
+
+class TestIrvCount {
+
+    // Need a lot of tries to be sure to get some double ties
+    // @Test
+    fun testRepeat() {
+        var idx = 0
+        repeat(1111) {
+            print("\n$idx ")
+            testIrvCount()
+            idx++
+        }
+    }
+
+    @Test
+    fun testIrvCount() {
+        for (ncands in 3..7) {
+            //println("\n====================================\n")
+            print("$ncands,")
+            testIrvCount(ncands)
+        }
+    }
+
+    fun testIrvCount(ncands: Int) {
+        val N = 20000
+        val minMargin = .05
+        val undervotePct = 0.0
+        val phantomPct = 0.0
+        val testContest = RaireContestTestData(
+            0,
+            ncands = ncands,
+            ncards = N,
+            minMargin = minMargin,
+            undervotePct = undervotePct,
+            phantomPct = phantomPct,
+            excessVotes = 0,
+        )
+        val candidateIds = testContest.info.candidateIds
+        val testCvrs = testContest.makeCvrs()
+
+        val vc = VoteConsolidator()
+        testCvrs.forEach { cvr ->
+            val votes = cvr.votes[testContest.info.id]
+            if (votes != null) {
+                vc.addVote(votes)
+            }
+        }
+        val cvotes = vc.makeVotes()
+        val irvCount = IrvCount(cvotes, candidateIds)
+
+        val result = irvCount.runRounds()
+        if (result.ivrRoundsPaths.size > 1) {
+            println(showIrvCountResult(result, testContest.info))
+            println()
+        }
+
+     }
+}

--- a/corla/src/main/kotlin/org/cryptobiotic/rlauxe/boulder/BoulderElectionFromCvrs.kt
+++ b/corla/src/main/kotlin/org/cryptobiotic/rlauxe/boulder/BoulderElectionFromCvrs.kt
@@ -263,7 +263,7 @@ fun createElectionFromDominionCvrs(
     minRecountMargin: Double = .01,
     auditConfigIn: AuditConfig? = null,
 ) {
-    clearDirectory(Path.of(auditDir))
+    // clearDirectory(Path.of(auditDir))
 
     val stopwatch = Stopwatch()
     val export: DominionCvrExport = readDominionCvrExport(cvrExportFile, "Boulder")
@@ -291,7 +291,7 @@ fun createElectionFromDominionCvrs(
 
     val cvrsUA = createSortedCvrs(allCvrs, auditConfig.seed)
     writeCvrsCsvFile(cvrsUA, publisher.cvrsCsvFile())
-    println("   writeCvrsCvsFile ${publisher.cvrsCsvFile()}")
+    println("   writeCvrsCvsFile ${publisher.cvrsCsvFile()} cvrs = ${allCvrs.size}")
 
     checkContestsWithCvrs(contestsUA, cvrsUA.iterator())
     checkCvrsVsSovo(contests, sovo)

--- a/corla/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCvrs.kt
+++ b/corla/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCvrs.kt
@@ -14,6 +14,8 @@ import org.cryptobiotic.rlauxe.raire.*
 import org.cryptobiotic.rlauxe.util.*
 import java.io.FileOutputStream
 
+private val quiet = false
+
 fun createSfElectionCvrs(topDir: String, castVoteRecordZip: String, manifestFile: String) {
     val stopwatch = Stopwatch()
     val outputFilename = "$topDir/cvrs.csv"
@@ -35,7 +37,7 @@ fun createSfElectionCvrs(topDir: String, castVoteRecordZip: String, manifestFile
     zipReader.tourFiles()
     outputStream.close()
     println("read $countCvrs cvrs $countFiles files took $stopwatch")
-    // read 1,641,744 cvrs 27,554 files took 58.67 s
+    println("took = $stopwatch")
 }
 
 fun createSfElectionFromCvrs(
@@ -88,8 +90,6 @@ fun createSfElectionFromCvrs(
 
     println("took = $stopwatch")
 }
-
-val quiet = false
 
 fun makeContestInfos(contestManifest: ContestManifestJson, candidateManifest: CandidateManifestJson): List<ContestInfo> {
     return contestManifest.List.map { contestM: ContestM ->

--- a/corla/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCvrsOA.kt
+++ b/corla/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCvrsOA.kt
@@ -1,0 +1,199 @@
+package org.cryptobiotic.rlauxe.sf
+
+
+import com.github.michaelbull.result.Ok
+import com.github.michaelbull.result.Result
+import com.github.michaelbull.result.unwrap
+import org.cryptobiotic.rlauxe.audit.*
+import org.cryptobiotic.rlauxe.core.*
+import org.cryptobiotic.rlauxe.dominion.DominionCvrExportJson
+import org.cryptobiotic.rlauxe.dominion.import
+import org.cryptobiotic.rlauxe.dominion.readDominionCvrJsonStream
+import org.cryptobiotic.rlauxe.oneaudit.OAContestUnderAudit
+import org.cryptobiotic.rlauxe.persist.csv.CvrCsv
+import org.cryptobiotic.rlauxe.persist.csv.publishCsv
+import org.cryptobiotic.rlauxe.persist.csv.writeCSV
+import org.cryptobiotic.rlauxe.persist.json.Publisher
+import org.cryptobiotic.rlauxe.persist.json.writeAuditConfigJsonFile
+import org.cryptobiotic.rlauxe.persist.json.writeContestsJsonFile
+import org.cryptobiotic.rlauxe.util.*
+import java.io.FileOutputStream
+
+fun createSfElectionCvrsOA(topDir: String, castVoteRecordZip: String, manifestFile: String) {
+    val cvrsOutputFilename = "$topDir/cvrs.csv"
+    val cvrsOutputStream = FileOutputStream(cvrsOutputFilename)
+    cvrsOutputStream.write(CvrCsv.header.toByteArray())
+
+    val irvIds = readContestManifestForIRV(manifestFile)
+
+    val countingContests = mutableMapOf<Int, ContestCount>()
+    val batches = mutableMapOf<String, BallotManifest>()
+    val pools = mutableMapOf<String, Pool>()
+
+    var countFiles = 0
+    var totalCards = 0
+    var countCvrs1 = 0
+    var countCvrs2 = 0
+    val zipReader = ZipReaderTour(
+        castVoteRecordZip,
+        silent = true,
+        filter = { path -> path.toString().contains("CvrExport_") },
+        visitor = { inputStream ->
+            val result: Result<DominionCvrExportJson, ErrorMessages> = readDominionCvrJsonStream(inputStream)
+            val dominionCvrs = if (result is Ok) result.unwrap()
+            else throw RuntimeException("Cannot read DominionCvrJson from stream err = $result")
+            countFiles++
+            dominionCvrs.Sessions.forEach { session ->
+                val sessionKey = "${session.TabulatorId}-${session.BatchId}"
+                val batch = batches.getOrPut(sessionKey) { BallotManifest(session.TabulatorId, session.BatchId, 0) }
+                batch.count += session.Original.Cards.size
+
+                session.Original.Cards.forEach { card ->
+                    card.Contests.forEach { contest ->
+                        val contestCount = countingContests.getOrPut(contest.Id) { ContestCount(0) }
+                        contestCount.total++
+                        val groupCount = contestCount.groupCount.getOrPut(session.CountingGroupId) { 0}
+                        contestCount.groupCount[session.CountingGroupId] = groupCount + 1
+                    }
+                    totalCards++
+                }
+
+                if (session.CountingGroupId == 2) {
+                    val cvrs = session.import(irvIds)
+                    cvrs.forEach {
+                        val cvrUA = CvrUnderAudit(it, 0, 0)
+                        cvrsOutputStream.write(writeCSV(cvrUA.publishCsv()).toByteArray()) // UTF-8
+                        countCvrs2++
+                    }
+                } else {
+                    val cvrs = session.import(irvIds)
+                    val pool = pools.getOrPut(sessionKey) { Pool() }
+                    cvrs.forEach {
+                        pool.addPooledVotes(it)
+                        countCvrs1++
+                    }
+                }
+            }
+        },
+    )
+    zipReader.tourFiles()
+    println(" createSfElectionCvrsOA $countFiles files totalCards=$totalCards group1=$countCvrs1 group2=$countCvrs2")
+    cvrsOutputStream.close()
+
+    println(" countingContests")
+    countingContests.toSortedMap().forEach { (key, value) -> println("   $key $value") }
+
+    // BallotManifest
+    val header = "    ,Tray #,Tabulator Number,Batch Number,Total Ballots,VBMCart.Cart number\n"
+    val outputFilename = "$topDir/ballotManifest.csv"
+    println(" writing to $outputFilename with ${batches.size} batches")
+    val outputStream = FileOutputStream(outputFilename)
+    outputStream.write(header.toByteArray()) // UTF-8
+    var total = 0
+    var lineNo = 0
+    val sbatches = batches.toSortedMap()
+    sbatches.values.forEach {
+        val line = "${lineNo},${lineNo+1},${it.tab},${it.batch},${it.count},${lineNo+1}\n"
+        outputStream.write(line.toByteArray())
+        lineNo++
+        total += it.count
+    }
+    outputStream.close()
+    println(" total ballotManifest = $total")
+
+    // BallotPools
+    var pcount = 0
+    val pheader = "Pool, Contest, count, candidate:nvotes, ...\n"
+    val poutputFilename = "$topDir/ballotPools.csv"
+    println(" writing to $outputFilename with ${pools.size} pools")
+    val poutputStream = FileOutputStream(poutputFilename)
+    poutputStream.write(pheader.toByteArray()) // UTF-8
+    val spools = pools.toSortedMap()
+    spools.forEach { (poolName, pool) ->
+        poutputStream.write(pool.contestLines(poolName).toByteArray())
+        pcount += pool.count
+    }
+    poutputStream.close()
+    println(" total cards in pools = $pcount")
+}
+
+class Pool() {
+    var count = 0
+    val votes = mutableMapOf<Int, MutableMap<Int, Int>>()
+    fun addPooledVotes(cvr : Cvr) {
+        count++
+        cvr.votes.forEach { (contestId, choiceIds) ->
+            val contestVotes = votes.getOrPut(contestId) { mutableMapOf() }
+            choiceIds.forEach { // TODO IRVs (is that even possible?)
+                val nvotes = contestVotes[it] ?: 0
+                contestVotes[it] = nvotes + 1
+            }
+        }
+    }
+    fun contestLines(poolName: String) = buildString {
+        votes.forEach { contestId, candidateVotes ->
+            if (!candidateVotes.isEmpty()) {
+                append("${poolName}, ${contestId}, $count, ")
+                candidateVotes.forEach { (candidateId, nvotes) -> append("$candidateId:$nvotes, ") }
+                appendLine()
+            }
+        }
+    }
+}
+
+class BallotManifest(val tab: Int, val batch: Int, var count: Int)
+class ContestCount(var total: Int) {
+    val groupCount = mutableMapOf<Int, Int>()
+    override fun toString(): String {
+        return "total=$total, groupCount=$groupCount"
+    }
+}
+
+////////////////////////////////////
+
+fun createSfElectionFromCvrsOA(
+    auditDir: String,
+    contestManifestFile: String,
+    candidateManifestFile: String,
+    cvrFile: String,
+    onlyContests: List<Int>,
+    auditConfigIn: AuditConfig? = null
+) {
+    // clearDirectory(Path.of(auditDir))
+
+    val stopwatch = Stopwatch()
+
+    val resultContestM: Result<ContestManifestJson, ErrorMessages> = readContestManifestJson(contestManifestFile)
+    val contestManifest = if (resultContestM is Ok) resultContestM.unwrap()
+    else throw RuntimeException("Cannot read ContestManifestJson from ${contestManifestFile} err = $resultContestM")
+
+    val resultCandidateM: Result<CandidateManifestJson, ErrorMessages> = readCandidateManifestJson(candidateManifestFile)
+    val candidateManifest = if (resultCandidateM is Ok) resultCandidateM.unwrap()
+    else throw RuntimeException("Cannot read CandidateManifestJson from ${candidateManifestFile} err = $resultCandidateM")
+
+    val contestInfos = makeContestInfos(contestManifest, candidateManifest)
+    println("contests = ${contestInfos.size}")
+
+    val regularVoteMap = makeRegularContestVotes(cvrFile)
+    val contests = makeRegularContests(contestInfos.filter { it.choiceFunction == SocialChoiceFunction.PLURALITY }, regularVoteMap)
+
+    // No IRV contests are allowed
+
+    val auditConfig = auditConfigIn ?: AuditConfig(
+        AuditType.ONEAUDIT, hasStyles = true, sampleLimit = 20000, riskLimit = .05,
+    )
+
+    val contestsUA = contests.filter { onlyContests.contains(it.id) }.map {
+        OAContestUnderAudit(it, isComparison=true, auditConfig.hasStyles).makeClcaAssertions()
+    }
+    // these checks may modify the contest status
+    checkContestsCorrectlyFormed(auditConfig, contestsUA)
+
+    val publisher = Publisher(auditDir)
+    writeContestsJsonFile(contestsUA, publisher.contestsFile())
+    println("   writeContestsJsonFile ${publisher.contestsFile()}")
+    writeAuditConfigJsonFile(auditConfig, publisher.auditConfigFile())
+    println("   writeAuditConfigJsonFile ${publisher.auditConfigFile()}")
+
+    println("took = $stopwatch")
+}

--- a/corla/src/test/kotlin/org/cryptobiotic/rlauxe/boulder/TestBoulderElectionFromCvrs.kt
+++ b/corla/src/test/kotlin/org/cryptobiotic/rlauxe/boulder/TestBoulderElectionFromCvrs.kt
@@ -3,7 +3,7 @@ package org.cryptobiotic.rlauxe.boulder
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
 
-class CreateBoulderElectionFromCvrs {
+class TestBoulderElectionFromCvrs {
 
     @Test
     fun testParseContestName() {

--- a/corla/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfElectionFromCvrs.kt
+++ b/corla/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfElectionFromCvrs.kt
@@ -14,13 +14,84 @@ import kotlin.test.Test
 
 class TestSfElectionFromCvrs {
 
+    // make a OneAudit from Dominion exprted CVRs, using CountingGroupId=1 as the pooled votes
+    @Test
+    fun createSF2024PoaCvrs() {
+        // write sf2024P cvr
+        val stopwatch = Stopwatch()
+        val sfDir = "/home/stormy/temp/sf2024P"
+        val zipFilename = "$sfDir/CVR_Export_20240322103409.zip"
+        val manifestFile = "$sfDir/CVR_Export_20240322103409/ContestManifest.json"
+        val topDir = "/home/stormy/temp/sf2024Poa"
+        createSfElectionCvrsOA(topDir, zipFilename, manifestFile) // write to "$topDir/cvrs.csv"
+
+        //  createSfElectionCvrsOA 8957 files totalCards=467063 group1=55810 group2=411253
+        // countingContests
+        //   1 total=176637, groupCount={2=155705, 1=20932}
+        //   2 total=19175, groupCount={2=15932, 1=3243}
+        //   3 total=4064, groupCount={2=3300, 1=764}
+        //   4 total=1314, groupCount={2=1112, 1=202}
+        //   5 total=919, groupCount={2=647, 1=272}
+        //   6 total=1092, groupCount={2=889, 1=203}
+        //   8 total=94083, groupCount={2=83709, 1=10374}
+        //   9 total=72733, groupCount={2=64285, 1=8448}
+        //   10 total=8818, groupCount={2=7304, 1=1514}
+        //   11 total=10357, groupCount={2=8628, 1=1729}
+        //   12 total=233465, groupCount={2=205536, 1=27929}
+        //   13 total=233465, groupCount={2=205536, 1=27929}
+        //   15 total=211793, groupCount={2=186075, 1=25718}
+        //   17 total=21672, groupCount={2=19461, 1=2211}
+        //   19 total=233598, groupCount={2=205717, 1=27881}
+        //   21 total=127791, groupCount={2=112879, 1=14912}
+        //   23 total=105807, groupCount={2=92838, 1=12969}
+        //   24 total=233598, groupCount={2=205717, 1=27881}
+        //   25 total=233598, groupCount={2=205717, 1=27881}
+        //   26 total=233598, groupCount={2=205717, 1=27881}
+        //   27 total=233598, groupCount={2=205717, 1=27881}
+        //   28 total=233598, groupCount={2=205717, 1=27881}
+        //   29 total=233598, groupCount={2=205717, 1=27881}
+        //   30 total=233598, groupCount={2=205717, 1=27881}
+        //   31 total=233598, groupCount={2=205717, 1=27881}
+        //   32 total=233598, groupCount={2=205717, 1=27881}
+        //   33 total=233598, groupCount={2=205717, 1=27881}
+        // writing to /home/stormy/temp/sf2024Poa/ballotManifest.csv with 8957 batches
+        // total ballotManifest = 467063
+        // writing to /home/stormy/temp/sf2024Poa/ballotManifest.csv with 2086 pools
+        // total cards in pools = 55810
+    }
+
+    @Test
+    fun createSF2024Poa() {
+        // write sf2024P cvr
+        val stopwatch = Stopwatch()
+        val sfDir = "/home/stormy/temp/sf2024P"
+        val topDir = "/home/stormy/temp/sf2024Poa"
+
+        // create sf2024 election audit
+        val auditDir = "$topDir/audit"
+        createSfElectionFromCvrsOA(
+            auditDir,
+            "$sfDir/CVR_Export_20240322103409/ContestManifest.json",
+            "$sfDir/CVR_Export_20240322103409/CandidateManifest.json",
+            "$topDir/cvrs.csv",
+            listOf(1, 2)
+        )
+
+        // create sorted cvrs
+        sortCvrs(auditDir, "$topDir/cvrs.csv", "$topDir/sortChunks")
+        mergeCvrs(auditDir, "$topDir/sortChunks") // merge to "$auditDir/sortedCvrs.csv"
+        // manually zip (TODO)
+        println("that took $stopwatch")
+    }
+
     @Test
     fun createSF2024P() {
-        // write sf2024 cvr
+        // write sf2024P cvr
         val stopwatch = Stopwatch()
+        val sfDir = "/home/stormy/temp/sf2024P"
+        val zipFilename = "$sfDir/CVR_Export_20240322103409.zip"
+        val manifestFile = "$sfDir/CVR_Export_20240322103409/ContestManifest.json"
         val topDir = "/home/stormy/temp/sf2024P"
-        val zipFilename = "$topDir/CVR_Export_20240322103409.zip"
-        val manifestFile = "$topDir/CVR_Export_20240322103409/ContestManifest.json"
         createSfElectionCvrs(topDir, zipFilename, manifestFile) // write to "$topDir/cvrs.csv"
 
         // create sf2024 election audit
@@ -34,7 +105,7 @@ class TestSfElectionFromCvrs {
 
         // create sorted cvrs
         sortCvrs(auditDir, "$topDir/cvrs.csv", "$topDir/sortChunks")
-        mergeCvrs(auditDir, "$topDir/sortChunks") // merge to "$topDir/sortedCvrs.csv"
+        mergeCvrs(auditDir, "$topDir/sortChunks") // merge to "auditDir/sortedCvrs.csv"
         // manually zip (TODO)
         println("that took $stopwatch")
     }
@@ -75,7 +146,7 @@ class TestSfElectionFromCvrs {
         )
 
         sortCvrs(auditDir, "$topDir/cvrs.csv", "$topDir/sortChunks")
-        mergeCvrs(auditDir, "$topDir/sortChunks") // merge to "$topDir/sortedCvrs.csv"
+        mergeCvrs(auditDir, "$topDir/sortChunks") // merge to "auditDir/sortedCvrs.csv"
         // manually zip (TODO)
         println("that took $stopwatch")
     }

--- a/corla/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfElectionFromCvrs.kt
+++ b/corla/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfElectionFromCvrs.kt
@@ -14,15 +14,16 @@ import kotlin.test.Test
 
 class TestSfElectionFromCvrs {
 
-    // write sf2024 cvrs
     @Test
     fun createSF2024P() {
+        // write sf2024 cvr
         val stopwatch = Stopwatch()
         val topDir = "/home/stormy/temp/sf2024P"
         val zipFilename = "$topDir/CVR_Export_20240322103409.zip"
         val manifestFile = "$topDir/CVR_Export_20240322103409/ContestManifest.json"
         createSfElectionCvrs(topDir, zipFilename, manifestFile) // write to "$topDir/cvrs.csv"
 
+        // create sf2024 election audit
         val auditDir = "$topDir/audit"
         createSfElectionFromCvrs(
             auditDir,
@@ -31,6 +32,7 @@ class TestSfElectionFromCvrs {
             "$topDir/cvrs.csv",
         )
 
+        // create sorted cvrs
         sortCvrs(auditDir, "$topDir/cvrs.csv", "$topDir/sortChunks")
         mergeCvrs(auditDir, "$topDir/sortChunks") // merge to "$topDir/sortedCvrs.csv"
         // manually zip (TODO)
@@ -136,27 +138,7 @@ data class IrvCounter(val rcontest: RaireContest) {
 }
 
 fun showIrvCount(rcontest: RaireContest, irvCount: IrvCount) {
-    var roundWinner = RoundWinner()
-    while (!roundWinner.done) {
-        roundWinner = irvCount.nextRoundCount()
-    }
-    val mult = if (roundWinner.winners.size > 1) "multipleWinenrs" else ""
-    println("winner=$roundWinner} $mult")
-
-    irvCount.rounds.forEachIndexed { idx, round -> println("round=$idx $round") }
-
-    print(sfn("round", 30))
-    repeat(irvCount.rounds.size) { print("${nfn(it,8)} ") }
-    println()
-
-    rcontest.info.candidateNames.forEach { (name, candId) ->
-        print(sfn(name, 30))
-        irvCount.rounds.forEachIndexed { idx, round ->
-            print("${nfn(round.countFor(candId),8)} ")
-        }
-        if (roundWinner.winners.contains(candId)) { print(" (winner)")}
-        println()
-    }
-
+    val roundResult = irvCount.runRounds()
+    println(showIrvCountResult(roundResult, rcontest.info))
     println("================================================================================================\n")
 }

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/ContestJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/ContestJson.kt
@@ -79,7 +79,7 @@ data class ContestIFJson(
     val winners: List<Int>?,
     val Nc: Int,
     val Np: Int,
-    val irvRounds: List<IrvRoundJson>? = null,
+    val irvRoundsPaths: List<IrvRoundsPathJson>? = null,
 )
 
 fun ContestIF.publishJson() : ContestIFJson {
@@ -100,7 +100,7 @@ fun ContestIF.publishJson() : ContestIFJson {
                 this.winners,
                 this.Nc,
                 this.Np,
-                this.rounds.map { it.publishJson() },
+                this.roundsPaths.map { it.publishJson() },
             )
         else -> throw RuntimeException("unknown assorter type ${this.javaClass.simpleName} = $this")
     }
@@ -122,8 +122,8 @@ fun ContestIFJson.import(info: ContestInfo): ContestIF {
                 this.Nc,
                 this.Np,
             )
-            if (this.irvRounds != null) {
-                rcontest.rounds.addAll(this.irvRounds.map { it.import() })
+            if (this.irvRoundsPaths != null) {
+                rcontest.roundsPaths.addAll(this.irvRoundsPaths.map { it.import() })
             }
             rcontest
         }
@@ -131,19 +131,26 @@ fun ContestIFJson.import(info: ContestInfo): ContestIF {
     }
 }
 
-
+// TODO multiple paths
 @Serializable
-data class IrvRoundJson(
-    val count: Map<Int, Int>
+data class IrvRoundsPathJson(
+    val rounds: List<Map<Int, Int>>,
+    val done: Boolean,
+    val winners: Set<Int>,
 )
 
-// val elim: List<Int>, val count: Map<Int, Int>
-fun IrvRound.publishJson() = IrvRoundJson(
-    this.count,
+// IrvRoundsPath(val rounds: List<IrvRound>, val irvWinner: IrvWinners)
+// IrvRound(val count: Map<Int, Int>)
+// IrvWinners(val done:Boolean = false, val winners: Set<Int> = emptySet())
+fun IrvRoundsPath.publishJson() = IrvRoundsPathJson(
+    this.rounds.map { round -> round.count }, // List<Map<Int, Int>>
+    this.irvWinner.done,
+    this.irvWinner.winners,
 )
 
-fun IrvRoundJson.import() = IrvRound(
-    this.count,
+fun IrvRoundsPathJson.import() = IrvRoundsPath(
+    this.rounds.map { count -> IrvRound(count) },
+    IrvWinners(this.done, this.winners),
 )
 
 // open class ContestUnderAudit(

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRlaRoundCli.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRlaRoundCli.kt
@@ -26,7 +26,7 @@ class TestRunRlaRoundCli {
 
     @Test
     fun testRrunBoulder() {
-        val topdir = "/home/stormy/temp/persist/runBoulder24"
+        val topdir = "/home/stormy/temp/persist/runBoulder23"
 
         RunRliRoundCli.main(
             arrayOf(


### PR DESCRIPTION
generalize making RaireContestUnderAudit with makeIrvContests()
CvrIteratorAdapter()
generalize IrvRounds with IrvRoundsPath, in case of multiple Elimination paths.