### PR TITLE
change to diluted N in OneAudit pool average

### DIFF
--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoOneAudit.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoOneAudit.kt
@@ -260,7 +260,7 @@ fun createColoradoOneAudit(
             AuditType.CLCA, hasStyle = true, contestSampleCutoff = 20000, riskLimit = .03, nsimEst=10,
             clcaConfig = ClcaConfig(strategy = ClcaStrategyType.previous)
         )
-        else -> AuditConfig( // HEY NOSTYLE
+        else -> AuditConfig( // TODO NOSTYLE
             AuditType.ONEAUDIT, hasStyle = false, riskLimit = .03, contestSampleCutoff = null, nsimEst = 1,
             oaConfig = OneAuditConfig(OneAuditStrategyType.optimalComparison, useFirst = true)
         )

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElection.kt
@@ -59,12 +59,13 @@ class CreateSfElection(
             contestManifestFilename,
             cvrExportCsv,
         )
+
         cardPoolMapByName = allCardPools.filter { it.value.poolName != unpooled } // exclude the unpooled
         cardPools = cardPoolMapByName.values.toList() // exclude the unpooled
-        val unpooledPool = allCardPools[unpooled]!!
+        val unpooledPool = allCardPools[unpooled]!! // this does not have the diluted count
         this.cardCount = ncards
 
-        // we need the contests to make the phantom cvrs in createCardIterator()
+        // we need Nc to make the phantom cvrs in createCardIterator()
         phantomCount = countPhantoms(allCvrTabs, contestNcs)
 
         // we need to know the diluted Nb before we can create the UAs: another pass through the cvrExports
@@ -188,7 +189,7 @@ fun makeOneAuditContests(allCvrTabs: Map<Int, ContestTabulation>, contestNcs: Ma
     val contestsUAs = mutableListOf<ContestUnderAudit>()
     allCvrTabs.map { (contestId, contestSumTab)  ->
         val info = contestSumTab.info
-        val unpooledTab: ContestTabulation = unpooled.contestTabs[contestId]!!
+        val unpooledTab: ContestTabulation = unpooled.contestTabs[contestId]!! // does not have the diluted count
 
         val useNc = contestNcs[info.id] ?: contestSumTab.ncards
         if (useNc > 0) {

--- a/cases/src/test/kotlin/org/cryptobiotic/cli/MeasureEstimationTaskConcurrency.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/cli/MeasureEstimationTaskConcurrency.kt
@@ -27,7 +27,7 @@ import kotlin.test.Test
 class MeasureEstimationTaskConcurrency {
     @Test
     fun measure() {
-        val test = MultiContestTestData(15, 1, 20000, hasStyle = true)
+        val test = MultiContestTestData(15, 1, 20000)
         val cards = test.makeCardsFromContests()
 
         val contestsUA  = test.contests.map { ContestUnderAudit(it).addStandardAssertions() }

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestCreateSfElection.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestCreateSfElection.kt
@@ -15,7 +15,7 @@ class TestCreateSfElection {
 
     @Test
     fun createSFElectionOA() {
-        val topdir = "/home/stormy/rla/cases/sf2024/oaCard"
+        val topdir = "/home/stormy/rla/cases/sf2024/oa"
 
         createSfElection(
             topdir,
@@ -23,7 +23,7 @@ class TestCreateSfElection {
             "ContestManifest.json",
             "CandidateManifest.json",
             cvrExportCsv = cvrExportCsv,
-            hasStyle = false, // HEY NOSTYLE
+            hasStyle = true, // hasStyle = cvrs are complete
             auditType = AuditType.ONEAUDIT,
         )
 
@@ -34,7 +34,7 @@ class TestCreateSfElection {
 
     @Test
     fun createSFElectionClca() {
-        val topdir = "/home/stormy/rla/cases/sf2024/clcaCard"
+        val topdir = "/home/stormy/rla/cases/sf2024/clca"
 
         createSfElection(
             topdir,

--- a/cases/src/test/kotlin/org/cryptobiotic/util/TestGenerateAllUseCases.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/util/TestGenerateAllUseCases.kt
@@ -105,7 +105,7 @@ class TestGenerateAllUseCases {
             "ContestManifest.json",
             "CandidateManifest.json",
             cvrExportCsv = "$sfDir/$cvrExportCsvFile",
-            hasStyle = false,
+            hasStyle = true,
             auditType = AuditType.ONEAUDIT,
         )
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Cvr.kt
@@ -9,7 +9,7 @@ data class Cvr(
     val id: String, // ballot identifier
     val votes: Map<Int, IntArray>, // contest -> list of candidates voted for; for IRV, ranked first to last
     val phantom: Boolean = false,
-    val poolId: Int? = null,  // or style.id ?
+    val poolId: Int? = null,  // or cardStyle.id
 ) {
     init {
         require(id.indexOf(',') < 0) { "cvr.id='$id' must not have commas"} // must not have nasty commas
@@ -63,10 +63,6 @@ data class Cvr(
         result = 31 * result + id.hashCode()
         votes.forEach { (contestId, candidates) -> result = 31 * result + contestId.hashCode() + candidates.contentHashCode() }
         return result
-    }
-
-    companion object {
-        fun makePhantom(cvrId: String, contestId: Int) = Cvr(cvrId, mapOf(contestId to IntArray(0)), phantom=true)
     }
 }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/CardPool.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/CardPool.kt
@@ -271,10 +271,6 @@ open class CardPoolFromCvrs(
         return result
     }
 
-    override fun toString(): String {
-        return "CardPoolFromCvrs(poolName='$poolName', poolId=$poolId, contestTabs=$contestTabs, totalCards=$totalCards)"
-    }
-
     companion object {
         // poolId -> CardPoolIF
         fun makeCardPools(cvrs: Iterator<Cvr>, infos: Map<Int, ContestInfo>): Map<Int, CardPoolFromCvrs> {
@@ -307,8 +303,9 @@ fun addOAClcaAssortersFromMargin(
             cardPools.forEach { cardPool ->
                 if (cardPool.hasContest(contestId)) {
                     val regVotes = cardPool.regVotes()[oaContest.id]!!
-                    if (regVotes.ncards() > 0) {
-                        val poolMargin = assertion.assorter.calcMargin(regVotes.votes, regVotes.ncards())
+                    if (cardPool.ncards() > 0) {
+                        // note: use cardPool.ncards(), this is the diluted count
+                        val poolMargin = assertion.assorter.calcMargin(regVotes.votes, cardPool.ncards())
                         assortAverages[cardPool.poolId] = margin2mean(poolMargin)
                     }
                 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/CardPoolJson.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/CardPoolJson.kt
@@ -42,7 +42,7 @@ fun CardPoolIF.publishJson(): CardPoolJson {
         CardPoolJson(
             "CardPoolWithBallotStyle",
             this.publishJson(),
-            null
+            null,
         ) else if (this is CardPoolFromCvrs)
         CardPoolJson(
             "CardPoolFromCvrs",

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/CardBuilder.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/CardBuilder.kt
@@ -73,6 +73,9 @@ class CardBuilder(
     constructor(location: String, index: Int):
             this(location, index, 0L, false, intArrayOf(), null, null, null)
 
+    constructor(location: String, index: Int, poolId: Int?, cardStyle: String?):
+            this(location, index, 0L, false, intArrayOf(), null, poolId, cardStyle)
+
     fun replaceContestVotes(contestId: Int, contestVotes: IntArray): CardBuilder  {
         votes[contestId] = contestVotes
         return this

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/CvrBuilder.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/CvrBuilder.kt
@@ -28,9 +28,9 @@ class CvrBuilders(startCvrId: Int = 0) {
     }
 
     // add a new CvrBuilder
-    fun addCvr(): CvrBuilder {
+    fun addCvr(poolId: Int? = null): CvrBuilder {
         this.nextCvrId++
-        val cb = CvrBuilder(this, "card${nextCvrId}")
+        val cb = CvrBuilder(this, "card${nextCvrId}", poolId = poolId)
         builders.add(cb)
         return cb
     }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditRound.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditRound.kt
@@ -14,7 +14,7 @@ class TestAuditRound {
 
     @Test
     fun testAuditRound() {
-        val test = MultiContestTestData(20, 11, 20000, hasStyle=true)
+        val test = MultiContestTestData(20, 11, 20000)
         val contestsUAs: List<ContestUnderAudit> = test.contests.map {
             ContestUnderAudit(it, isClca = true).addStandardAssertions()
         }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditableCard.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditableCard.kt
@@ -10,13 +10,15 @@ import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 
 // data class AuditableCard (
-//    val desc: String, // info to find the card for a manual audit. Part of the info the Prover commits to before the audit.
-//    val index: Int,  // index into the original, canonical (committed-to) list of cards
-//    val prn: Long,
+//    val location: String, // info to find the card for a manual audit. Aka ballot identifier.
+//    val index: Int,  // index into the original, canonical list of cards
+//    val prn: Long,   // psuedo random number
 //    val phantom: Boolean,
-//    val contests: IntArray, // aka ballot style.
-//    val votes: List<IntArray>?, // contest -> list of candidates voted for; for IRV, ranked first to last
-//    val poolId: Int?, // for OneAudit
+//    val possibleContests: IntArray, // list of contests that might be on the ballot. TODO replace with cardStyle?
+//    val votes: Map<Int, IntArray>?, // for CLCA or OneAudit, a map of contest -> the candidate ids voted; must include undervotes; missing for pooled data or polling audits
+//                                                                                // when IRV, ranked first to last
+//    val poolId: Int?, // for OneAudit, or for setting style
+//    val cardStyle: String? = null, // set style in a way that doesnt interfere with onaudit....
 //)
 class TestAuditableCard {
 
@@ -62,7 +64,8 @@ fun makeCvr(id: Int, ncontests: Int, ncandidates: Int): Cvr {
     val cvrb = CvrBuilder2(id.toString(),  false)
     repeat(ncontests) {
         val contestId = Random.nextInt(ncontests)
-        val candidates = IntArray(ncandidates) { Random.nextInt(ncontests) }
+        val votesForN = Random.nextInt(ncandidates)
+        val candidates = IntArray(votesForN) { Random.nextInt(ncandidates) }
         cvrb.addContest(contestId, candidates)
     }
     return cvrb.build()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestCardsWithStylesToCards.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestCardsWithStylesToCards.kt
@@ -1,0 +1,230 @@
+package org.cryptobiotic.rlauxe.audit
+
+import org.cryptobiotic.rlauxe.util.Closer
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+// data class AuditableCard (
+//    val location: String, // info to find the card for a manual audit. Aka ballot identifier.
+//    val index: Int,  // index into the original, canonical list of cards
+//    val prn: Long,   // psuedo random number
+//    val phantom: Boolean,
+//    val possibleContests: IntArray, // list of contests that might be on the ballot. TODO replace with cardStyle?
+//    val votes: Map<Int, IntArray>?, // for CLCA or OneAudit, a map of contest -> the candidate ids voted; must include undervotes; missing for pooled data or polling audits
+//                                                                                // when IRV, ranked first to last
+//    val poolId: Int?, // for OneAudit, or for setting style
+//    val cardStyle: String? = null, // set style in a way that doesnt interfere with onaudit....
+//)
+//
+// class CardsWithStylesToCards(
+//    val type: AuditType,
+//    val hasStyle: Boolean,
+//    val cards: CloseableIterator<AuditableCard>,
+//    phantomCards : List<AuditableCard>?,
+//    styles: List<CardStyleIF>?,
+//)
+class TestCardsWithStylesToCards {
+
+    @Test
+    fun testCardsWithStylesToCardsForClca() {
+        val cardOrg = AuditableCard ("cardOrg", 42, 0L, false, intArrayOf(1,2,3),
+            mapOf(1 to intArrayOf(1,2,3), 2 to intArrayOf(4,5,6), 3 to intArrayOf(0,1)), 1)
+        
+        var auditType = AuditType.CLCA
+
+        // simple hasStyle with or without poolid. aka "cvrs are complete".
+        var hasStyle = true
+        var hasCardStyles = false
+        var hasPoolId = false
+
+        var cvr = cardOrg.copy(cardStyle=null)
+        var target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=null, )
+        var card = target.next()
+        testOneTarget("** clca complete cvrs", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, null)
+
+        hasPoolId = true
+        cvr = cardOrg.copy(cardStyle="no")
+        target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=null)
+        card = target.next()
+        testOneTarget("clca hasStyle and poolIds", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = null)
+
+        val styleName = "yes"
+        val cardStyle = CardStyle(styleName, 1, emptyList(), listOf(0,1,2,3,4), null)
+        // doesnt make sense to use; hasStyle means use cvr
+        hasStyle = true
+        hasCardStyles = true
+        hasPoolId = true
+        cvr = cardOrg.copy(cardStyle=styleName)
+        target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=listOf(cardStyle))
+        card = target.next()
+        testOneTarget("clca hasStyle and poolIds and styles", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // noStyle means votes isnt complete, so you need cardStyles and poolIds. should test if votes cubset of cardpool contests
+        hasStyle = false
+        hasCardStyles = true
+        hasPoolId = true
+        cvr = cardOrg.copy(cardStyle=styleName)
+        target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=listOf(cardStyle))
+        card = target.next()
+        testOneTarget("** clca incomplete cvrs", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // what if you dont supply the poolId? FAIL
+        hasStyle = false
+        hasCardStyles = true
+        hasPoolId = false
+        cvr = cardOrg.copy(cardStyle=null)
+        target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=listOf(cardStyle))
+        card = target.next()
+        // testOneTarget("", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // what if you dont supply the cardStyles? FAIL
+        hasStyle = false
+        hasCardStyles = false
+        hasPoolId = true
+        cvr = cardOrg.copy(cardStyle=styleName)
+        target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=null)
+        card = target.next()
+       //  testOneTarget("", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = null)
+    }
+
+    @Test
+    fun testCardsWithStylesToCardsForPolling() {
+        val cardOrg = AuditableCard ("cardOrg", 42, 0L, false, intArrayOf(1,2,3),
+            mapOf(1 to intArrayOf(1,2,3), 2 to intArrayOf(4,5,6), 3 to intArrayOf(0,1)), 1)
+
+        var auditType = AuditType.POLLING
+        var hasStyle = true
+        var hasCardStyles = false
+        var hasPoolId = false
+
+        var cvr = cardOrg.copy(poolId=null)
+        var target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=null, )
+        var card = target.next()
+        testOneTarget("polling hasStyle", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, null)
+
+        hasPoolId = true
+        cvr = cardOrg.copy(cardStyle="no")
+        target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=null)
+        card = target.next()
+        testOneTarget("polling hasStyle and poolIds", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = null)
+
+        // what happens if the poolId doesnt match ??
+        val styleName = "yes"
+        val cardStyle = CardStyle(styleName, 1, emptyList(), listOf(0,1,2,3,4), null)
+        hasStyle = true
+        hasCardStyles = true
+        hasPoolId = true
+        cvr = cardOrg.copy(cardStyle=styleName)
+        target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=listOf(cardStyle))
+        card = target.next()
+        testOneTarget("polling hasStyle and poolIds and styles", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // noStyle means must supply the list of possibleContests
+        hasStyle = false
+        hasCardStyles = true
+        hasPoolId = true
+        cvr = cardOrg.copy(cardStyle=styleName)
+        target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=listOf(cardStyle))
+        card = target.next()
+        testOneTarget("** poll noStyle", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // what if you dont supply the poolId? FAIL
+        hasStyle = false
+        hasCardStyles = true
+        hasPoolId = false
+        cvr = cardOrg.copy(cardStyle=null)
+        target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=listOf(cardStyle))
+        card = target.next()
+        // testOneTarget("", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // what if you dont supply the cardStyles? FAIL
+        hasStyle = false
+        hasCardStyles = false
+        hasPoolId = true
+        cvr = cardOrg.copy(cardStyle=styleName)
+        target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCards=null, styles=null)
+        card = target.next()
+        // testOneTarget("", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = null)
+    }
+
+    @Test
+    fun testCardsWithStylesToCardsForOA() {
+        val styleName1 = "oapool1"
+        val styleName2 = "oapool2"
+
+        val cardOrg = AuditableCard ("cardOrg", 42, 0L, false, intArrayOf(1,2,3),
+            mapOf(1 to intArrayOf(1,2,3), 2 to intArrayOf(4,5,6), 3 to intArrayOf(0,1)), 1)
+        val cvrc = cardOrg.copy(cardStyle = null)
+        val cvrp = cardOrg.copy(cardStyle = styleName1)
+        val cvrs = listOf(cvrc, cvrp)
+
+        var auditType = AuditType.ONEAUDIT
+        var hasStyle = true
+        var hasCardStyles = true
+        var hasPoolId = true
+
+        val cardStyle1 = CardStyle(styleName1, 1, emptyList(), listOf(0,1,2), null)
+        val cardStyle2 = CardStyle(styleName2, 2, emptyList(), listOf(0,1,2,3,4,7), null)
+        val cardStyles = listOf(cardStyle1, cardStyle2)
+
+        // hasStyle means must supply the list of possibleContests only for pooled data
+        var target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(cvrs.iterator()), phantomCards=null, cardStyles, )
+        testOneTarget("oa hasStyle", cvrc, target.next(), auditType, hasStyle, hasPoolId, hasCardStyles, null)
+        testOneTarget("oa hasStyle pooled", cvrp, target.next(), auditType, hasStyle, hasPoolId, hasCardStyles, cardStyle1)
+
+        // noStyle means must supply the list of possibleContests for pooled data and cvrs
+        hasStyle = false
+        hasCardStyles = true
+        hasPoolId = true
+        val cvrp2 = cardOrg.copy(cardStyle = styleName2)
+        val cvrs2 = listOf(cvrp, cvrp2)
+        target = CardsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(cvrs2.iterator()), phantomCards=null, cardStyles, )
+        testOneTarget("oa noStyle", cvrc, target.next(), auditType, hasStyle, hasPoolId, hasCardStyles, cardStyle1)
+        testOneTarget("oa noStyle pooled", cvrp, target.next(), auditType, hasStyle, hasPoolId, hasCardStyles, cardStyle2)
+    }
+
+    fun testOneTarget(what: String, cardOrg: AuditableCard, card: AuditableCard, auditType: AuditType, hasStyle: Boolean, hasPoolId: Boolean, hasCardStyles: Boolean, expectStyle:CardStyle?) {
+        println("$what [$auditType hasStyle=$hasStyle hasPoolId:$hasPoolId hasCardStyles:$hasCardStyles]:")
+        println("  ${cardOrg.show()}")
+        println("  ${card.show()}")
+        println()
+
+        if (auditType.isClca()) {
+            // assertEquals(cardOrg, card.cvr())
+            assertNotNull(card.votes)
+            assertEquals(cardOrg.votes, card.votes)
+
+        } else if (auditType.isPolling()) {
+            assertNull(card.votes)
+        }
+
+        assertEquals(cardOrg.location, card.location)
+        assertEquals(cardOrg.phantom, card.phantom)
+        assertEquals(cardOrg.poolId, card.poolId, "poolId")
+        assertEquals(expectStyle?.name(), card.cardStyle, "cardStyle")
+
+        val expectPossibleContests = when (auditType) {
+            AuditType.ONEAUDIT -> if (card.cardStyle == null && hasStyle) emptySet() else expectStyle?.contests()?.toSet() ?: emptySet()
+            AuditType.CLCA -> if (hasStyle) emptySet() else expectStyle?.contests()?.toSet() ?: emptySet()
+            AuditType.POLLING -> expectStyle?.contests()?.toSet() ?: cardOrg.contests().toSet()
+        }
+        assertEquals(expectPossibleContests, card.possibleContests.toSet(), "possibleContests")
+
+        val expectContests = when (auditType) {
+            AuditType.ONEAUDIT -> {
+                if (card.votes != null && hasStyle)
+                    card.votes.keys.toSet()
+                else if (card.cardStyle == expectStyle!!.name) {
+                    expectStyle.contests().toSet()
+                } else {
+                    expectPossibleContests
+                }
+            }
+            AuditType.CLCA -> if (hasStyle) card.votes!!.keys.toSet() else expectPossibleContests
+            AuditType.POLLING -> expectStyle?.contests()?.toSet() ?: cardOrg.contests().toSet()
+        }
+        assertEquals(expectContests, card.contests().toSet(), "card.contests()")
+    }
+}

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestCvrsWithStylesToCards.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestCvrsWithStylesToCards.kt
@@ -1,0 +1,231 @@
+package org.cryptobiotic.rlauxe.audit
+
+import org.cryptobiotic.rlauxe.core.Cvr
+import org.cryptobiotic.rlauxe.util.Closer
+import org.junit.jupiter.api.Test
+import kotlin.math.abs
+import kotlin.random.Random
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+// data class AuditableCard (
+//    val location: String, // info to find the card for a manual audit. Aka ballot identifier.
+//    val index: Int,  // index into the original, canonical list of cards
+//    val prn: Long,   // psuedo random number
+//    val phantom: Boolean,
+//    val possibleContests: IntArray, // list of contests that might be on the ballot. TODO replace with cardStyle?
+//    val votes: Map<Int, IntArray>?, // for CLCA or OneAudit, a map of contest -> the candidate ids voted; must include undervotes; missing for pooled data or polling audits
+//                                                                                // when IRV, ranked first to last
+//    val poolId: Int?, // for OneAudit, or for setting style
+//    val cardStyle: String? = null, // set style in a way that doesnt interfere with onaudit....
+//)
+class TestCvrsWithStylesToCards {
+
+    @Test
+    fun testCvrsWithStylesToCardsForClca() {
+        val cvrr = makeCvr(abs(Random.nextInt()), 2 + Random.nextInt(3), 2 + Random.nextInt(2))
+
+        var auditType = AuditType.CLCA
+
+        // simple hasStyle with or without poolid. aka "cvrs are complete".
+        var hasStyle = true
+        var hasCardStyles = false
+        var hasPoolId = false
+
+        var cvr = cvrr.copy(poolId=null)
+        var target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=null, )
+        var card = target.next()
+        testOneTarget("** clca complete cvrs", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, null)
+
+        hasPoolId = true
+        cvr = cvrr.copy(poolId=1)
+        target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=null)
+        card = target.next()
+        testOneTarget("clca hasStyle and poolIds", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = null)
+
+        val cardStyle = CardStyle("you", 1, emptyList(), listOf(0,1,2,3,4), null)
+        // doesnt make sense to use; hasStyle means use cvr
+        hasStyle = true
+        hasCardStyles = true
+        hasPoolId = true
+        cvr = cvrr.copy(poolId=1)
+        target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=listOf(cardStyle))
+        card = target.next()
+        testOneTarget("clca hasStyle and poolIds and styles", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // noStyle means votes isnt complete, so you need cardStyles and poolIds. should test if votes cubset of cardpool contests
+        hasStyle = false
+        hasCardStyles = true
+        hasPoolId = true
+        cvr = cvrr.copy(poolId=1)
+        target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=listOf(cardStyle))
+        card = target.next()
+        testOneTarget("** clca incomplete cvrs", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // what if you dont supply the poolId? FAIL
+        hasStyle = false
+        hasCardStyles = true
+        hasPoolId = false
+        cvr = cvrr.copy(poolId=null)
+        target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=listOf(cardStyle))
+        card = target.next()
+        // testOneTarget("", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // what if you dont supply the cardStyles? FAIL
+        hasStyle = false
+        hasCardStyles = false
+        hasPoolId = true
+        cvr = cvrr.copy(poolId=1)
+        target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=null)
+        card = target.next()
+       //  testOneTarget("", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = null)
+    }
+
+    @Test
+    fun testCvrsWithStylesToCardsForPolling() {
+        val cvrr = makeCvr(abs(Random.nextInt()), 2 + Random.nextInt(3), 2 + Random.nextInt(2))
+
+        var auditType = AuditType.POLLING
+        var hasStyle = true
+        var hasCardStyles = false
+        var hasPoolId = false
+
+        var cvr = cvrr.copy(poolId=null)
+        var target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=null, )
+        var card = target.next()
+        testOneTarget("polling hasStyle", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, null)
+
+        hasPoolId = true
+        cvr = cvrr.copy(poolId=1)
+        target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=null)
+        card = target.next()
+        testOneTarget("polling hasStyle and poolIds", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = null)
+
+        // what happens if the poolId doesnt match ??
+        val cardStyle = CardStyle("cardstyle1", 1, emptyList(), listOf(0,1,2,3,4), null)
+        hasStyle = true
+        hasCardStyles = true
+        hasPoolId = true
+        cvr = cvrr.copy(poolId=1)
+        target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=listOf(cardStyle))
+        card = target.next()
+        testOneTarget("polling hasStyle and poolIds and styles", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // noStyle means must supply the list of possibleContests
+        hasStyle = false
+        hasCardStyles = true
+        hasPoolId = true
+        cvr = cvrr.copy(poolId=1)
+        target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=listOf(cardStyle))
+        card = target.next()
+        testOneTarget("** poll noStyle", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // what if you dont supply the poolId? FAIL
+        hasStyle = false
+        hasCardStyles = true
+        hasPoolId = false
+        cvr = cvrr.copy(poolId=null)
+        target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=listOf(cardStyle))
+        card = target.next()
+        // testOneTarget("", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = cardStyle)
+
+        // what if you dont supply the cardStyles? FAIL
+        hasStyle = false
+        hasCardStyles = false
+        hasPoolId = true
+        cvr = cvrr.copy(poolId=1)
+        target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(listOf(cvr).iterator()), phantomCvrs=null, styles=null)
+        card = target.next()
+        // testOneTarget("", cvr, card, auditType, hasStyle, hasPoolId, hasCardStyles, expectStyle = null)
+    }
+
+    @Test
+    fun testCvrsWithStylesToCardsForOA() {
+        val cvrr = makeCvr(abs(Random.nextInt()), 2 + Random.nextInt(3), 2 + Random.nextInt(2))
+        val cvrc = cvrr.copy(poolId=null)
+        val cvrp = cvrr.copy(poolId=2)
+        val cvrs = listOf(cvrc, cvrp)
+
+        var auditType = AuditType.ONEAUDIT
+        var hasStyle = true
+        var hasCardStyles = true
+        var hasPoolId = true
+
+        val cardStyle = CardStyle("oapool2", 2, emptyList(), listOf(0,1,2), null)
+        var target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(cvrs.iterator()), phantomCvrs=null, styles=listOf(cardStyle), )
+        testOneTarget("oa hasStyle", cvrc, target.next(), auditType, hasStyle, hasPoolId, hasCardStyles, null)
+        testOneTarget("oa hasStyle pooled", cvrp, target.next(), auditType, hasStyle, hasPoolId, hasCardStyles, cardStyle)
+
+        // noStyle means must supply the list of possibleContests for pooled data and cvrs
+        hasStyle = false
+        hasCardStyles = true
+        hasPoolId = true
+        target = CvrsWithStylesToCards(auditType, cvrsAreComplete=hasStyle, Closer(cvrs.iterator()), phantomCvrs=null, styles=listOf(cardStyle), )
+        testOneTarget("oa noStyle", cvrc, target.next(), auditType, hasStyle, hasPoolId, hasCardStyles, null)
+        testOneTarget("oa noStyle pooled", cvrp, target.next(), auditType, hasStyle, hasPoolId, hasCardStyles, cardStyle)
+    }
+
+
+    fun testOneTarget(what: String, cvr: Cvr, card: AuditableCard, auditType: AuditType, hasStyle: Boolean, hasPoolId: Boolean, hasCardStyles: Boolean, expectStyle:CardStyle?) {
+        println("$what [$auditType hasStyle=$hasStyle hasPoolId:$hasPoolId hasCardStyles:$hasCardStyles]:")
+        println("  ${cvr.show()}")
+        println("  ${card.show()}")
+        println()
+
+        if (auditType.isClca()) {
+            assertEquals(cvr, card.cvr())
+            assertNotNull(card.votes)
+            assertEquals(cvr.votes, card.votes)
+
+        } else if (auditType.isPolling()) {
+            assertNull(card.votes)
+        }
+
+        assertEquals(cvr.id, card.location)
+        assertEquals(cvr.phantom, card.phantom)
+        assertEquals(cvr.poolId, card.poolId, "poolId")
+        assertEquals(expectStyle?.name(), card.cardStyle, "cardStyle")
+
+        val expectPossibleContests = when (auditType) {
+            AuditType.ONEAUDIT -> if (card.poolId == null && hasStyle) emptySet() else expectStyle?.contests()?.toSet() ?: emptySet()
+            AuditType.CLCA -> if (hasStyle) emptySet() else expectStyle?.contests()?.toSet() ?: emptySet()
+            AuditType.POLLING -> expectStyle?.contests()?.toSet() ?: cvr.contests().toSet()
+        }
+        assertEquals(expectPossibleContests, card.possibleContests.toSet(), "possibleContests")
+
+        val expectContests = when (auditType) {
+            AuditType.ONEAUDIT -> {
+                if (card.votes != null)
+                    card.votes.keys.toSet() // not correct; noStyles means cvrs are incomplete,
+                                            // but then we need poolId to see what pool; interferes with pooled vs nonpooled cards
+                                            // so cant do this case with Cvr as input
+                else
+                    expectPossibleContests
+            }
+            AuditType.CLCA -> if (hasStyle) card.votes!!.keys.toSet() else expectPossibleContests
+            AuditType.POLLING -> expectStyle?.contests()?.toSet() ?: cvr.contests().toSet()
+        }
+        assertEquals(expectContests, card.contests().toSet(), "card.contests()")
+    }
+}
+
+fun Cvr.show() = buildString {
+    append("$id phantom=$phantom votes={")
+    votes.toSortedMap().forEach { (id, cands) -> append("$id: ${cands.contentToString()}, ") }
+    append("} poolId=$poolId")
+}
+
+fun AuditableCard.show() = buildString {
+    append("$location phantom=$phantom")
+    if (votes != null) {
+        append(" votes={")
+        votes.toSortedMap().forEach { (id, cands) -> append("$id: ${cands.contentToString()}, ") }
+        append("}")
+    }
+    append(" poolId=$poolId")
+    append(" possibleContests=${possibleContests.contentToString()}")
+    append(" contests=${contests().contentToString()}")
+    append(" cardStyle=$cardStyle")
+
+}

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestAlphaMart.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestAlphaMart.kt
@@ -28,7 +28,7 @@ class TestAlphaMart {
         val marginRange= 0.01 .. 0.01
         val underVotePct= 0.20 .. 0.20
         val phantomRange= 0.005 .. 0.005
-        val test = MultiContestTestData(ncontests, nbs, N, hasStyle=true, marginRange, underVotePct, phantomRange)
+        val test = MultiContestTestData(ncontests, nbs, N, marginRange, underVotePct, phantomRange)
 
         val contest = test.contests.first()
         val contestUA = ContestUnderAudit(contest, isClca = false, hasStyle = true).addStandardAssertions()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestAssorterMargins.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestAssorterMargins.kt
@@ -22,7 +22,7 @@ class TestAssorterMargins {
     @Test
     fun testProblem() {
         //repeat(100) {
-            val test = MultiContestTestData(16, 13, 27703, hasStyle=true, 0.02..0.033)
+            val test = MultiContestTestData(16, 13, 27703, 0.02..0.033)
             test.contests.forEach { contest ->
                 val contestUA = ContestUnderAudit(contest, isClca = false).addStandardAssertions()
                 val cvrs = test.makeCvrsFromContests()
@@ -41,7 +41,7 @@ class TestAssorterMargins {
                 Arb.int(min = 2, max = 4),
                 Arb.int(min = 10000, max = 20000),
             ) { ncontests, nstyles, Nc ->
-                val test = MultiContestTestData(ncontests, nstyles, Nc, hasStyle=true, 0.011..0.033)
+                val test = MultiContestTestData(ncontests, nstyles, Nc, 0.011..0.033)
                 val cvrs = test.makeCvrsFromContests()
                 println("$ncontests, $nstyles, $Nc")
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestContest.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestContest.kt
@@ -284,7 +284,7 @@ class TestContest {
 
         val expectedShow = """Contest 'testContestInfo' (0) PLURALITY voteForN=1 votes={1=108, 0=100, 2=0} undervotes=1, voteForN=1
    winners=[1] Nc=211 Np=2 Nu=1 sumVotes=208
-   1/0 votes=108/100 diff=8 (w-l)/w =0.0741 Nb=211 dilutedMargin=3.7915%
+   1/0 votes=108/100 diff=8 (w-l)/w =0.0741 Nb=211 dilutedMargin=3.7915% reportedMargin=3.7915% recountMargin=7.4074% 
    0 'cand0': votes=100 
    1 'cand1': votes=108  (winner)
    2 'cand2': votes=0 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
@@ -18,7 +18,7 @@ class TestConsistentSampling {
 
     @Test
     fun testConsistentClcaSampling() {
-        val test = MultiContestTestData(20, 11, 20000, hasStyle=true)
+        val test = MultiContestTestData(20, 11, 20000)
         val contestsUAs: List<ContestUnderAudit> = test.contests.map {
             ContestUnderAudit(it, isClca = true).addStandardAssertions()
         }
@@ -63,7 +63,7 @@ class TestConsistentSampling {
 
     @Test
     fun testConsistentPollingSampling() {
-        val test = MultiContestTestData(20, 11, 20000, hasStyle=true)
+        val test = MultiContestTestData(20, 11, 20000)
         val contestsUAs: List<ContestUnderAudit> = test.contests.map { ContestUnderAudit(it, isClca = false).addStandardAssertions() }
         val contestRounds = contestsUAs.map{ contest -> ContestRound(contest, 1) }
         contestRounds.forEach { it.estSampleSize = it.Nc / 11 } // random
@@ -96,7 +96,7 @@ class TestConsistentSampling {
     @Test
     fun testUniformPollingSampling() {
         val N = 20000
-        val test = MultiContestTestData(20, 11, N, hasStyle=false)
+        val test = MultiContestTestData(20, 11, N)
         val contestsUAs: List<ContestUnderAudit> = test.contests.map { ContestUnderAudit(it, isClca = false).addStandardAssertions() }
         val contestRounds = contestsUAs.map{ contest -> ContestRound(contest, 1) }
         contestRounds.forEach { it.estSampleSize = 100 + Random.nextInt(it.Nc/2) }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestFuzzedErrors.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestFuzzedErrors.kt
@@ -13,7 +13,7 @@ class TestFuzzedErrors {
         val show = false
         val ncontests = 11
         val phantomPct = 0.02
-        val test = MultiContestTestData(ncontests, 1, 50000, hasStyle=true, phantomPctRange=phantomPct..phantomPct)
+        val test = MultiContestTestData(ncontests, 1, 50000, phantomPctRange=phantomPct..phantomPct)
         val contestsUA = test.contests.map { ContestUnderAudit(it).addStandardAssertions() }
         val cards = test.makeCardsFromContests()
         val fuzzPcts = listOf(0.0, 0.001, .005, .01, .02, .05)
@@ -72,7 +72,7 @@ fuzzPct 0.050: 0.0077, 0.0350, 0.0125, 0.0064, 0.06162
         val show = false
         val ncontests = 11
         val phantomPct = .02
-        val test = MultiContestTestData(ncontests, 1, 50000, hasStyle=true, phantomPctRange=phantomPct..phantomPct)
+        val test = MultiContestTestData(ncontests, 1, 50000, phantomPctRange=phantomPct..phantomPct)
         val contestsUA = test.contests.map { ContestUnderAudit(it).addStandardAssertions() }
         val cvrs = test.makeCvrsFromContests()
         val fuzzPcts = listOf(0.0, 0.001, .005, .01, .02, .05)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestFuzzedWithRaire.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestFuzzedWithRaire.kt
@@ -24,7 +24,7 @@ class TestFuzzedWithRaire {
         val show = false
 
         val testData =
-            MultiContestTestData(1, 4, N, hasStyle=true,
+            MultiContestTestData(1, 4, N,
                 marginRange = margin..margin,
                 underVotePctRange = underVotePct .. underVotePct,
                 phantomPctRange = phantomPct..phantomPct)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMakeFuzzedCvrs.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMakeFuzzedCvrs.kt
@@ -101,7 +101,7 @@ class TestMakeFuzzedCvrs {
         val choiceChanges = mutableListOf<MutableMap<String, Int>>()
         fuzzPcts.forEach { fuzzPct ->
             margins.forEach { margin ->
-                val test = MultiContestTestData(1, 1, N, hasStyle = true, margin..margin, underVotePctRange = 0.1..0.1)
+                val test = MultiContestTestData(1, 1, N, margin..margin, underVotePctRange = 0.1..0.1)
                 val cvrs = test.makeCvrsFromContests()
                 val contest = test.contests.first()
                 val ncands = contest.ncandidates
@@ -228,7 +228,7 @@ class TestMakeFuzzedCvrs {
     @Test
     fun testFuzzedCvrsMultipleContests() {
         val ncontests = 11
-        val test = MultiContestTestData(ncontests, 1, 50000, hasStyle = true)
+        val test = MultiContestTestData(ncontests, 1, 50000)
         println("contest = ${test.contests.first()}\n")
         val cvrs = test.makeCvrsFromContests()
         val ntrials = 2

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMultiContestTestData.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMultiContestTestData.kt
@@ -30,7 +30,7 @@ class TestMultiContestTestData {
     val infos: Map<Int, ContestInfo>
 
     init {
-        test = MultiContestTestData(ncontests, nbs, N, hasStyle=true, marginRange, underVotePct, phantomRange)
+        test = MultiContestTestData(ncontests, nbs, N, marginRange, underVotePct, phantomRange)
         infos = test.contests.associate { it.id to it.info }
     }
 
@@ -165,7 +165,7 @@ class TestMultiContestTestData {
         val underVotePct = 0.20..0.20
         val phantomPct = .05
         val phantomRange = phantomPct..phantomPct
-        val test = MultiContestTestData(ncontests, nbs, N, hasStyle=true, marginRange, underVotePct, phantomRange)
+        val test = MultiContestTestData(ncontests, nbs, N, marginRange, underVotePct, phantomRange)
         val calcN = test.ballotStylePartition.map { it.value }.sum()
         assertEquals(N, calcN)
         println(test)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/corla/TestCorlaEstimateSampleSize.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/corla/TestCorlaEstimateSampleSize.kt
@@ -17,7 +17,7 @@ class TestCorlaEstimateSampleSize {
 
     @Test
     fun testFindSampleSizePolling() {
-        val test = MultiContestTestData(20, 11, 20000, hasStyle=true)
+        val test = MultiContestTestData(20, 11, 20000)
         val contestsUA: List<ContestUnderAudit> = test.contests.map { ContestUnderAudit(it, isClca = false, hasStyle = true).addStandardAssertions() } // CORLA does polling?
 
         contestsUA.forEach { contest ->
@@ -30,7 +30,7 @@ class TestCorlaEstimateSampleSize {
 
     @Test
     fun testFindSampleSize() {
-        val test = MultiContestTestData(20, 11, 20000, hasStyle=true)
+        val test = MultiContestTestData(20, 11, 20000)
         val contestsUAs: List<ContestUnderAudit> = test.contests.map { ContestUnderAudit( it, isClca = true, hasStyle = true).addStandardAssertions() }
         val cvrs = test.makeCvrsFromContests()
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestCardPool.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestCardPool.kt
@@ -39,7 +39,7 @@ class TestCardPool {
 
     @Test
     fun testAddUndervotes() {
-        val test = MultiContestTestData(20, 11, 20000, hasStyle=true)
+        val test = MultiContestTestData(20, 11, 20000)
         val contestsUAs: List<ContestUnderAudit> = test.contests.map {
             ContestUnderAudit(it, isClca = true).addStandardAssertions()
         }
@@ -70,7 +70,7 @@ class TestCardPool {
 
     @Test
     fun testCardPool() {
-        val test = MultiContestTestData(20, 11, 20000, hasStyle=true)
+        val test = MultiContestTestData(20, 11, 20000)
         val contestsUAs: List<ContestUnderAudit> = test.contests.map {
             ContestUnderAudit(it, isClca = true).addStandardAssertions()
         }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditRoundJson.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditRoundJson.kt
@@ -23,7 +23,7 @@ class TestAuditRoundJson {
 
     @Test
     fun testRoundtrip() {
-        val testData = MultiContestTestData(11, 4, 50000,  hasStyle=false)
+        val testData = MultiContestTestData(11, 4, 50000)
         val contestsUAs: List<ContestUnderAudit> = testData.contests. map { ContestUnderAudit(it, isClca=false, hasStyle=false).addStandardAssertions()}
         val contestRounds = contestsUAs.map{ contest ->
             val cr = ContestRound(contest, 1,)
@@ -70,7 +70,7 @@ class TestAuditRoundJson {
     @Test
     fun testRoundtripIO() {
 
-        val testData = MultiContestTestData(11, 4, 50000, hasStyle=false)
+        val testData = MultiContestTestData(11, 4, 50000)
         val contestsUAs: List<ContestUnderAudit> = testData.contests. map { ContestUnderAudit(it, isClca=false, hasStyle=false).addStandardAssertions()}
         val contestRounds = contestsUAs.map{ contest ->
             val cr = ContestRound(contest, 1)
@@ -116,7 +116,7 @@ class TestAuditRoundJson {
             AuditType.CLCA, hasStyle = true, seed = 12356667890L, nsimEst = 10,
         )
         val N = 5000
-        val testData = MultiContestTestData(11, 4, N, hasStyle=false, marginRange = 0.03..0.05)
+        val testData = MultiContestTestData(11, 4, N, marginRange = 0.03..0.05)
 
         val contests: List<Contest> = testData.contests
         println("Start testComparisonWorkflow $testData")
@@ -170,7 +170,7 @@ class TestAuditRoundJson {
         )
 
         val N = 5000
-        val testData = MultiContestTestData(11, 4, N, config.hasStyle , marginRange = 0.03..0.05)
+        val testData = MultiContestTestData(11, 4, N, marginRange = 0.03..0.05)
 
         val contests: List<Contest> = testData.contests
         println("Start testComparisonWorkflow $testData")

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCardBuilders.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCardBuilders.kt
@@ -11,7 +11,7 @@ class TestCardBuilders {
 
     @Test
     fun testConvertCardsRoundtrip() {
-        val test = MultiContestTestData(20, 11, 20000, hasStyle=true)
+        val test = MultiContestTestData(20, 11, 20000)
         val cards = test.makeCardsFromContests()
         val cardMap = cards.associateBy { it.location }
 
@@ -39,7 +39,7 @@ class TestCardBuilders {
     @Test
     fun testFuzzedCards() {
         val ncontests = 20
-        val test = MultiContestTestData(ncontests, 11, 50000, hasStyle=true)
+        val test = MultiContestTestData(ncontests, 11, 50000)
         val contests: List<Contest> = test.contests
         val cards = test.makeCardsFromContests()
         val cvrs = cards.map { it.cvr() }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCvrBuilders.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCvrBuilders.kt
@@ -10,7 +10,7 @@ class TestCvrBuilders {
 
     @Test
     fun testConvertCvrsRoundtrip() {
-        val test = MultiContestTestData(20, 11, 20000, hasStyle=true)
+        val test = MultiContestTestData(20, 11, 20000)
         val contests: List<Contest> = test.contests
         val cvrs = test.makeCvrsFromContests()
 
@@ -35,7 +35,7 @@ class TestCvrBuilders {
     @Test
     fun testFuzzedCvrs() {
         val ncontests = 20
-        val test = MultiContestTestData(ncontests, 11, 50000, hasStyle=true)
+        val test = MultiContestTestData(ncontests, 11, 50000)
         val contests: List<Contest> = test.contests
         val cvrs = test.makeCvrsFromContests()
         val detail = false

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestClcaAudit.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestClcaAudit.kt
@@ -24,7 +24,7 @@ class TestClcaAudit {
         val underVotePct= 0.02 .. 0.12
         val phantomPct= 0.00
         val phantomRange= phantomPct .. phantomPct
-        val testData = MultiContestTestData(ncontests, nbs, N, config.hasStyle, marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
+        val testData = MultiContestTestData(ncontests, nbs, N, marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
 
         // val errorRates = ClcaErrorRates(0.0, phantomPct, 0.0, 0.0, )
         // val config = config.copy(clcaConfig = ClcaConfig(ClcaStrategyType.apriori, errorRates=errorRates))
@@ -42,7 +42,7 @@ class TestClcaAudit {
         val marginRange= 0.015 .. 0.05
         val underVotePct= 0.02 .. 0.12
         val phantomPct= 0.00 .. 0.00
-        val testData = MultiContestTestData(ncontests, nbs, N, config.hasStyle, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomPct)
+        val testData = MultiContestTestData(ncontests, nbs, N, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomPct)
 
         val finalRound = testClcaWorkflow(config, testData)
         assertNotNull(finalRound)
@@ -57,7 +57,7 @@ class TestClcaAudit {
         val marginRange= 0.01 .. 0.05
         val underVotePct= 0.02 .. 0.22
         val phantomPct= 0.005 .. 0.005
-        val testData = MultiContestTestData(ncontests, nbs, N, config.hasStyle, marginRange =marginRange, underVotePctRange=underVotePct, phantomPctRange=phantomPct)
+        val testData = MultiContestTestData(ncontests, nbs, N, marginRange =marginRange, underVotePctRange=underVotePct, phantomPctRange=phantomPct)
 
         val finalRound = testClcaWorkflow(config, testData)
         assertNotNull(finalRound)
@@ -72,7 +72,7 @@ class TestClcaAudit {
         val underVotePct= 0.02 .. 0.22
         val phantomPct= 0.005
         val phantomRange= phantomPct .. phantomPct
-        val testData = MultiContestTestData(ncontests, nbs, N, config.hasStyle, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
+        val testData = MultiContestTestData(ncontests, nbs, N, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
 
         val errorRates = ClcaErrorRates(0.0, phantomPct, 0.0, 0.0, ) // TODO automatic
         val config = config.copy(clcaConfig = ClcaConfig(ClcaStrategyType.apriori, errorRates=errorRates))
@@ -85,7 +85,7 @@ class TestClcaAudit {
     @Test
     fun testClcaWithSimFuzz() {
         val config = config.copy(clcaConfig = ClcaConfig(ClcaStrategyType.fuzzPct, simFuzzPct=0.05))
-        val testData = MultiContestTestData(11, 1, N, config.hasStyle, )
+        val testData = MultiContestTestData(11, 1, N,  )
         val finalRound = testClcaWorkflow(config, testData)
         assertNotNull(finalRound)
         println(finalRound.show())
@@ -93,7 +93,7 @@ class TestClcaAudit {
 
     @Test
     fun testClcaWithMvrFuzz() {
-        val testData = MultiContestTestData(11, 1, N, config.hasStyle,)
+        val testData = MultiContestTestData(11, 1, N, )
         val finalRound = testClcaWorkflow(config, testData, .05)
         assertNotNull(finalRound)
         println(finalRound.show())
@@ -102,7 +102,7 @@ class TestClcaAudit {
     @Test // TODO oracle disabled
     fun testClcaOracle() {
         val config = config.copy(clcaConfig = ClcaConfig(ClcaStrategyType.oracle))
-        val testData = MultiContestTestData(11, 4, N, config.hasStyle,)
+        val testData = MultiContestTestData(11, 4, N, )
         val finalRound = testClcaWorkflow(config, testData)
         assertNotNull(finalRound)
         println(finalRound.show())
@@ -111,7 +111,7 @@ class TestClcaAudit {
     @Test
     fun testClcaPhantoms() {
         val config = config.copy(clcaConfig = ClcaConfig(ClcaStrategyType.phantoms))
-        val testData = MultiContestTestData(11, 4, N, config.hasStyle,)
+        val testData = MultiContestTestData(11, 4, N, )
         val finalRound = testClcaWorkflow(config, testData)
         assertNotNull(finalRound)
         println(finalRound.show())
@@ -120,7 +120,7 @@ class TestClcaAudit {
     @Test
     fun testClcaPhantomStrategy() {
         val config = config.copy(clcaConfig = ClcaConfig(ClcaStrategyType.phantoms))
-        val testData = MultiContestTestData(11, 4, N, config.hasStyle,)
+        val testData = MultiContestTestData(11, 4, N, )
         val finalRound = testClcaWorkflow(config, testData)
         assertNotNull(finalRound)
         println(finalRound.show())

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestClcaAuditNoStyles.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestClcaAuditNoStyles.kt
@@ -20,7 +20,7 @@ class TestClcaAuditNoStyles {
         val underVotePct= 0.02 .. 0.12
         val phantomPct= 0.005
         val phantomRange= phantomPct .. phantomPct
-        val testData = MultiContestTestData(ncontests, nbs, N, hasStyle=false, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
+        val testData = MultiContestTestData(ncontests, nbs, N, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
 
         val errorRates = ClcaErrorRates(0.0, phantomPct, 0.0, 0.0, )
         val config = AuditConfig(
@@ -39,7 +39,7 @@ class TestClcaAuditNoStyles {
         val underVotePct= 0.02 .. 0.12
         val phantomPct= 0.005
         val phantomRange= phantomPct .. phantomPct
-        val testData = MultiContestTestData(ncontests, nbs, N, hasStyle=false, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
+        val testData = MultiContestTestData(ncontests, nbs, N, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
 
         val errorRates = ClcaErrorRates(0.0, phantomPct, 0.0, 0.0, )
         val config = AuditConfig(
@@ -65,7 +65,7 @@ class TestClcaAuditNoStyles {
         val marginRange= 0.015 .. 0.05
         val underVotePct= 0.02 .. 0.12
         val phantomPct= 0.00 .. 0.00
-        val testData = MultiContestTestData(ncontests, nbs, N, hasStyle=false, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomPct)
+        val testData = MultiContestTestData(ncontests, nbs, N, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomPct)
         testClcaWorkflow(config, testData)
     }
 
@@ -77,7 +77,7 @@ class TestClcaAuditNoStyles {
         val marginRange= 0.01 .. 0.05
         val underVotePct= 0.02 .. 0.22
         val phantomPct= 0.005 .. 0.005
-        val testData = MultiContestTestData(ncontests, nbs, N, hasStyle=false, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomPct)
+        val testData = MultiContestTestData(ncontests, nbs, N, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomPct)
         testClcaWorkflow(config, testData)
     }
 
@@ -89,7 +89,7 @@ class TestClcaAuditNoStyles {
         val underVotePct= 0.02 .. 0.22
         val phantomPct= 0.005
         val phantomRange= phantomPct .. phantomPct
-        val testData = MultiContestTestData(ncontests, nbs, N, hasStyle=false, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
+        val testData = MultiContestTestData(ncontests, nbs, N, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
 
         val errorRates = ClcaErrorRates(0.0, phantomPct, 0.0, 0.0, )
         val config = AuditConfig(
@@ -107,7 +107,7 @@ class TestClcaAuditNoStyles {
         )
 
         val N = 50000
-        val testData = MultiContestTestData(11, 4, N, config.hasStyle)
+        val testData = MultiContestTestData(11, 4, N)
         testClcaWorkflow(config, testData)
     }
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestOneRoundClcaAudit.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestOneRoundClcaAudit.kt
@@ -18,7 +18,7 @@ class TestOneRoundClcaAudit {
         val underVotePct= 0.02 .. 0.12
         val phantomPct= 0.005
         val phantomRange= phantomPct .. phantomPct
-        val testData = MultiContestTestData(ncontests, nbs, N, hasStyle=true, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
+        val testData = MultiContestTestData(ncontests, nbs, N, marginRange =marginRange, underVotePctRange =underVotePct, phantomPctRange =phantomRange)
 
         val errorRates = ClcaErrorRates(0.0, phantomPct, 0.0, 0.0, )
         val config = config.copy(clcaConfig = ClcaConfig(ClcaStrategyType.apriori, errorRates=errorRates))

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistedWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistedWorkflow.kt
@@ -27,7 +27,7 @@ class TestPersistedWorkflow {
             clcaConfig = ClcaConfig(strategy=ClcaStrategyType.previous, simFuzzPct = .005))
 
         val N = 50000
-        val testData = MultiContestTestData(11, 4, N, hasStyle=true, marginRange=0.03..0.05)
+        val testData = MultiContestTestData(11, 4, N, marginRange=0.03..0.05)
 
         val contests: List<Contest> = testData.contests
         println("Start testPersistedAuditClca $testData")
@@ -51,7 +51,7 @@ class TestPersistedWorkflow {
         val config = AuditConfig(AuditType.POLLING, hasStyle=true, seed = 12356667890L, nsimEst=10)
 
         val N = 50000
-        val testData = MultiContestTestData(11, 4, N, hasStyle=true, marginRange=0.03..0.05)
+        val testData = MultiContestTestData(11, 4, N, marginRange=0.03..0.05)
 
         val contests: List<Contest> = testData.contests
         println("Start testPersistedAuditPolling $testData")
@@ -95,8 +95,6 @@ class TestPersistedWorkflow {
 
         val election = CreateElectionFromCvrs(contestsUA, testCvrs, cardPools, config=config)
         CreateAudit("testPersistedAuditPolling", topdir, config, election, clear = true)
-
-        runPersistedAudit(topdir)
 
         runPersistedAudit(topdir)
     }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPollingAudit.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPollingAudit.kt
@@ -33,7 +33,6 @@ class TestPollingAudit {
             ncontests,
             nbs,
             N,
-            hasStyle=auditConfig.hasStyle,
             marginRange = marginRange,
             underVotePctRange = underVotePct,
             phantomPctRange = phantomPct
@@ -72,7 +71,6 @@ class TestPollingAudit {
             ncontests,
             nbs,
             N,
-            auditConfig.hasStyle,
             marginRange = marginRange,
             underVotePctRange = underVotePct,
             phantomPctRange = phantomPct
@@ -118,7 +116,6 @@ class TestPollingAudit {
             ncontests,
             nbs,
             N,
-            auditConfig.hasStyle,
             marginRange = marginRange,
             underVotePctRange = underVotePct,
             phantomPctRange = phantomPct
@@ -147,7 +144,6 @@ class TestPollingAudit {
             ncontests,
             nbs,
             Nc,
-            true,
             marginRange = marginRange,
             underVotePctRange = underVotePct,
             phantomPctRange = phantomPct

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaStartFuzz.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaStartFuzz.kt
@@ -123,7 +123,7 @@ class TestPollingElection(
         val useMin = min(minMargin, maxMargin)
         val phantomPctRange: ClosedFloatingPointRange<Double> =
             if (pctPhantoms == null) 0.00..0.005 else pctPhantoms..pctPhantoms
-        val testData = MultiContestTestData(ncontests, 4, ncards, config.hasStyle, marginRange = useMin..maxMargin, phantomPctRange = phantomPctRange)
+        val testData = MultiContestTestData(ncontests, 4, ncards, marginRange = useMin..maxMargin, phantomPctRange = phantomPctRange)
 
         val contests: List<Contest> = testData.contests
         println("Start testPersistentWorkflowPolling $testData")
@@ -211,7 +211,7 @@ class TestClcaElection(
             if (pctPhantoms == null) 0.00..0.005 else pctPhantoms..pctPhantoms
 
         val testData =
-            MultiContestTestData(ncontests, 4, ncards, config.hasStyle, marginRange = useMin..maxMargin, phantomPctRange = phantomPctRange)
+            MultiContestTestData(ncontests, 4, ncards, marginRange = useMin..maxMargin, phantomPctRange = phantomPctRange)
         println("$testData")
 
         // Synthetic cvrs for testing, reflecting the exact contest votes, plus undervotes and phantoms.

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/GenerateClcaErrorTable.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/GenerateClcaErrorTable.kt
@@ -86,7 +86,7 @@ class GenerateClcaErrorTable {
         val show = false
         val ncontests = 11
         val phantomPct = 0.02
-        val test = MultiContestTestData(ncontests, 1, 50000, hasStyle=true, phantomPctRange=phantomPct..phantomPct)
+        val test = MultiContestTestData(ncontests, 1, 50000, phantomPctRange=phantomPct..phantomPct)
         val contestsUA = test.contests.map { ContestUnderAudit(it).addStandardAssertions() }
         val cards = test.makeCardsFromContests()
         val fuzzPcts = listOf(0.0, 0.001, .005, .01, .02, .05)

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/TestAuditPolling.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/TestAuditPolling.kt
@@ -34,7 +34,7 @@ class TestAuditPolling {
         val marginRange= 0.01 .. 0.01
         val underVotePct= 0.20 .. 0.20
         val phantomRange= 0.005 .. 0.005
-        val test = MultiContestTestData(ncontests, nbs, N, hasStyle=true, marginRange, underVotePct, phantomRange)
+        val test = MultiContestTestData(ncontests, nbs, N, marginRange, underVotePct, phantomRange)
 
         val contest = test.contests.first()
         val contestUA = ContestUnderAudit(contest, isClca = false).addStandardAssertions()

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestClcaEstimationFailure.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestClcaEstimationFailure.kt
@@ -21,7 +21,7 @@ class TestClcaEstimationFailure {
     @Test
     fun testClcaEstimationFailure() {
         // TODO margin not accounting for phantoms
-        val test = MultiContestTestData(50, 25, 50000, hasStyle=true) // , phantomPctRange = 0.0 .. 0.0)
+        val test = MultiContestTestData(50, 25, 50000) // , phantomPctRange = 0.0 .. 0.0)
         val testCvrs = test.makeCvrsFromContests()
 
         val auditConfig = AuditConfig(

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestClcaFuzzSampler.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestClcaFuzzSampler.kt
@@ -15,7 +15,7 @@ class TestClcaFuzzSampler {
 
     @Test
     fun testComparisonFuzzed() {
-        val test = MultiContestTestData(20, 11, 20000, hasStyle=true)
+        val test = MultiContestTestData(20, 11, 20000)
         val contestsUA: List<ContestUnderAudit> = test.contests.map { ContestUnderAudit(it).addStandardAssertions() }
         val cvrs = test.makeCvrsFromContests()
         println("total ncvrs = ${cvrs.size}\n")


### PR DESCRIPTION
refine AuditableCard meaning
AuditableCard.hasStyle -> cvrsAreComplete
ContestUnderAudit.make()
writeAuditableCardCsv: always save possibleContests, not cardStyle (for now) 
VerifyContests: add verifyOApools, fix verifyOAassortAvg 
add TestCvrsWithStylesToCards, TestCardsWithStylesToCards