### PR TITLE
CvrsWithStylesToCards, CardsWithStylesToCards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **rlauxe ("r-lux")**
 
 WORK IN PROGRESS
-_last changed: 10/19/2025_
+_last changed: 11/09/2025_
 
 A library for [Risk Limiting Audits](https://en.wikipedia.org/wiki/Risk-limiting_audit) (RLA), based on Philip Stark's SHANGRLA framework and related code.
 The Rlauxe library is a independent implementation of the SHANGRLA framework, based on the
@@ -506,9 +506,11 @@ STYLISH	    Stylish Risk-Limiting Audits in Practice. Glazer, Spertus, Stark  16
 
 SliceDice   Dice, but don’t slice: Optimizing the efficiency of ONEAudit. Spertus, Glazer and Stark, Aug 18 2025
     https://arxiv.org/pdf/2507.22179; https://github.com/spertus/UI-TS
+    
+Verifiable  Risk-Limiting Audits Are Interactive Proofs — How Do We Guarantee They Are Sound?
 
 ````
-Also see (reference notes)[docs/notes/papers.txt].
+Also see [complete list](docs/notes/papers.txt).
 
 ## Differences with SHANGRLA
 

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoOneAudit.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoOneAudit.kt
@@ -178,9 +178,9 @@ open class ColoradoOneAudit (
         val phantomCvrs = makePhantomCvrs(contests)
 
         val cvrsFromPools = CloseableIterable { CvrIteratorfromPools()  } // "fake" truth
-        val poolMap = cardPools.associateBy { it.poolId }
 
-        return CardLocationManifest(CvrsWithPoolsToCards(cvrsFromPools, poolMap, phantomCvrs, config), emptyList())
+        return CardLocationManifest(CvrsWithStylesToCards(cvrsFromPools, cardPools, phantomCvrs,
+            config.auditType, hasStyle), emptyList())
     }
 
     // dont load into memory all at once, just one pool at a time

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditConfig.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditConfig.kt
@@ -3,7 +3,11 @@ package org.cryptobiotic.rlauxe.audit
 import org.cryptobiotic.rlauxe.core.ClcaErrorRates
 import org.cryptobiotic.rlauxe.util.secureRandom
 
-enum class AuditType { POLLING, CLCA, ONEAUDIT }
+enum class AuditType { POLLING, CLCA, ONEAUDIT;
+    fun isClca() = (this == CLCA)
+    fun isOA() = (this == ONEAUDIT)
+    fun isPolling() = (this == POLLING)
+}
 
 data class AuditConfig(
     val auditType: AuditType,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Contest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Contest.kt
@@ -356,8 +356,6 @@ open class ContestUnderAudit(
 
     fun makeDilutedMargin(assorter: AssorterIF): Double {
         val margin = assorter.calcMargin(contest.votes(), Nb)
-        if (margin < 0)
-            println("makeDilutedMargin")
         return margin
     }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
@@ -16,6 +16,7 @@ data class Cvr(
     }
 
     fun hasContest(contestId: Int): Boolean = votes[contestId] != null
+    fun contests() = votes.keys.toList().sorted().toIntArray()
 
     constructor(oldCvr: Cvr, votes: Map<Int, IntArray>) : this(oldCvr.id, votes, oldCvr.phantom)
     constructor(contest: Int, ranks: List<Int>): this( "testing", mapOf(contest to ranks.toIntArray())) // for quick testing

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/CardBuilder.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/CardBuilder.kt
@@ -50,7 +50,7 @@ class CardBuilder(
         if (allVotes[id] == null) allVotes[id] = if (candidateId == null) intArrayOf() else intArrayOf(candidateId)
     }
 
-    fun build() : AuditableCard {
+    fun build(poolId:Int? = 0) : AuditableCard {
         // data class AuditableCard (
         //    val location: String, // info to find the card for a manual audit. Aka ballot identifier.
         //    val index: Int,  // index into the original, canonical list of cards
@@ -63,6 +63,7 @@ class CardBuilder(
         //    val cardStyle: String? = null,
         return AuditableCard(location, index=idx, prn=0L, phantom=phantom, possibleContests=possibleContests,
             votes= if (allVotes.isEmpty()) null else allVotes,
-            poolId=poolId, cardStyle=cardStyle)
+            poolId=poolId ?: this.poolId,
+            cardStyle=cardStyle)
     }
 }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaCreateOneAudit.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaCreateOneAudit.kt
@@ -13,7 +13,7 @@ import org.cryptobiotic.rlauxe.oneaudit.CardPoolIF
 import org.cryptobiotic.rlauxe.oneaudit.makeOneContestUA
 import org.cryptobiotic.rlauxe.persist.clearDirectory
 import org.cryptobiotic.rlauxe.util.CloseableIterable
-import org.cryptobiotic.rlauxe.util.CvrsWithPoolsToCards
+import org.cryptobiotic.rlauxe.util.CvrsWithStylesToCards
 import org.cryptobiotic.rlauxe.util.tabulateCvrs
 import kotlin.io.path.Path
 
@@ -181,10 +181,8 @@ object RunRlaCreateOneAudit {
         override fun contestsUA() = contestsUA
 
         override fun cardManifest(): CardLocationManifest {
-            val poolMap = allCardPools.associateBy { it.poolId }
-
             val cvrsIterable  = CloseableIterable{ allCvrs.iterator() }
-            val cardLocations = CvrsWithPoolsToCards(cvrsIterable, poolMap, null, config) // already has phantoms
+            val cardLocations = CvrsWithStylesToCards(cvrsIterable, styles=allCardPools, null, config.auditType, config.hasStyle) // already has phantoms
             return CardLocationManifest(cardLocations, emptyList())
         }
     }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/MultiContestCombineData.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/MultiContestCombineData.kt
@@ -4,7 +4,6 @@ import org.cryptobiotic.rlauxe.audit.AuditableCard
 import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.util.*
 import kotlin.collections.shuffle
-import kotlin.math.abs
 import kotlin.random.Random
 
 private const val debugAdjust = false
@@ -12,7 +11,7 @@ private const val debugAdjust = false
 data class MultiContestCombineData(
     val contests: List<Contest>,
     val totalBallots: Int, // including undervotes and phantoms
-    val hasStyle: Boolean,
+    val poolId: Int? = null,
 ) {
     val contestBuilders: List<ContestTracker>
 
@@ -40,7 +39,7 @@ data class MultiContestCombineData(
     private fun makeCard(cvrbs: CardBuilders, fcontests: List<ContestTracker>): AuditableCard {
         val cvrb = cvrbs.addCard()
         fcontests.forEach { fcontest -> fcontest.addContestToCard(cvrb) }
-        return cvrb.build()
+        return cvrb.build(poolId)
     }
 
     // multicontest cvrs
@@ -63,7 +62,7 @@ data class MultiContestCombineData(
     private fun makeCvr(cvrbs: CvrBuilders, fcontests: List<ContestTracker>): Cvr {
         val cvrb = cvrbs.addCvr()
         fcontests.forEach { fcontest -> fcontest.addContestToCvr(cvrb) }
-        return cvrb.build()
+        return cvrb.build(poolId)
     }
 }
 

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/MultiContestTestData.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/MultiContestTestData.kt
@@ -25,6 +25,7 @@ data class MultiContestTestData(
     val marginRange: ClosedFloatingPointRange<Double> = 0.01.. 0.03,
     val underVotePctRange: ClosedFloatingPointRange<Double> = 0.01.. 0.30, // needed to set Nc
     val phantomPctRange: ClosedFloatingPointRange<Double> = 0.00..  0.005, // needed to set Nc
+    val poolId: Int? = null
 ) {
     // generate with ballotStyles; but if hasStyle = false, then these are not visible to the audit
     val ballotStylePartition = partition(totalBallots, nballotStyles).toMap() // Map bsidx -> ncards in each ballot style (bs)
@@ -117,7 +118,7 @@ data class MultiContestTestData(
     private fun makeCvr(cvrbs: CvrBuilders, fcontests: List<ContestTestDataBuilder>): Cvr {
         val cvrb = cvrbs.addCvr()
         fcontests.forEach { fcontest -> fcontest.addContestToCvr(cvrb) }
-        return cvrb.build()
+        return cvrb.build(poolId)
     }
 
     // multicontest cvrs

--- a/docs/Overview.md
+++ b/docs/Overview.md
@@ -246,3 +246,26 @@ So when calculating the overstatement_error, use hasStyles=true if the card has 
 
 If using CSD, the Prover must commit to the CSD before the PRN is chosen.
 A verifier needs to check that cards are chosen in order of smallest PRN, and satisfy the CSD if used.
+
+MoreStyles Section 5 shows that polling audits can have hasStyle = true.
+
+==========================
+
+````
+    data class AuditableCard (
+        val location: String, // info to find the card for a manual audit. Aka ballot identifier.
+        val index: Int,  // index into the original, canonical list of cards
+        val prn: Long,   // psuedo random number
+        val phantom: Boolean,
+        val possibleContests: IntArray, // list of contests that might be on the ballot. TODO replace with cardStyle?
+        val votes: Map<Int, IntArray>?, // for CLCA or OneAudit, a map of contest -> the candidate ids voted; must include undervotes; missing for pooled data or polling audits
+        
+        val poolId: Int?, // for OneAudit
+        val cardStyle: String? = null, // not used yet
+    ) {
+        fun hasContest(contestId: Int): Boolean {
+            if (possibleContests.isEmpty() && votes == null) return true
+            return contests().contains(contestId)
+        }
+    }
+````

--- a/docs/PublicallyVerifiableRLAs.md
+++ b/docs/PublicallyVerifiableRLAs.md
@@ -148,3 +148,66 @@ ClcaAssorter
         return cvr_assort - mvr_assort
     }
 ````
+
+## 4.3 The Instance
+
+Before the protocol begins, the prover fixes an instance, which represents the claim it will prove. The instance is:
+
+* a multiset x of ID-tagged cards,
+* a reported outcome O ∈ the set of possible outcomes,
+* a (trusted) upper bound Ncard on the number of cards,
+* (optionally) a decision to use style-based sampling and a (trusted) upper bound Ncontest on the number of cards containing the contest.
+
+The prover will attempt to show that the social choice function TALLY yields the reported outcome O, when applied to the cards x.
+
+## 4.4 The Prover's First Message
+
+In the first step of the protocol, the prover P commits to a collection of claims about x.
+
+* An ID commitment FIND (see Definition 6).
+* (Optionally) a CVR commitment (see Definition 7).
+* A list ASSERTIONS of assertions with corresponding assorters ASSORTERS (see Definition 4, Definition 8 and Definition 9).
+* (Optionally) other data AUX - P , such as tallies or subtotals, which the p-value calculator may input.
+
+## 4.5 The Verifier's challenge
+
+The verifier V samples and sends a seed s.
+
+## 4.6 The Provers Response
+
+The prover P computes uses PRG(s) and π ← ḠSAMPLE,N (se). 
+
+For each index i = 1.. P retrieves MVR(i) with identifier FIND (π_i) ("but is free to do otherwise" ??)
+
+## 4.7 The Verifiers Decision
+
+### 4.7.1. Validating the prover’s first message
+
+1) Each assorter satisfies its upper bound.
+2) ASSERTIONS implies O given TALLY (see Definition 5)
+3) |ASSERTIONS| = |ASSORTERS|.
+4) for all i ∈ 1..|ASSORTERS|, ASSORTERSi expresses ASSERTIONS i (see Definition 9 and 10). This effectively says that 
+   if we are using style-based sampling and there are CVRs that claim to have the contest but are outside the image of
+   FIND then we ignore them.
+5) FIND assigns some i ∈ I to every index in 1..N and does not repeat any ballot ID.
+
+### 4.7.2. Validating the prover’s response to s
+
+Algorithm 1. This is what we call running the audit.
+
+On Line 7, the verifier V identifies the identifier of the card that must be audited. 
+On Line 8, V reads that card, or sets it to ⊥ if no card has been returned. 
+On Line 9, V checks whether the card returned by the prover has the expected ID. If so, V sets MVR(t) to the
+canonical interpretation of that card, and to BAD otherwise.
+
+V then goes through all the assorters 
+on Line 15, it extends the vector a_i with the value that assorter ai takes for this audited card. 
+on line 16 it  updates pi with the p-value computed for this assorter
+
+on line 19 it checks if all p-values are less than the risk limit
+on line 24 it accepts O if all p-values are less than the risk limit
+
+So we need to check that the samples are sorted by PRN.
+So we need to check that the samples PRN are te smallest available based for that contest.
+So we need to check that the MVR id matches the CVR id.
+

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/PlotDistributions.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/PlotDistributions.kt
@@ -87,7 +87,7 @@ class PlotDistributions {
         return estimateSampleSizes(
             config,
             auditRound,
-            cardManifest = if (config.auditType == AuditType.POLLING) null else mvrManager.sortedCards(),
+            cardManifest = mvrManager.sortedCards(),
         )
     }
 


### PR DESCRIPTION
trying to canonicalize cardManifest with CvrsWithStylesToCards, CardsWithStylesToCards iterators that do the conversion.rework TestHasStyle.
MultiContestTestData, MultiContestCombineData take an optional poolId .
added Cvr.contests().