### PR TITLE
OneAuditConfig useFirst to use the actual nsamples as estimate.

### DIFF
--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCards.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCards.kt
@@ -100,6 +100,7 @@ fun createSfElectionFromCsvExport(
 
     val auditConfig = auditConfigIn ?: AuditConfig(
         AuditType.CLCA, hasStyles = true, sampleLimit = 20000, riskLimit = .05,
+        clcaConfig = ClcaConfig(strategy=ClcaStrategyType.noerror),
     )
     val contestsUA = contests.map { ContestUnderAudit(it, isComparison=true, auditConfig.hasStyles) }
     val allContests = contestsUA + irvContests

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCardsOA.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCardsOA.kt
@@ -68,6 +68,7 @@ fun createSfElectionFromCsvExportOA(
     // these checks may modify the contest status; dont call until clca assertions are created
     val auditConfig = auditConfigIn ?: AuditConfig(
         AuditType.ONEAUDIT, hasStyles = true, sampleLimit = 20000, riskLimit = .05, nsimEst = 10,
+        oaConfig = OneAuditConfig(OneAuditStrategyType.optimalBet, useFirst = true)
     )
 
     // TODO check that the sum of pooled and unpooled votes is correct

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCardsOANS.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionFromCardsOANS.kt
@@ -2,6 +2,7 @@ package org.cryptobiotic.rlauxe.sf
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.audit.*
+import org.cryptobiotic.rlauxe.audit.OneAuditConfig
 import org.cryptobiotic.rlauxe.core.ContestInfo
 import org.cryptobiotic.rlauxe.core.SocialChoiceFunction
 import org.cryptobiotic.rlauxe.core.TestH0Status
@@ -57,6 +58,7 @@ fun createSfElectionFromCsvExportOANS(
     // these checks may modify the contest status; dont call until clca assertions are created
     val auditConfig = auditConfigIn ?: AuditConfig(
         AuditType.ONEAUDIT, hasStyles = true, sampleLimit = 20000, riskLimit = .05, nsimEst = 10,
+        oaConfig = OneAuditConfig(OneAuditStrategyType.optimalBet, useFirst = true)
     )
 
     checkContestsCorrectlyFormed(auditConfig, contests)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditConfig.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditConfig.kt
@@ -21,7 +21,7 @@ data class AuditConfig(
     val pollingConfig: PollingConfig = PollingConfig(),
     val clcaConfig: ClcaConfig = ClcaConfig(ClcaStrategyType.phantoms),
     val oaConfig: OneAuditConfig = OneAuditConfig(OneAuditStrategyType.optimalBet),
-    val version: Double = 1.0,
+    val version: Double = 1.1,
 ) {
     val isClca = auditType == AuditType.CLCA || auditType == AuditType.ONEAUDIT
 
@@ -70,6 +70,7 @@ data class OneAuditConfig(
     val strategy: OneAuditStrategyType = OneAuditStrategyType.optimalBet,
     val simFuzzPct: Double? = null, // for the estimation
     val d: Int = 100,  // shrinkTrunc weight
+    val useFirst: Boolean = false, // use actual cvrs for estimation
 )
 
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRound.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRound.kt
@@ -186,6 +186,7 @@ data class EstimationRoundResult(
     val startingTestStatistic: Double,
     val startingRates: ClcaErrorRates? = null, // apriori error rates (clca only)
     val estimatedDistribution: List<Int>,   // distribution of estimated sample size; currently deciles
+    val firstSample: Int,
 ) {
     override fun toString() = "round=$roundIdx estimatedDistribution=$estimatedDistribution fuzzPct=$fuzzPct " +
             " startingRates=$startingRates"

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/MvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/MvrManager.kt
@@ -85,7 +85,7 @@ fun wantSampleSize(contestsNotDone: List<ContestRound>, previousSamples: Set<Lon
     }
     // we need prevContestCounts in order to calculate wantSampleSize if contest.auditorWantNewMvrs has been set
     val wantSampleSizeMap = prevContestCounts.entries.map { it.key.id to it.key.wantSampleSize(it.value) }.toMap()
-    logger.debug{"**wantSampleSize = $wantSampleSizeMap"}
+    if (debug) logger.debug{"wantSampleSize = $wantSampleSizeMap"}
 
     return wantSampleSizeMap
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ConsistentSampling.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ConsistentSampling.kt
@@ -128,11 +128,11 @@ fun consistentSampling(
             }
         }
         countSamples++
-        if (countSamples % 10000 == 0) print("$countSamples ")
+        /* if (countSamples % 10000 == 0) print("$countSamples ")
         if (countSamples % 100000 == 0) {
             val wants = contestsIncluded.filter { contestWantsMoreSamples(it) }.map { "${it.id}:${contestWants(it)}" }
-            logger.info{"\nsampledCards = ${sampledCards.size} newMvrs=$newMvrs wants = $wants"}
-        }
+            print{"sampledCards = ${sampledCards.size} newMvrs=$newMvrs wants = $wants"}
+        } */
     }
 
     if (debugConsistent) logger.info{"**consistentSampling haveActualMvrs = $haveActualMvrs, haveNewSamples = $haveNewSamples, newMvrs=$newMvrs"}

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/RunRepeated.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/RunRepeated.kt
@@ -29,8 +29,7 @@ fun runTestRepeated(
     val sampleCounts = mutableListOf<Int>()
 
     repeat(ntrials) {
-        // TODO TIMING reset taking 12% of audit round, already have the sample Limit on it....
-        drawSample.reset() // TODO this is supposed to create all the variation for the estimation
+        if (it != 0) drawSample.reset() // TODO this is supposed to create all the variation for the estimation
         val testH0Result = testFn.testH0(
             maxSamples=drawSample.maxSamples(),
             terminateOnNullReject=terminateOnNullReject,
@@ -69,7 +68,7 @@ data class RunTestRepeatedResult(
     val nsuccess: Int,           // number of successful trials
     val ntrials: Int,            // total number of trials
     val variance: Double,        // variance over ntrials of samples needed
-    val percentHist: Deciles? = null, // TODO remove
+    val percentHist: Deciles? = null, // TODO remove?
     val status: Map<TestH0Status, Int>? = null, // count of the trial status
     val sampleCount: List<Int> = emptyList(),
     val margin: Double?, // TODO needed?

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/IrvContestVotes.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/IrvContestVotes.kt
@@ -69,23 +69,6 @@ fun makeRaireContests(contestInfos: List<ContestInfo>, contestVotes: Map<Int, Ir
                 Ncast = irvContestVotes.ncards,
             )
             contests.add(rcontestUA)
-
-            // TODO added to makeRaireContestUA; duplicate ??
-            //// annotate RaireContest with IrvRounds TODO put inside RaireContestUnderAudit or RaireContest or makeRaireContestUA
-
-            // The candidate Ids go from 0 ... ncandidates-1 because of Raire; use the ordering from ContestInfo.candidateIds
-            // this just makes the candidateIds the sequential indexes (0..ncandidates-1)
-            val candidateIdxs = info.candidateIds.mapIndexed { idx, candidateId -> idx } // TODO use candidateIdToIndex?
-            val cvotes = irvContestVotes.vc.makeVotes()
-            val irvCount = IrvCount(cvotes, candidateIdxs)
-            val roundResultByIdx = irvCount.runRounds()
-
-            // now convert results back to using the real Ids:
-            val roundPathsById = roundResultByIdx.ivrRoundsPaths.map { roundPath ->
-                val roundsById = roundPath.rounds.map { round -> round.convert(info.candidateIds) }
-                IrvRoundsPath(roundsById, roundPath.irvWinner.convert(info.candidateIds))
-            }
-            (rcontestUA.contest as RaireContest).roundsPaths.addAll(roundPathsById)
         }
     }
     return contests

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAudit.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAudit.kt
@@ -84,7 +84,7 @@ class OneAuditAssertionAuditor(val quiet: Boolean = true) : ClcaAssertionAuditor
             measuredMean = testH0Result.tracker.mean(),
         )
 
-        if (!quiet) logger.debug{" ${contest.name} ${assertionRound.auditResult}"}
+        if (!quiet) logger.debug{" ${contest.name} auditResult= ${assertionRound.auditResult}"}
         return testH0Result
     }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/RlauxAuditIF.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/RlauxAuditIF.kt
@@ -5,6 +5,7 @@ import org.cryptobiotic.rlauxe.audit.*
 import org.cryptobiotic.rlauxe.core.ContestUnderAudit
 import org.cryptobiotic.rlauxe.estimate.estimateSampleSizes
 import org.cryptobiotic.rlauxe.estimate.sampleCheckLimits
+import org.cryptobiotic.rlauxe.util.Stopwatch
 
 private val logger = KotlinLogging.logger("RlauxAuditIF")
 
@@ -31,13 +32,16 @@ interface RlauxAuditIF {
         }
         auditRounds.add(auditRound)
 
-        if (!quiet) logger.info{"Estimate round ${roundIdx}"}
+        logger.info{"Estimate round ${roundIdx}"}
+        val stopwatch = Stopwatch()
+
         // 1. _Estimation_: for each contest, estimate how many samples are needed to satisfy the risk function,
         estimateSampleSizes(
             auditConfig(),
             auditRound,
             mvrManager().sortedCvrs(),
         )
+        logger.info{"Estimate round ${roundIdx} took ${stopwatch}"}
 
         // 2. _Choosing sample sizes_: the Auditor decides which contests and how many samples will be audited.
         // 3. _Random sampling_: The actual ballots to be sampled are selected randomly based on a carefully chosen random seed.
@@ -47,6 +51,7 @@ interface RlauxAuditIF {
             auditRound,
             auditRounds.previousSamples(roundIdx),
             quiet)
+
         return auditRound
     }
 

--- a/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AuditRoundJson.kt
+++ b/rla/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AuditRoundJson.kt
@@ -217,6 +217,7 @@ fun AssertionRoundJson.import(assertion: Assertion): AssertionRound {
 //    val startingTestStatistic: Double,
 //    val startingRates: ClcaErrorRates? = null, // aprioti error rates (clca only)
 //    val sampleDeciles: List<Int>,   // distribution of estimated sample size as deciles
+//    val firstSample: Int
 //)
 
 @Serializable
@@ -227,6 +228,7 @@ data class EstimationRoundResultJson(
     val startingTestStatistic: Double,
     val startingRates: List<Double>?,
     val estimatedDistribution: List<Int>,
+    val firstSample: Int,
 )
 
 fun EstimationRoundResult.publishJson() = EstimationRoundResultJson(
@@ -236,6 +238,7 @@ fun EstimationRoundResult.publishJson() = EstimationRoundResultJson(
     this.startingTestStatistic,
     this.startingRates?.toList(),
     this.estimatedDistribution,
+    this.firstSample,
 )
 
 fun EstimationRoundResultJson.import() : EstimationRoundResult {
@@ -246,6 +249,7 @@ fun EstimationRoundResultJson.import() : EstimationRoundResult {
         this.startingTestStatistic,
         if (this.startingRates != null) ClcaErrorRates.fromList(this.startingRates) else null,
         this.estimatedDistribution,
+        this.firstSample,
     )
 }
 


### PR DESCRIPTION
OneAuditConfig uses actual cvrs for estimate.
useFirst to use the actual nsamples as estimate. May be cheating.
AuditConfig version 1.1
Fix bug where roundsPaths added twice to RaireContest.