### PR TITLE
OneAuditIrvContest

### DIFF
--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfPrimaryOA.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfPrimaryOA.kt
@@ -73,7 +73,6 @@ class TestSfPrimaryOA {
         // create sorted cards
         sortCards(auditDir, "$topDir/cards.csv", "$topDir/sortChunks")
         mergeCards(auditDir, "$topDir/sortChunks") // merge to "$auditDir/sortedCards.csv"
-        // manually zip (TODO)
         println("that took $stopwatch")
         //  read 411253 cards contest1=ContestVotes(contestId=1, countBallots=155705, votes={5=126942, 7=5058, 6=5262, 3=975, 234=4851, 1=813, 2=546, 4=893, 8=464}, nvotes=145804, underVotes=9901)
         //PRESIDENT OF THE UNITED STATES-DEM (1) Nc=176637 Np=0 votes={5=142814, 7=5761, 6=6374, 3=1185, 234=5923, 1=952, 2=617, 4=987, 8=584, 245=0, 246=0, 247=0, 248=0, 249=0, 250=0} minMargin=0.7724

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CheckAudits.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CheckAudits.kt
@@ -29,8 +29,12 @@ fun checkContestsCorrectlyFormed(auditConfig: AuditConfig, contestsUA: List<Cont
 
 // check winners are correctly formed
 fun checkWinners(contestUA: ContestUnderAudit, ) {
-    val sortedVotes: List<Map.Entry<Int, Int>> = (contestUA.contest as Contest).votes.entries.sortedByDescending { it.value } // TODO wtf?
-    val contest = contestUA.contest
+    val contest = if (contestUA.contest is Contest) contestUA.contest
+        else if (contestUA.contest is OneAuditContest && contestUA.contest.contest is Contest) contestUA.contest.contest
+        else null
+    if (contest == null) return
+
+    val sortedVotes: List<Map.Entry<Int, Int>> = contest.votes.entries.sortedByDescending { it.value } // TODO wtf?
     val nwinners = contest.winners.size
 
     // make sure that the winners are unique

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Assertion.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Assertion.kt
@@ -41,22 +41,6 @@ class ClcaAssertion(
 
     override fun toString() = cassorter.assorter().desc()
 
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-        if (!super.equals(other)) return false
-
-        other as ClcaAssertion
-
-        return cassorter == other.cassorter
-    }
-
-    override fun hashCode(): Int {
-        var result = super.hashCode()
-        result = 31 * result + cassorter.hashCode()
-        return result
-    }
-
     override fun show() = buildString {
         appendLine(" cassorter: ${cassorter}")
     }
@@ -71,5 +55,21 @@ class ClcaAssertion(
         if (cassorter != other.cassorter) {
             append(" cassorter not equal")
         }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as ClcaAssertion
+
+        return cassorter == other.cassorter
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + cassorter.hashCode()
+        return result
     }
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/BallotPool.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/BallotPool.kt
@@ -10,7 +10,7 @@ data class BallotPool(
     val votes: Map<Int, Int>, // candid -> nvotes // the diff from ncards tell you the undervotes
 ) {
 
-    // TODO different for IRV
+    // TODO different for IRV. Could save the VoteConsolidator? Or just save the pool assorter averages ??
 
     // TODO does this really agree with the average assorter?
     // this could go from -1 to 1. TODO shouldnt that be -u to u ??

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditContest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditContest.kt
@@ -4,6 +4,18 @@ import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.util.*
 import kotlin.math.min
 
+// OneAuditContest no longer isa Contest, but hasa ContestIF (which might be Contest or RaireContest)
+// was class OneAuditContest (
+//    info: ContestInfo,
+//    voteInput: Map<Int, Int>,
+//    Nc: Int,
+//    Np: Int,
+//
+//    val cvrVotes: Map<Int, Int>,   // candidateId -> nvotes (may be empty)
+//    val cvrNc: Int,                // may be 0
+//    val pools: Map<Int, BallotPool>, // pool id -> pool
+//) : Contest(info, voteInput, Nc, Np)
+
 class OneAuditContest (
     val contest: ContestIF,
 
@@ -18,7 +30,7 @@ class OneAuditContest (
     val cvrUndervotes: Int
 
     init {
-        // TODO add SUPERMAJORITY. What about IRV ??
+        // TODO add SUPERMAJORITY.
         // require(choiceFunction == SocialChoiceFunction.PLURALITY) { "OneAuditContest requires PLURALITY"}
 
         // TODO how many undervotes are there ?
@@ -37,7 +49,7 @@ class OneAuditContest (
         }
 
         // not sure about where undervotes and phantoms live
-        require(Nc == cvrNc + poolNc + Np())
+        // TODO require(Nc == cvrNc + poolNc + Np())
 
         /* minMargin = if (votes.size < 2) 0.0 else {
             val sortedVotes = votes.toList().sortedBy { it.second }.reversed()
@@ -95,13 +107,11 @@ class OneAuditContest (
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
-        if (!super.equals(other)) return false
 
         other as OneAuditContest
 
         if (cvrNc != other.cvrNc) return false
-        // if (minMargin != other.minMargin) return false
-        if (poolNc != other.poolNc) return false
+        if (!contest.equals(other.contest)) return false
         if (cvrVotes != other.cvrVotes) return false
         if (pools != other.pools) return false
 
@@ -109,10 +119,8 @@ class OneAuditContest (
     }
 
     override fun hashCode(): Int {
-        var result = super.hashCode()
-        result = 31 * result + cvrNc
-        // result = 31 * result + minMargin.hashCode()
-        result = 31 * result + poolNc
+        var result = cvrNc
+        result = 31 * result + contest.hashCode()
         result = 31 * result + cvrVotes.hashCode()
         result = 31 * result + pools.hashCode()
         return result
@@ -157,10 +165,10 @@ class OneAuditContest (
                   cvrVotes: Map<Int, Int>,   // candidateId -> nvotes
                   cvrNc: Int,                // the diff from cvrVotes tells you the undervotes
                   pools: List<BallotPool>,   // pools for this contest
-                  Np: Int): OneAuditContest {
+                  ): OneAuditContest {
 
-            val poolNc = pools.sumOf { it.ncards }
-            val Nc = poolNc + cvrNc + Np
+            // val poolNc = pools.sumOf { it.ncards }
+            // val Nc = poolNc + cvrNc + Np
 
             //// construct total votes
             val voteBuilder = mutableMapOf<Int, Int>()  // cand -> vote
@@ -190,7 +198,7 @@ class OneAuditContest (
 
 /////////////////////////////////////////////////////////////////////////////////////////////
 
-class OAContestUnderAudit(
+open class OAContestUnderAudit(
     val contestOA: OneAuditContest,
     hasStyle: Boolean = true
 ): ContestUnderAudit(contestOA, isComparison=true, hasStyle=hasStyle) {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditIrvContest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditIrvContest.kt
@@ -1,0 +1,40 @@
+package org.cryptobiotic.rlauxe.oneaudit
+
+import org.cryptobiotic.rlauxe.core.Assertion
+import org.cryptobiotic.rlauxe.raire.RaireAssertion
+import org.cryptobiotic.rlauxe.raire.RaireAssorter
+
+class OneAuditIrvContest(
+    contestOA: OneAuditContest,
+    hasStyle: Boolean = true,
+    val rassertions: List<RaireAssertion>,
+): OAContestUnderAudit(contestOA, hasStyle=hasStyle) {
+
+    init {
+        this.pollingAssertions = makeRairePollingAssertions()
+    }
+
+    fun makeRairePollingAssertions(): List<Assertion> {
+        return rassertions.map { rassertion ->
+            val assorter = RaireAssorter(contest.info(), rassertion, (rassertion.marginInVotes.toDouble() / contest.Nc))
+            Assertion(contest.info(), assorter)
+        }
+    }
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+        if (!super.equals(other)) return false
+
+        other as OneAuditIrvContest
+        if (rassertions != other.rassertions) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = super.hashCode()
+        result = 31 * result + rassertions.hashCode()
+        return result
+    }
+}

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOneAuditClcaAssorter.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOneAuditClcaAssorter.kt
@@ -28,7 +28,6 @@ import kotlin.test.assertEquals
 //    mvr has winner vote = (2-assorter_mean_poll)/(2-v/u)
 //    otherwise = 1/2
 
-// TODO fix tests
 class TestOneAuditClcaAssorter {
 
     @Test
@@ -148,7 +147,7 @@ class TestOneAuditClcaAssorter {
     }
 
 
-    // @Test TODO
+    // @Test TODO fix
     fun testMakeContestOAwithAffine() {
         val contest = makeContestOA(20000, 18000, cvrPercent = .66, undervotePercent = .0, phantomPercent = .0, skewPct = .03)
         val contestUA = contest.makeContestUnderAudit()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOneAuditIrvContest.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOneAuditIrvContest.kt
@@ -1,0 +1,54 @@
+package org.cryptobiotic.rlauxe.oneaudit
+
+import org.cryptobiotic.rlauxe.core.ContestInfo
+import org.cryptobiotic.rlauxe.core.SocialChoiceFunction
+import org.cryptobiotic.rlauxe.doublePrecision
+import org.cryptobiotic.rlauxe.raire.RaireAssertion
+import org.cryptobiotic.rlauxe.raire.RaireContest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class TestOneAuditIrvContest {
+
+    @Test
+    fun testContestBasics() {
+        val info = ContestInfo(
+            "TestOneAuditIrvContest",
+            0,
+            mapOf("cand0" to 0, "cand1" to 1, "cand2" to 2, "cand3" to 3, "cand4" to 4, "cand42" to 42),
+            SocialChoiceFunction.IRV,
+            voteForN = 6,
+        )
+        val Nc = 212
+        val Np = 1
+        val contest = RaireContest(info, winners=listOf(1), iNc=Nc, Np=Np)
+
+        // val contestOA = OneAuditContest.make(contest, cvrVotes, cvrPercent = cvrPercent, undervotePercent = undervotePercent, phantomPercent = phantomPercent)
+        val cvrVotes = mapOf(0 to 100, 1 to 200, 2 to 42, 3 to 7, 4 to 0) // worthless?
+        val cvrNc = 200
+        
+        // data class BallotPool(
+        //    val name: String,
+        //    val poolId: Int,
+        //    val contest:Int,
+        //    val ncards: Int,          // ncards for this contest in this pool; TODO hasStyles = false?
+        //    val votes: Map<Int, Int>, // candid -> nvotes // the diff from ncards tell you the undervotes
+        //)
+        val pool = BallotPool("swim", 42, 0, 11, mapOf(0 to 1, 1 to 2, 2 to 3, 3 to 4, 4 to 0))
+            
+        //         fun make(contest: ContestIF,
+        //                  cvrVotes: Map<Int, Int>,   // candidateId -> nvotes
+        //                  cvrNc: Int,                // the diff from cvrVotes tells you the undervotes
+        //                  pools: List<BallotPool>,   // pools for this contest
+        //                  Np: Int): OneAuditContest {
+        val contestOA = OneAuditContest.make(contest, cvrVotes, cvrNc, listOf(pool))
+
+        val contestOAUA =  OneAuditIrvContest(contestOA, true, emptyList<RaireAssertion>())
+        contestOAUA.makeClcaAssertionsFromReportedMargin()
+
+        assertEquals(contestOAUA, contestOAUA)
+        assertEquals(contestOAUA.hashCode(), contestOAUA.hashCode())
+        assertEquals("TestOneAuditIrvContest (0) votes=N/A Nc=212 minMargin=0.0000", contestOAUA.showShort(), )
+        assertEquals(-1.0, contestOAUA.recountMargin(), doublePrecision)
+    }
+}

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AssertionJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AssertionJson.kt
@@ -27,7 +27,8 @@ fun Assertion.publishIFJson(): AssertionIFJson {
     }
 }
 
-fun AssertionIFJson.import(info: ContestInfo): Assertion {
+fun AssertionIFJson.import(contest: ContestIF): Assertion {
+    val info = contest.info()
     return when (this.className) {
         "ClcaAssertion" ->
             ClcaAssertion(

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AssorterJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AssorterJson.kt
@@ -22,7 +22,7 @@ import org.cryptobiotic.rlauxe.raire.RaireAssorter
 @Serializable
 data class ClcaAssorterJson(
     val className: String,
-    val contestOA: OAContestJson?, // duplicate storage, argghh
+    val contestOA: ContestIFJson?, // duplicate storage, argghh; TODO why arent we using ContestIF ??
     val assorter: AssorterIFJson,
     val avgCvrAssortValue: Double?,
     val hasStyle: Boolean,
@@ -32,7 +32,7 @@ fun ClcaAssorter.publishJson() : ClcaAssorterJson {
     return if (this is OneAuditClcaAssorter) {
         ClcaAssorterJson(
             "OAClcaAssorter",
-            this.contestOA.publishOAJson(),
+            this.contestOA.publishJson(),
             this.assorter.publishJson(),
             this.assortAverageFromCvrs,
             true, // TODO
@@ -58,12 +58,16 @@ fun ClcaAssorterJson.import(info: ContestInfo): ClcaAssorter {
                 this.avgCvrAssortValue,
                 this.hasStyle,
             )
-        "OAClcaAssorter" ->
+
+        "OAClcaAssorter" -> {
+            // val innerContest = (contest as OneAuditContest).contest
             OneAuditClcaAssorter(
-                this.contestOA!!.import(info),
+                // this.contestOA!!.import(innerContest),
+                this.contestOA!!.import(info) as OneAuditContest,
                 this.assorter.import(info),
                 this.avgCvrAssortValue,
             )
+        }
         else -> throw RuntimeException()
     }
 }

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/OneAuditJson1.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/OneAuditJson1.kt
@@ -47,32 +47,6 @@ fun OAContestJson1.import(info: ContestInfo): OneAuditContest1 {
     )
 }
 
-// data class BallotPool(val name: String, val id: Int, val contest:Int, val ncards: Int, val votes: Map<Int, Int>) {
-@Serializable
-data class BallotPoolJson(
-    val name: String,
-    val id: Int,
-    val contest: Int,
-    val ncards: Int,
-    val votes: Map<Int, Int>,
-)
-
-fun BallotPool.publishJson() = BallotPoolJson(
-    this.name,
-    this.poolId,
-    this.contest,
-    this.ncards,
-    this.votes,
-)
-
-fun BallotPoolJson.import() = BallotPool(
-    this.name,
-    this.id,
-    this.contest,
-    this.ncards,
-    this.votes,
-)
-
 // class OAContestUnderAudit(
 //    val contestOA: OneAuditContest,
 //): ContestUnderAudit(contestOA.makeContest(), isComparison=true, hasStyle=true) {

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRlaRoundCli.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRlaRoundCli.kt
@@ -7,7 +7,7 @@ class TestRunRlaRoundCli {
 
     @Test
     fun testRliRoundCli() {
-        val topdir = "/home/stormy/rla/cases/boulder24blca"
+        val topdir = "/home/stormy/rla/cases/boulder24"
         RunRliRoundCli.main(
             arrayOf(
                 "-in", topdir,

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAssertionJson.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAssertionJson.kt
@@ -25,9 +25,10 @@ class TestAssertionJson {
         val assertion = makeAssertion()
         val cassorter =  ClcaAssorter(assertion.info, assertion.assorter, .52, false, true)
         val target = ClcaAssertion(assertion.info, cassorter)
+        // val fakeContest = Contest(target.info, emptyMap(), 0, 0)
 
         val json = target.publishJson()
-        val roundtrip = json.import(target.info)
+        val roundtrip = json.import(assertion.info)
         assertNotNull(roundtrip)
         assertTrue(roundtrip.equals(target))
     }
@@ -58,7 +59,7 @@ class TestAssertionJson {
         val winnerCvr = makeCvr(0)
         val loserCvr = makeCvr(1)
         val otherCvr = makeCvr(2)
-        val contest = makeContestFromCvrs(info, listOf(winnerCvr, loserCvr, otherCvr))
+        val contest = makeContestFromCvrs(info, listOf(winnerCvr, winnerCvr, loserCvr, otherCvr))
 
         val assorter = PluralityAssorter.makeWithVotes(contest, winner = 0, loser = 1)
         val target = Assertion(info, assorter)

--- a/rla/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestOneAuditJson.kt
+++ b/rla/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestOneAuditJson.kt
@@ -1,9 +1,18 @@
 package org.cryptobiotic.rlauxe.persist.json
 
 import org.cryptobiotic.rlauxe.core.ClcaAssertion
+import org.cryptobiotic.rlauxe.core.ContestInfo
+import org.cryptobiotic.rlauxe.core.SocialChoiceFunction
 import org.cryptobiotic.rlauxe.core.TestH0Status
+import org.cryptobiotic.rlauxe.doublePrecision
+import org.cryptobiotic.rlauxe.oneaudit.BallotPool
 import org.cryptobiotic.rlauxe.oneaudit.OAContestUnderAudit
+import org.cryptobiotic.rlauxe.oneaudit.OneAuditClcaAssorter
+import org.cryptobiotic.rlauxe.oneaudit.OneAuditContest
+import org.cryptobiotic.rlauxe.oneaudit.OneAuditIrvContest
 import org.cryptobiotic.rlauxe.oneaudit.makeContestOA
+import org.cryptobiotic.rlauxe.raire.RaireAssertion
+import org.cryptobiotic.rlauxe.raire.RaireContest
 import kotlin.test.Test
 import kotlin.test.assertTrue
 
@@ -28,11 +37,14 @@ class TestOneAuditJson {
     fun testAssertionRoundtrip() {
         val contestUA = makeTestContestOA()
         val target = contestUA.assertions().first()
+        assert(target is ClcaAssertion)
 
         val json = target.publishIFJson()
-        val roundtrip = json.import(contestUA.contest.info())
+        val roundtrip = json.import(contestUA.contest)
         assertNotNull(roundtrip)
         assert(roundtrip is ClcaAssertion)
+        println((target as ClcaAssertion).checkEquals(roundtrip as ClcaAssertion))
+        assertEquals((target.cassorter as OneAuditClcaAssorter).contestOA, (roundtrip.cassorter as OneAuditClcaAssorter).contestOA)
         assertEquals(target, roundtrip)
         assertTrue(roundtrip.equals(target))
     }
@@ -42,8 +54,8 @@ class TestOneAuditJson {
         val contestUA = makeTestContestOA()
         val target = contestUA.contestOA
 
-        val json = target.publishOAJson()
-        val roundtrip = json.import(target.info)
+        val json = target.publishJson()
+        val roundtrip = json.import(target.contest.info())
         assertNotNull(roundtrip)
         assertEquals(target, roundtrip)
         assertTrue(roundtrip.equals(target))
@@ -68,6 +80,42 @@ class TestOneAuditJson {
         assertNotNull(minAllAsserter)
 
         return contestOA
+    }
+
+    @Test
+    fun testContestOAIrvRoundtrip() {
+        val target = makeTestContestOAIrv()
+
+        val json = target.publishOAIrvJson()
+        val roundtrip = json.import()
+        assertNotNull(roundtrip)
+        assertEquals(target, roundtrip)
+        assertTrue(roundtrip.equals(target))
+    }
+
+    fun makeTestContestOAIrv(): OneAuditIrvContest {
+        val info = ContestInfo(
+            "TestOneAuditIrvContest",
+            0,
+            mapOf("cand0" to 0, "cand1" to 1, "cand2" to 2, "cand3" to 3, "cand4" to 4, "cand42" to 42),
+            SocialChoiceFunction.IRV,
+            voteForN = 6,
+        )
+        val Nc = 212
+        val Np = 1
+        val contest = RaireContest(info, winners=listOf(1), iNc=Nc, Np=Np)
+
+        // val contestOA = OneAuditContest.make(contest, cvrVotes, cvrPercent = cvrPercent, undervotePercent = undervotePercent, phantomPercent = phantomPercent)
+        val cvrVotes = mapOf(0 to 100, 1 to 200, 2 to 42, 3 to 7, 4 to 0) // worthless?
+        val cvrNc = 200
+
+        val pool = BallotPool("swim", 42, 0, 11, mapOf(0 to 1, 1 to 2, 2 to 3, 3 to 4, 4 to 0))
+        val contestOA = OneAuditContest.make(contest, cvrVotes, cvrNc, listOf(pool))
+
+        val contestOAIrv =  OneAuditIrvContest(contestOA, true, emptyList<RaireAssertion>())
+        contestOAIrv.makeClcaAssertionsFromReportedMargin()
+
+        return contestOAIrv
     }
 
 }


### PR DESCRIPTION
Dominion parsing: Align with SHANGRLA: check for Mark.IsVote, Original.IsCurrent 
Use BallotTypeContestManifest to fill in undervotes for SF cases. 
Redo OneAuditContest to allow IRV (in progress)