### PR TITLE
cleanup, annotate core classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **RLAUXE ("relax")**
 
 WORK IN PROGRESS
-_last changed: 04/07/2026_
+_last changed: 04/17/2026_
 
 A port of Philip Stark's SHANGRLA framework and related code to kotlin, 
 for the purpose of making a reusable and maintainable library.
@@ -13,6 +13,7 @@ Click on plot images to get an interactive html plot. You can also read this doc
 **Table of Contents**
 <!-- TOC -->
 * [Audit Workflow](#audit-workflow)
+  * [Estimation](#estimation)
 * [SHANGRLA framework](#shangrla-framework)
   * [Assorters and supported SocialChoices](#assorters-and-supported-socialchoices)
     * [Plurality](#plurality)
@@ -29,7 +30,7 @@ Click on plot images to get an interactive html plot. You can also read this doc
   * [Samples needed when there are errors](#samples-needed-when-there-are-errors)
   * [Effect of Phantoms on Samples needed](#effect-of-phantoms-on-samples-needed)
 * [Estimating Sample Batch sizes](#estimating-sample-batch-sizes)
-  * [Estimation](#estimation)
+  * [Estimation](#estimation-1)
   * [Card Style Data](#card-style-data)
     * [Consistent Sampling with Card Style Data](#consistent-sampling-with-card-style-data)
     * [Uniform Sampling without Card Style Data](#uniform-sampling-without-card-style-data)
@@ -179,6 +180,9 @@ Notes
 Also known as Ranked Choice Voting, this allows voters to rank their choices by preference.
 In each round, the candidate with the fewest first-preferences (among the remaining candidates) is eliminated. 
 This continues until only one candidate is left.
+
+Currently we only support IRV with CLCA audits. In principle one could use polling audits for IRV, but the information
+needed to create the RaireAssertions all but necessitates CVRs.
 
 We use the [RAIRE java library](https://github.com/DemocracyDevelopers/raire-java) to generate IRV assertions 
 that fit into the SHANGRLA framewok, and makes IRV contests amenable to risk limiting auditing, just like plurality contests.

--- a/README.md
+++ b/README.md
@@ -181,8 +181,9 @@ Also known as Ranked Choice Voting, this allows voters to rank their choices by 
 In each round, the candidate with the fewest first-preferences (among the remaining candidates) is eliminated. 
 This continues until only one candidate is left.
 
-Currently we only support IRV with CLCA audits. In principle one could use polling audits for IRV, but the information
+In principle one could use polling audits for IRV, but the information
 needed to create the RaireAssertions all but necessitates CVRs.
+So currently we only support IRV with CLCA audits.
 
 We use the [RAIRE java library](https://github.com/DemocracyDevelopers/raire-java) to generate IRV assertions 
 that fit into the SHANGRLA framewok, and makes IRV contests amenable to risk limiting auditing, just like plurality contests.

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCardsOA.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCardsOA.kt
@@ -243,7 +243,7 @@ fun createSfElectionFromCardsOA(
             val pools = ballotPools.filter { it.contest == info.id }.associateBy { it.id }
             val contestOA = OneAuditContest(info, contestVotes.votes, contestVotes.countBallots, pools)
             println(contestOA)
-            contestsUA.add(OAContestUnderAudit(contestOA, isComparison = true, auditConfig.hasStyles).makeClcaAssertions())
+            contestsUA.add(OAContestUnderAudit(contestOA, auditConfig.hasStyles).makeClcaAssertions())
         }
     }
     // these checks may modify the contest status

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditConfig.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditConfig.kt
@@ -7,7 +7,7 @@ enum class AuditType { POLLING, CLCA, ONEAUDIT }
 
 data class AuditConfig(
     val auditType: AuditType,
-    val hasStyles: Boolean,
+    val hasStyles: Boolean, // has Card Style Data (CSD), i.e. we know which contests each card/ballot contains
     val riskLimit: Double = 0.05,
     val seed: Long = secureRandom.nextLong(), // determines sample order. set carefully to ensure truly random.
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRound.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRound.kt
@@ -60,7 +60,7 @@ data class ContestRound(val contestUA: ContestUnderAudit, val assertionRounds: L
 
     var done = false
     var included = true
-    var status = contestUA.status
+    var status = contestUA.preAuditStatus
 
     init {
         if (status.complete) {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCard.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCard.kt
@@ -2,11 +2,6 @@ package org.cryptobiotic.rlauxe.audit
 
 import org.cryptobiotic.rlauxe.core.Cvr
 
-// PS email 3/27/25. I think this is the case when theres no style info for the pooled cards
-// With ONEAudit, things get more complicated because you have to start by adding every contest that appears on any card
-// in a tally batch to every card in that tally batch and increase the upper bound on the number of cards in
-// the contest appropriately. That's in the SHANGRLA codebase.
-
 data class AuditableCard (
     val desc: String, // info to find the card for a manual audit. Part of the info the Prover commits to before the audit.
     val index: Int,  // index into the original, canonical (committed-to) list of cards

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CardLocationManifest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CardLocationManifest.kt
@@ -1,12 +1,15 @@
 package org.cryptobiotic.rlauxe.audit
 
-// used for polling audits
+// used for polling audits using List<CardLocation> instead of List<Cvr>
+// AuditableCard serializes both, adding the original index in the manifest and the prn.
 data class CardLocationManifest(
     val cardLocations: List<CardLocation>,
     val cardStyles: List<CardStyle> // empty if style info not available
 )
 
-// if hasStyles, has cardStyle or contestIds, otherwise both are null
+// if hasStyles, then either cardStyle or contestIds is non null, otherwise both are null
+// essentially, CardStyle factors out the contestIds, which the CardLocation references
+// so its a form of normalization
 data class CardLocation(
     val id: String,
     val phantom: Boolean = false,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Assertion.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Assertion.kt
@@ -32,7 +32,6 @@ open class Assertion(
         appendLine(" contestInfo: $info")
         appendLine(" assorter: ${assorter.desc()}")
     }
-
 }
 
 class ClcaAssertion(

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ClcaAssorter.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ClcaAssorter.kt
@@ -159,12 +159,4 @@ open class ClcaAssorter(
         result = 31 * result + assorter.hashCode()
         return result
     }
-
 }
-
-// ONEAUDIT p 9
-// This algorithm be made more efficient statistically and logistically in a variety
-//of ways, for instance, by making an affine translation of the data so that the
-//minimum possible value is 0 (by subtracting the minimum of the possible over-
-//statement assorters across batches and re-scaling so that the null mean is still
-//1/2)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
@@ -1,7 +1,8 @@
 package org.cryptobiotic.rlauxe.core
 
-// TODO immutable except for the IntArray (!)
-// assumes that a vote is 0 or 1. compact form might be List<Pair<contestId, candidateId>>
+// TODO immutable except for the IntArray (!) Consider https://github.com/daniel-rusu/pods4k/tree/main/immutable-arrays
+// assumes that a vote is 0 or 1.
+// compact form in AuditableCard is (contests: IntArray, val votes: List<IntArray>?)
 data class Cvr(
     val id: String,
     val votes: Map<Int, IntArray>, // contest -> list of candidates voted for; for IRV, ranked first to last

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/RiskTestingFn.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/RiskTestingFn.kt
@@ -2,13 +2,15 @@ package org.cryptobiotic.rlauxe.core
 
 // NOTE: contest status is min rank of assertions
 enum class TestH0Status(val rank: Int, val complete: Boolean, val success: Boolean) {
+    // starting state
     InProgress(0,false, false),
 
-    // contest status
+    // "pre-audit" contest status
     NoLosers(1,true, true),  // no losers, ie ncandidates <= nwinners
     ContestMisformed(2,true, false), // Contest incorrectly formed
     MinMargin(3,true, false), // margin too small for RLA to efficiently work
     TooManyPhantoms(4,true, false), // too many phantoms, makes margin < 0
+
     FailMaxSamplesAllowed(5,true, false),  // estimated samples greater than maximum samples allowed
     AuditorRemoved(6,true, false),  // auditor decide to remove it
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/EstimateSampleSize.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/EstimateSampleSize.kt
@@ -5,7 +5,7 @@ import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.oneaudit.OAContestUnderAudit
 import org.cryptobiotic.rlauxe.oneaudit.makeTestCvrs
 import org.cryptobiotic.rlauxe.raire.RaireContest
-import org.cryptobiotic.rlauxe.raire.SimulateRaireTestData
+import org.cryptobiotic.rlauxe.raire.SimulateIrvTestData
 import org.cryptobiotic.rlauxe.util.df
 import org.cryptobiotic.rlauxe.util.margin2mean
 import org.cryptobiotic.rlauxe.util.makeDeciles
@@ -94,7 +94,7 @@ fun makeEstimationTasks(
         AuditType.CLCA -> {
             // Simulation of Contest that reflects the exact votes and Nc, along with undervotes and phantoms, as specified in Contest.
             if (contest.isIRV()) {
-                SimulateRaireTestData(contest as RaireContest, contestRound.contestUA.minMargin(), auditConfig.sampleLimit).makeCvrs()
+                SimulateIrvTestData(contest as RaireContest, contestRound.contestUA.minMargin(), auditConfig.sampleLimit).makeCvrs()
             } else {
                 ContestSimulation.makeContestWithLimits(contest as Contest, auditConfig.sampleLimit).makeCvrs()
             }
@@ -255,12 +255,11 @@ fun simulateSampleSizeClcaAssorter(
     }
 
     // optional fuzzing of the cvrs
-    // TODO without Optimal strategy, the bettingFn is the same
+    val isIrvFzz = (contest.isIRV() && clcaConfig.simFuzzPct != null)
     val (sampler: Sampler, bettingFn: BettingFn) = if (errorRates != null && !errorRates.areZero()) {
-        val irvFuzz = (contest.isIRV() && clcaConfig.simFuzzPct != null)
-        if (irvFuzz) fuzzPct = clcaConfig.simFuzzPct!! // TODO
+        if (isIrvFzz) fuzzPct = clcaConfig.simFuzzPct!!
         Pair(
-            if (irvFuzz) ClcaFuzzSampler(clcaConfig.simFuzzPct!!, cvrs, contest, cassorter)
+            if (isIrvFzz) ClcaFuzzSampler(clcaConfig.simFuzzPct!!, cvrs, contest, cassorter)
             else ClcaSimulation(cvrs, contest, cassorter, errorRates), // TODO why cant we use this with IRV??
             AdaptiveBetting(Nc = contest.Nc, a = cassorter.noerror(), d = clcaConfig.d, errorRates = errorRates)
         )

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/IrvCount.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/IrvCount.kt
@@ -8,6 +8,9 @@ import kotlin.collections.getOrPut
 
 private val quiet = true
 
+// recreate raire's elimination paths, so that we can display to the user
+
+// this is called from Viewer in "Show Contest" for IRV
 fun showIrvCountResult(result: IrvCountResult, info: ContestInfo) = buildString {
     val multipleRounds = result.ivrRoundsPaths.size > 1
 
@@ -32,7 +35,7 @@ fun showIrvCountResult(result: IrvCountResult, info: ContestInfo) = buildString 
     }
 }
 
-// one for each round, in order
+// one for each round, in order, for one elimination path
 data class IrvRoundsPath(val rounds: List<IrvRound>, val irvWinner: IrvWinners)
 
 data class IrvRound(val count: Map<Int, Int>) { // count is candidate -> nvotes for one round
@@ -45,6 +48,7 @@ data class IrvRound(val count: Map<Int, Int>) { // count is candidate -> nvotes 
     }
 }
 
+// there may be multiple paths through the elimination tree when there are ties
 data class IrvCountResult(val ivrRoundsPaths: List<IrvRoundsPath>)
 
 data class IrvWinners(val done:Boolean = false, val winners: Set<Int> = emptySet()) {
@@ -69,12 +73,6 @@ class IrvCount(val votes: Array<Vote>, val candidates: List<Int>) {
         }
         return IrvCountResult(rootPath.paths(emptyList()))
     }
-
-    /* alternate, lower level API for testing
-    fun runRound(): IrvCountWinners {
-        if (rootPath.roundWinner.done) return rootPath.roundWinner
-        return rootPath.nextRoundCount()
-    } */
 }
 
 class EliminationPath(startingRound: Int, startingElimination: List<Int>, startingViable: Set<Int>, val votes: Array<Vote>) {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/MakeRaireContest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/MakeRaireContest.kt
@@ -51,7 +51,7 @@ fun makeRaireContestUA(info: ContestInfo, voteConsolidator: VoteConsolidator, Nc
         val votes = if (aand.assertion is NotEliminatedNext) {
             val nen = (aand.assertion as NotEliminatedNext)
             val voteSeq = VoteSequences.eliminate(startingVotes, nen.continuing.toList())
-            val nenChoices = voteSeq.nenChoices(nen.winner, nen.loser)
+            val nenChoices = voteSeq.nenFirstChoices(nen.winner, nen.loser)
             val margin = voteSeq.margin(nen.winner, nen.loser, nenChoices)
             // println("    nenChoices = $nenChoices margin=$margin\n")
             require(aand.margin == margin)
@@ -60,7 +60,7 @@ fun makeRaireContestUA(info: ContestInfo, voteConsolidator: VoteConsolidator, Nc
         } else {
             val neb = (aand.assertion as NotEliminatedBefore)
             val voteSeq = VoteSequences(startingVotes)
-            val nebChoices = voteSeq.nebChoices(neb.winner, neb.loser)
+            val nebChoices = voteSeq.nebFirstChoices(neb.winner, neb.loser)
             val margin = voteSeq.margin(neb.winner, neb.loser, nebChoices)
             // println("    nebChoices = $nebChoices margin=$margin\n")
             require(aand.margin == margin)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/SimulateIrvTestData.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/SimulateIrvTestData.kt
@@ -6,7 +6,7 @@ import kotlin.math.min
 import kotlin.random.Random
 
 // called from estimateSampleSize
-data class SimulateRaireTestData(
+data class SimulateIrvTestData(
     val contest: RaireContest,
     val minMargin: Double,
     val sampleLimits: Int,
@@ -61,7 +61,6 @@ data class SimulateRaireTestData(
     }
 
     override fun toString() = buildString {
-        append("SimulateRaireTestData(${contest.id}, undervotePct=${df(contest.undervoteRate())}")
-        append(" phantomPct=${df(contest.phantomRate())} ncards=${ncards}")
+        append("SimulateRaireTestData(${contest.id}} phantomPct=${df(contest.phantomRate())} ncards=${ncards}")
     }
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/VoteConsolidator.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/VoteConsolidator.kt
@@ -4,6 +4,7 @@ import au.org.democracydevelopers.raire.irv.Vote
 import kotlin.collections.getOrPut
 
 /**
+ * Adapted from au.org.democracydevelopers.raire.util.VoteConsolidator
  * For a single Contest.
  *
  * A utility class for building an array of Vote[] structures
@@ -33,12 +34,12 @@ class VoteConsolidator {
     }
 }
 
-// Used to calculate the margin and assertion-specific votes
+// Added here because I want to show the runoff stages, embodied in nenFirstChoices() and nebFirstChoices()
 // TODO the candidate Ids go from 0 ... ncandidates-1
 data class VoteList(val n: Int, val candRanks: List<Int>)
 data class VoteSequences(val votes: List<VoteList>) {
 
-    fun nenChoices(winner: Int, loser: Int): Map<Int, Int> {
+    fun nenFirstChoices(winner: Int, loser: Int): Map<Int, Int> {
         val firstChoices = mutableMapOf<Int, Int>()
         votes.forEach { vote ->
             if (vote.candRanks.isNotEmpty()) {
@@ -57,15 +58,8 @@ data class VoteSequences(val votes: List<VoteList>) {
         return winnerVotes - loserVotes
     }
 
-
-    /** Compute and return the difficulty estimate associated with this assertion. This method
-     * computes the minimum tally of the assertion's winner (its first preference tally) and the
-     * maximum tally of the assertion's loser, according to the given set of Votes (votes). This
-     * maximum tally contains all votes that preference the loser higher than the winner, or on
-     * which the loser appears and the winner does not. The given AuditType, audit, defines the
-     * chosen method of computing assertion difficulty given these winner and loser tallies.*/
-    fun nebChoices(winner: Int, loser: Int): Map<Int, Int> {
-        val firstChoices = nenChoices(winner, loser)
+    fun nebFirstChoices(winner: Int, loser: Int): Map<Int, Int> {
+        val firstChoices = nenFirstChoices(winner, loser)
         val minWinner = firstChoices[winner] ?: 0
         var maxLoser = 0
         votes.forEach { vote ->
@@ -93,6 +87,7 @@ data class VoteSequences(val votes: List<VoteList>) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+// Adapted from au.org.democracydevelopers.raire.util.VoteConsolidator
 /** A wrapper around int[] that works as a key in a hash map  */
 private class HashableIntArray(val array: IntArray) {
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestContest.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestContest.kt
@@ -129,11 +129,11 @@ class TestContest {
         assertEquals(contest.hashCode(), contest2.hashCode())
 
         assertEquals("testContestInfo (0) Nc=211 Np=1 votes={1=108, 0=100, 2=0}", contest.toString())
-        assertEquals("Contest(info='testContestInfo' (0) candidates={cand0=0, cand1=1, cand2=2}, Nc=211, Np=1, id=0, name='testContestInfo', choiceFunction=PLURALITY, ncandidates=3, votes={1=108, 0=100, 2=0}, winnerNames=[cand1], winners=[1], losers=[0, 2], undervotes=2)",
+        assertEquals("Contest(info='testContestInfo' (0) candidates={cand0=0, cand1=1, cand2=2}, Nc=211, Np=1, id=0, name='testContestInfo', choiceFunction=PLURALITY, ncandidates=3, votes={1=108, 0=100, 2=0}, winnerNames=[cand1], winners=[1], losers=[0, 2])",
             contest.show())
 
 
-        assertEquals((211-208-1)/211.toDouble(), contest.undervoteRate())
+        // assertEquals((211-208-1)/211.toDouble(), contest.undervoteRate())
         assertEquals(1/211.toDouble(), contest.phantomRate())
     }
 
@@ -164,7 +164,7 @@ class TestContest {
         assertEquals(expectedShowCandidates, contestUAc.showCandidates())
 
         val expectedShow = """'testContestInfo' (0) votes={1=108, 0=100, 2=0}
- margin=0.0379 recount=0.0741 Nc=211 Np=0 Nu=3
+ margin=0.0379 recount=0.0741 Nc=211 Np=0
  choiceFunction=PLURALITY nwinners=1, winners=[1]
    0 'cand0': votes=100
    1 'cand1': votes=108

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestRaireContest.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestRaireContest.kt
@@ -33,7 +33,7 @@ class TestRaireContest {
             contest.toString()
         )
 
-        assertEquals(-1, contest.undervotes) // TODO
+        // assertEquals(-1, contest.undervotes) // TODO
         assertEquals(1/211.toDouble(), contest.phantomRate())
     }
 
@@ -58,7 +58,7 @@ class TestRaireContest {
         assertEquals(expectedShowCandidates, rcontestUA.showCandidates()) */
 
         assertTrue(rcontestUA.showShort().startsWith("rcontest111 (111) Nc=5000 winner0 losers [1, 2] minMargin="))
-        assertTrue(rcontestUA.show().contains("recount=-1.0000 Nc=5000 Np=25 Nu=-1\n choiceFunction=IRV nwinners=1, winners=[0]"))
+        assertTrue(rcontestUA.show().contains("recount=-1.0000 Nc=5000 Np=25\n choiceFunction=IRV nwinners=1, winners=[0]"))
         assertEquals(-1.0, rcontestUA.recountMargin(), doublePrecision)
     }
 

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/raire/SimulateRaireTestContest.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/raire/SimulateRaireTestContest.kt
@@ -83,7 +83,7 @@ private fun trytoMakeRaireContest(N: Int, contestId: Int, ncands:Int, minMargin:
         val votes = if (aand.assertion is NotEliminatedNext) {
             val nen = (aand.assertion as NotEliminatedNext)
             val voteSeq = VoteSequences.eliminate(startingVotes, nen.continuing.toList())
-            val nenChoices = voteSeq.nenChoices(nen.winner, nen.loser)
+            val nenChoices = voteSeq.nenFirstChoices(nen.winner, nen.loser)
             val margin = voteSeq.margin(nen.winner, nen.loser, nenChoices)
             // println("    nenChoices = $nenChoices margin=$margin\n")
             require(aand.margin == margin)
@@ -92,7 +92,7 @@ private fun trytoMakeRaireContest(N: Int, contestId: Int, ncands:Int, minMargin:
         } else {
             val neb = (aand.assertion as NotEliminatedBefore)
             val voteSeq = VoteSequences(startingVotes)
-            val nebChoices = voteSeq.nebChoices(neb.winner, neb.loser)
+            val nebChoices = voteSeq.nebFirstChoices(neb.winner, neb.loser)
             val margin = voteSeq.margin(neb.winner, neb.loser, nebChoices)
             // println("    nebChoices = $nebChoices margin=$margin\n")
             require(aand.margin == margin)

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestClcaEstimationFailure.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestClcaEstimationFailure.kt
@@ -53,7 +53,7 @@ class TestClcaEstimationFailure {
         val phantomRate = contest.phantomRate()
         val errorRates = ClcaErrorRates(0.0, phantomRate, 0.0, 0.0)
         val sampler = ClcaSimulation(cvrs, contestUA.contest, cassorter, errorRates)
-        if (debug) print(sampler.showFlips())
+        // if (debug) print(sampler.showFlips())
 
         sampler.reset()
 

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/ContestJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/ContestJson.kt
@@ -186,7 +186,7 @@ fun ContestUnderAudit.publishJson() : ContestUnderAuditJson {
         this.hasStyle,
         this.pollingAssertions.map { it.publishJson() },
         this.clcaAssertions.map { it.publishJson() },
-        this.status
+        this.preAuditStatus
     )
 }
 
@@ -199,7 +199,7 @@ fun ContestUnderAuditJson.import(): ContestUnderAudit {
     )
     contestUA.pollingAssertions = this.pollingAssertions.map { it.import(info) }
     contestUA.clcaAssertions = this.clcaAssertions.map { it.import(info) }
-    contestUA.status = this.status
+    contestUA.preAuditStatus = this.status
     return contestUA
 }
 

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/OneAuditJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/OneAuditJson.kt
@@ -82,8 +82,8 @@ fun OAContestUnderAuditJson.import(): OAContestUnderAudit {
     val contestUA = this.contestUA.import()
     val contestOA = this.contestOA.import(contestUA.contest.info)
 
-    val result = OAContestUnderAudit(contestOA, contestUA.isComparison, contestUA.hasStyle)
-    result.pollingAssertions = contestUA.pollingAssertions
+    val result = OAContestUnderAudit(contestOA, contestUA.hasStyle)
+    // result.pollingAssertions = contestUA.pollingAssertions
     result.clcaAssertions = contestUA.clcaAssertions
     return result
 }

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/RaireJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/RaireJson.kt
@@ -40,10 +40,10 @@ fun RaireContestUnderAuditJson.import(): RaireContestUnderAudit {
         raireContest as RaireContest,
         this.winner,
         this.rassertions.map { it.import() },
-        contestUA.isComparison,
+        // contestUA.isComparison,
         contestUA.hasStyle,
     )
-    result.pollingAssertions = contestUA.pollingAssertions
+    // result.pollingAssertions = contestUA.pollingAssertions
     result.clcaAssertions = contestUA.clcaAssertions
     return result
 }
@@ -74,7 +74,6 @@ data class RaireAssertionJson(
     val assertion_type: String,
     val eliminated: List<Int>,
     val votes: Map<Int, Int>,
-    val explanation: String?,
 )
 
 fun RaireAssertion.publishJson() = RaireAssertionJson(
@@ -84,7 +83,6 @@ fun RaireAssertion.publishJson() = RaireAssertionJson(
     this.assertionType.name,
     this.eliminated,
     this.votes,
-    this.explanation,
 )
 
 fun RaireAssertionJson.import(): RaireAssertion {
@@ -95,6 +93,5 @@ fun RaireAssertionJson.import(): RaireAssertion {
         RaireAssertionType.fromString(this.assertion_type),
         this.eliminated,
         this.votes,
-        this.explanation,
     )
 }

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestRaireJson.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestRaireJson.kt
@@ -52,7 +52,7 @@ class TestRaireJson {
 
         val assert1 = RaireAssertion(1, 0, 42, RaireAssertionType.winner_only)
         val assert2 = RaireAssertion(1, 2, 422, RaireAssertionType.irv_elimination,
-            listOf(2), mapOf(1 to 1, 2 to 2, 3 to 3), "some explanation")
+            listOf(2), mapOf(1 to 1, 2 to 2, 3 to 3))
 
         val target = RaireContestUnderAudit(contest, 1, listOf(assert1, assert2))
 
@@ -66,7 +66,7 @@ class TestRaireJson {
     @Test
     fun testAssertionRoundtrip() {
         val target = RaireAssertion(4, 2, 42, RaireAssertionType.irv_elimination,
-            listOf(1,3,5), mapOf(1 to 11, 2 to 22, 3 to 33),"some explanation")
+            listOf(1,3,5), mapOf(1 to 11, 2 to 22, 3 to 33))
 
         val json = target.publishJson()
         val roundtrip = json.import()
@@ -84,7 +84,7 @@ class TestRaireJson {
             candidateNames = listToMap("A", "B", "C", "D"),
         )
         val rassertion = RaireAssertion(4, 2, 42, RaireAssertionType.irv_elimination,
-            listOf(1,3,5),  mapOf(1 to 111, 2 to 222, 3 to 333), "some explanation")
+            listOf(1,3,5),  mapOf(1 to 111, 2 to 222, 3 to 333))
         val target = RaireAssorter(info, rassertion, rassertion.marginInVotes.toDouble() / 1000)
 
         val json = target.publishJson()

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/raire/RaireResultsJson.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/raire/RaireResultsJson.kt
@@ -72,7 +72,7 @@ data class RaireResultsAssertionJson(
     val loser: String,
     val assertion_type: String,
     val already_eliminated: List<String>,
-    val explanation: String?,
+    val explanation: String?,  // thiese json files have an explanation tacked on, not on the raire Assertion object I think
 )
 
 fun RaireResultsAssertionJson.import(): RaireAssertion {
@@ -83,7 +83,6 @@ fun RaireResultsAssertionJson.import(): RaireAssertion {
         RaireAssertionType.fromString(this.assertion_type),
         this.already_eliminated.map { it.toInt() },  // must invert
         emptyMap(),
-        this.explanation,
     )
 }
 

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestReadRaireBallotsCsv.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestReadRaireBallotsCsv.kt
@@ -113,14 +113,14 @@ fun tabulateRaireMargins(rcontests: List<RaireContestUnderAudit>, cvrs: List<Cvr
         rcontest.rassertions.forEach { rassertion ->
             if (rassertion.assertionType == RaireAssertionType.irv_elimination) {
                 val voteSeqElim = VoteSequences.eliminate(startingVotes, rassertion.remaining(rcontest.candidates))
-                val nenChoices = voteSeqElim.nenChoices(rassertion.winnerId, rassertion.loserId)
+                val nenChoices = voteSeqElim.nenFirstChoices(rassertion.winnerId, rassertion.loserId)
                 val margin = voteSeqElim.margin(rassertion.winnerId, rassertion.loserId, nenChoices)
                 //println("${rassertion.winnerId}, ${rassertion.loserId} == $margin")
                 assertTrue(margin > 0)
                 rassertion.marginInVotes = margin
             } else {
                 val voteSeq = VoteSequences(startingVotes)
-                val nebChoices = voteSeq.nebChoices(rassertion.winnerId, rassertion.loserId)
+                val nebChoices = voteSeq.nebFirstChoices(rassertion.winnerId, rassertion.loserId)
                 val margin = voteSeq.margin(rassertion.winnerId, rassertion.loserId, nebChoices)
                 assertTrue(margin > 0)
                 rassertion.marginInVotes = margin

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestReadRaireResultsJson.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestReadRaireResultsJson.kt
@@ -199,3 +199,9 @@ class TestReadRaireResultsJson {
         assertEquals(0.5, eassorter.assort(Cvr(contest, listOf())))
     }
 }
+
+fun RaireContestUnderAudit.makeAssorters(): List<RaireAssorter> {
+    return this.rassertions.map {
+        RaireAssorter(contest.info, it, (it.marginInVotes.toDouble() / contest.Nc))
+    }
+}


### PR DESCRIPTION
contestUA.status -> preAuditStatusremove
remove Contest.undervotes
ClcaSimulation handles IRV contests
OA, Raire are always CLCA