### PR TITLE
refactor hasStyle

### DIFF
--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/belgium/CreateBelgiumClca.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/belgium/CreateBelgiumClca.kt
@@ -11,7 +11,6 @@ private val logger = KotlinLogging.logger("BelgiumClca")
 
 class BelgiumClca (
     contestd: DHondtContest,
-    val hasStyle: Boolean,
 ): CreateElectionPIF {
 
     val infoMap: Map<Int, ContestInfo>
@@ -19,7 +18,7 @@ class BelgiumClca (
     val cvrs: List<Cvr>
 
     init {
-        val contestUA = ContestUnderAudit(contestd, isClca=true, hasStyle=hasStyle).addAssertionsFromAssorters(contestd.assorters)
+        val contestUA = ContestUnderAudit(contestd, isClca=true).addAssertionsFromAssorters(contestd.assorters)
         contestsUA = listOf(contestUA)
         infoMap = contestsUA.associate { it.id to it.contest.info() }
         cvrs = contestd.createSimulatedCvrs()
@@ -54,7 +53,7 @@ fun createBelgiumClca(
             AuditType.CLCA, hasStyle = true, removeCutoffContests = false, riskLimit = .05, nsimEst=10, minRecountMargin=0.0, simFuzzPct = 0.001, // auditSampleLimit=1000,
         )
     }
-    val election = BelgiumClca(contestd, config.hasStyle)
+    val election = BelgiumClca(contestd)
 
     CreateAuditP("belgiumClca", config, election, auditdir, clear = clear)
     println("createBelgiumClca took $stopwatch")

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/boulder/CreateBoulderElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/boulder/CreateBoulderElection.kt
@@ -63,7 +63,7 @@ class CreateBoulderElection(
         val manifestTabs = tabulateAuditableCards(createCardManifest(), infoMap)
         val contestNbs = manifestTabs.mapValues { it.value.ncards }
 
-        contestsUA = makeOneAuditContests(hasStyle, contests, contestNbs, cardPools).sortedBy { it.id }
+        contestsUA = makeOneAuditContests(contests, contestNbs, cardPools).sortedBy { it.id }
 
         val totalRedactedBallots = cardPools.sumOf { it.ncards() }
         logger.info { "number of redacted ballots = $totalRedactedBallots in ${cardPools.size} cardPools"}

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/boulder/CreateBoulderElectionP.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/boulder/CreateBoulderElectionP.kt
@@ -29,7 +29,6 @@ class CreateBoulderElectionP(
     val sovo: BoulderStatementOfVotes,
     val isClca: Boolean,
     val distributeOvervotes: List<Int> = listOf(0, 63),
-    val hasStyle: Boolean = true,
     val quiet: Boolean = true,
 ): CreateElectionPIF {
     val exportCvrs: List<Cvr> = export.cvrs.map { it.convertToCvr() }
@@ -65,7 +64,7 @@ class CreateBoulderElectionP(
         val manifestTabs = tabulateAuditableCards(createCardManifest(), infoMap)
         val contestNbs = manifestTabs.mapValues { it.value.ncards }
 
-        contestsUA = makeOneAuditContests(hasStyle, contests, contestNbs, cardPools).sortedBy { it.id }
+        contestsUA = makeOneAuditContests(contests, contestNbs, cardPools).sortedBy { it.id }
 
         val totalRedactedBallots = cardPools.sumOf { it.ncards() }
         logger.info { "number of redacted ballots = $totalRedactedBallots in ${cardPools.size} cardPools"}
@@ -348,7 +347,7 @@ fun createBoulderElectionP(
         )
     else throw RuntimeException("unsupported audit type $auditType")
 
-    val election = CreateBoulderElectionP(export, sovo, isClca = auditType.isClca(), hasStyle=config.hasStyle)
+    val election = CreateBoulderElectionP(export, sovo, isClca = auditType.isClca())
 
     CreateAuditP("boulder", config, election, auditDir = auditDir, clear = clear)
     println("createBoulderElectionOAnew took $stopwatch")

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoElection.kt
@@ -56,7 +56,7 @@ open class CreateColoradoElection (
             undervote.add(it.poolUndervote(cardPools))
         }
         contests = makeContests()
-        contestsUA = ContestUnderAudit.make(contests, createCardManifest(), isClca=true, hasStyle)
+        contestsUA = ContestUnderAudit.make(contests, createCardManifest(), isClca=true)
     }
 
     private fun makeOneContestInfo(electionDetailXml: ElectionDetailXml, roundContests: List<CorlaContestRoundCsv>): List<OneAuditContestCorla> {

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoElectionP.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoElectionP.kt
@@ -22,7 +22,6 @@ open class CreateColoradoElectionP (
     contestRoundFile: String,
     precinctFile: String,
     val config: AuditConfig,
-    val hasStyle: Boolean = true,
 ): CreateElectionPIF {
     val roundContests: List<CorlaContestRoundCsv> = readColoradoContestRoundCsv(contestRoundFile)
     val electionDetailXml: ElectionDetailXml = readColoradoElectionDetail(electionDetailXmlFile)
@@ -55,7 +54,7 @@ open class CreateColoradoElectionP (
 
         cardPools = cardPoolBuilders.map { it.toOneAuditPool() }
         contests = makeContests()
-        contestsUA = ContestUnderAudit.make(contests, createCardManifest(), isClca=true, hasStyle)
+        contestsUA = ContestUnderAudit.make(contests, createCardManifest(), isClca=true, )
     }
 
     private fun makeOneContestInfo(electionDetailXml: ElectionDetailXml, roundContests: List<CorlaContestRoundCsv>): List<OneAuditContestCorla> {

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoPolling.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoPolling.kt
@@ -38,7 +38,7 @@ class ColoradoPolling (
             val contest = Contest(info, candVotes, useNc, ncards)
             info.metadata["PoolPct"] = (100.0 * oaContest.poolTotalCards() / useNc).toInt()
             val Nb = tabs[contest.id]?.ncards // tabs.ncards + contest.Np TODO
-            ContestUnderAudit(contest, isClca=false, hasStyle=config.hasStyle, NpopIn=Nb).addStandardAssertions()
+            ContestUnderAudit(contest, isClca=false, NpopIn=Nb).addStandardAssertions()
         }
 
         return regContests

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionP.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElectionP.kt
@@ -31,7 +31,6 @@ class CreateSfElectionP(
     candidateManifestFile: String,
     val cvrExportCsv: String,
     val config: AuditConfig,
-    val hasStyle:Boolean,
 ): CreateElectionPIF {
     val cardPoolMapByName: Map<String, OneAuditPoolIF>
     val cardPools: List<OneAuditPoolIF>
@@ -70,12 +69,12 @@ class CreateSfElectionP(
         println("contestNbs= ${contestNbs}")
 
         // make contests based on cvr tabulations
-        contestsUA = if (config.isClca) makeClcaContests(allCvrTabs, contestNcs, contestNbs, hasStyle).sortedBy { it.id }
+        contestsUA = if (config.isClca) makeClcaContests(allCvrTabs, contestNcs, contestNbs).sortedBy { it.id }
             else if (config.isOA) {
                 val contests = makeContests(allCvrTabs, unpooledPool, contestNcs) // TODO leave out IRV
-                makeOneAuditContests(hasStyle, contests, contestNbs, cardPools).sortedBy { it.id }
+                makeOneAuditContests(contests, contestNbs, cardPools).sortedBy { it.id }
             }
-            else makePollingContests(allCvrTabs, contestNcs, contestNbs, hasStyle).sortedBy { it.id }
+            else makePollingContests(allCvrTabs, contestNcs, contestNbs).sortedBy { it.id }
     }
 
     fun createCardPools(
@@ -216,7 +215,6 @@ fun createSfElectionP(
         candidateManifestFile,
         cvrExportCsv,
         config = config,
-        hasStyle = hasStyle,
     )
 
     CreateAuditP("sf2024", config, election, auditDir = "$topdir/audit", )

--- a/cases/src/test/kotlin/org/cryptobiotic/cli/ShowPoolSizes.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/cli/ShowPoolSizes.kt
@@ -27,7 +27,7 @@ class ShowPoolSizes {
         val allContests = if (contestsResults is Ok) contestsResults.unwrap().sortedBy { it.id } else null
         val infos = allContests?.map{ it.contest.info() }?.associateBy { it.id }
 
-        val cardManifest = readCardManifest(publisher, infos!!)
+        val cardManifest = readCardManifest(publisher)
         val ncards = cardManifest.populations.map { it.ncards() }
         val deciles = makeDeciles(ncards)
         println(" $what ncards deciles = $deciles npools= ${cardManifest.populations.size}")

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestComparisonSamplerWithRaire.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestComparisonSamplerWithRaire.kt
@@ -47,7 +47,7 @@ class TestComparisonSamplerWithRaire {
         val sampleMvrs = sampler.mvrs.map { cassorter.assorter().assort(it) }.average()
         println(" orgCvrs=${df(orgCvrs)} sampleCvrs=${df(sampleCvrs)} sampleMvrs=${df(sampleMvrs)}")
 
-        val before = cvrs.map { cassorter.bassort(it, it) }.average()
+        val before = cvrs.map { cassorter.bassort(it, it, hasStyle=true) }.average()
         sampler.reset()
         val welford = Welford()
         repeat(cvrs.size) {

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestReadRaireBallotsCsv.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestReadRaireBallotsCsv.kt
@@ -37,8 +37,8 @@ class TestReadRaireBallotsCsv {
             assertTrue(0.5 < margin2mean(cassertion.assorter.dilutedMargin()))
             cvrs.forEach {
                 assertTrue(cassertion.cassorter.assorter().assort(it) in 0.0..cassertion.cassorter.assorter().upperBound())
-                if (!it.phantom) assertEquals(cassertion.cassorter.noerror(), cassertion.cassorter.bassort(it, it))
-                else assertEquals(cassertion.cassorter.noerror()/2, cassertion.cassorter.bassort(it, it))
+                if (!it.phantom) assertEquals(cassertion.cassorter.noerror(), cassertion.cassorter.bassort(it, it, hasStyle=true))
+                else assertEquals(cassertion.cassorter.noerror()/2, cassertion.cassorter.bassort(it, it, hasStyle=true))
             }
         }
     }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCard.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCard.kt
@@ -79,6 +79,14 @@ data class AuditableCard (
             else intArrayOf()
     }
 
+    // better if every card has a population
+    fun exactContests(): Boolean {
+        return if (population != null) population.exactContests()
+        else if (cardStyle == "all") false
+        else true // else config.cvrsHaveUndervotes
+
+    }
+
     // Let 1candidate(bi) = 1 if ballot i has a mark for candidate, and 0 if not; SHANGRLA section 2, page 4
     override fun hasMarkFor(contestId: Int, candidateId: Int): Int {
         val contestVotes = votes?.get(contestId)
@@ -131,6 +139,11 @@ data class AuditableCard (
             // val sortedVotes = cvr.votes.toSortedMap()
             // val contests = sortedVotes.keys.toList()
             return AuditableCard(cvr.id, index, prn=prn, cvr.phantom, cvr.votes, cvr.poolId)
+        }
+        fun fromCvrs(cvrs: List<Cvr>): List<AuditableCard> {
+            // val sortedVotes = cvr.votes.toSortedMap()
+            // val contests = sortedVotes.keys.toList()
+            return cvrs.mapIndexed { idx, cvr -> AuditableCard.fromCvr(cvr, idx, 0) }
         }
     }
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/Population.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/Population.kt
@@ -20,7 +20,7 @@ data class NamedCardStyle(
 interface PopulationIF {
     fun name(): String
     fun id(): Int
-    fun contests(): IntArray // each card may have any of these contests
+    fun contests(): IntArray // any card may have any of these contests
     fun exactContests(): Boolean // each card has exactly these contests on it
     fun ncards(): Int
     fun hasContest(contestId: Int): Boolean

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAudit.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAudit.kt
@@ -144,7 +144,7 @@ fun runRoundAgain(auditDir: String, contestRound: ContestRound, assertionRound: 
     }
 }
 
-fun runClcaAudit(config: AuditConfig, cvrPairs: List<Pair<CvrIF, CvrIF>>, contestRound: ContestRound, assertionRound: AssertionRound, auditRoundResult: AuditRoundResult): TestH0Result? {
+fun runClcaAudit(config: AuditConfig, cvrPairs: List<Pair<CvrIF, AuditableCard>>, contestRound: ContestRound, assertionRound: AssertionRound, auditRoundResult: AuditRoundResult): TestH0Result? {
     try {
         val auditor = ClcaAssertionAuditor()
 
@@ -163,7 +163,7 @@ fun runClcaAudit(config: AuditConfig, cvrPairs: List<Pair<CvrIF, CvrIF>>, contes
     }
 }
 
-fun runOneAudit(config: AuditConfig, cvrPairs: List<Pair<CvrIF, CvrIF>>, pools: List<OneAuditPoolIF>, contestRound: ContestRound, assertionRound: AssertionRound, auditRoundResult: AuditRoundResult): TestH0Result? {
+fun runOneAudit(config: AuditConfig, cvrPairs: List<Pair<CvrIF, AuditableCard>>, pools: List<OneAuditPoolIF>, contestRound: ContestRound, assertionRound: AssertionRound, auditRoundResult: AuditRoundResult): TestH0Result? {
     try {
         val auditor = OneAuditAssertionAuditor(pools)
         val cassertion = assertionRound.assertion as ClcaAssertion

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/PluralityErrorRates.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/PluralityErrorRates.kt
@@ -116,7 +116,7 @@ object ClcaErrorTable {
     ) : PluralityErrorRates {
         require(cvrPairs.size > 0)
         val samples = PluralityErrorTracker(cassorter.noerror()) // accumulate error counts here
-        cvrPairs.filter { it.first.hasContest(contestId) }.forEach { samples.addSample(cassorter.bassort(it.first, it.second)) }
+        cvrPairs.filter { it.first.hasContest(contestId) }.forEach { samples.addSample(cassorter.bassort(it.first, it.second, true)) }
         // require( samples.errorCounts().sum() ==  cvrPairs.size)
         return samples.pluralityErrorRates()
     }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/SamplingForEstimation.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/SamplingForEstimation.kt
@@ -33,7 +33,7 @@ class ClcaCardFuzzSampler(
             val (mvr, card) = cvrPairs[permutedIndex[idx]]
             idx++
             if (card.hasContest(contest.id)) {
-                val result = cassorter.bassort(mvr.cvr(), card.cvr())
+                val result = cassorter.bassort(mvr.cvr(), card.cvr(), card.exactContests())
                 welford.update(result)
                 return result
             }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AssorterJson.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AssorterJson.kt
@@ -25,7 +25,6 @@ import org.cryptobiotic.rlauxe.raire.RaireAssorter
 data class ClcaAssorterJson(
     val className: String,
     val assorter: AssorterIFJson,
-    val hasStyle: Boolean,
     val dilutedMargin: Double,
     val poolAverages: AssortAvgsInPoolsJson?,
 )
@@ -35,7 +34,6 @@ fun ClcaAssorter.publishJson() : ClcaAssorterJson {
         ClcaAssorterJson(
             "OAClcaAssorter",
             this.assorter.publishJson(),
-            this.hasUndervotes,
             this.dilutedMargin,
             poolAverages.publishJson()
         )
@@ -44,7 +42,6 @@ fun ClcaAssorter.publishJson() : ClcaAssorterJson {
         ClcaAssorterJson(
             "ClcaAssorter",
             this.assorter.publishJson(),
-            this.hasUndervotes,
             this.dilutedMargin,
             null,
         )
@@ -57,7 +54,6 @@ fun ClcaAssorterJson.import(info: ContestInfo): ClcaAssorter {
             ClcaAssorter(
                 info,
                 this.assorter.import(info),
-                this.hasStyle,
                 this.dilutedMargin,
             )
 
@@ -65,7 +61,6 @@ fun ClcaAssorterJson.import(info: ContestInfo): ClcaAssorter {
             ClcaAssorterOneAudit(
                 info,
                 this.assorter.import(info),
-                this.hasStyle,
                 this.dilutedMargin,
                 poolAverages!!.import()
             )

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/ContestJson.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/ContestJson.kt
@@ -217,7 +217,6 @@ data class ContestUnderAuditJson(
     val info: ContestInfoJson, // This is where the infos are kept.
     val contest: ContestIFJson,
     val isComparison: Boolean,
-    val hasStyle: Boolean,
     var pollingAssertions: List<AssertionIFJson>,
     var clcaAssertions: List<ClcaAssertionJson>,
     val status: TestH0Status,
@@ -229,7 +228,6 @@ fun ContestUnderAudit.publishJson() : ContestUnderAuditJson {
         this.contest.info().publishJson(),
         this.contest.publishJson(),
         this.isClca,
-        this.hasCompleteCvrs,
         this.pollingAssertions.map { it.publishIFJson() },
         this.clcaAssertions.map { it.publishJson() },
         this.preAuditStatus,
@@ -239,7 +237,7 @@ fun ContestUnderAudit.publishJson() : ContestUnderAuditJson {
 
 fun ContestUnderAuditJson.import(): ContestUnderAudit {
     val info = this.info.import()
-    val contestUA = ContestUnderAudit(this.contest.import(info), isClca=this.isComparison, hasStyle=this.hasStyle, NpopIn = this.Npop)
+    val contestUA = ContestUnderAudit(this.contest.import(info), isClca=this.isComparison, NpopIn = this.Npop)
     contestUA.pollingAssertions = this.pollingAssertions.map { it.import(info) }
     contestUA.clcaAssertions = this.clcaAssertions.map { it.import(info) }
     contestUA.preAuditStatus = this.status

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/RaireJson.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/RaireJson.kt
@@ -34,7 +34,6 @@ fun RaireContestUnderAuditJson.import(): RaireContestUnderAudit {
     val result = RaireContestUnderAudit(
         raireContest as RaireContest,
         this.rassertions.map { it.import() },
-        hasStyle=contestUA.hasCompleteCvrs,
     )
     result.clcaAssertions = contestUA.clcaAssertions // TODO wonky
     return result

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/MakeRaireContest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/MakeRaireContest.kt
@@ -19,7 +19,7 @@ private val logger = KotlinLogging.logger("MakeRaireContest")
 // TODO diluted margin
 // make RaireContestUnderAudit from ContestTabulation; get RaireAssertions from raire-java libray
 // note ivrRoundsPaths are filled in
-fun makeRaireContestUA(info: ContestInfo, contestTab: ContestTabulation, Nc: Int, hasStyle: Boolean, Nbin: Int? = null): RaireContestUnderAudit {
+fun makeRaireContestUA(info: ContestInfo, contestTab: ContestTabulation, Nc: Int, Nbin: Int? = null): RaireContestUnderAudit {
     // TODO consistency checks on voteConsolidator
     // all candidate indexes
     val vc = contestTab.irvVotes
@@ -109,7 +109,6 @@ fun makeRaireContestUA(info: ContestInfo, contestTab: ContestTabulation, Nc: Int
         Ncast = contestTab.ncards,
         undervotes = contestTab.undervotes,
         raireAssertions,
-        hasStyle,
     )
 
     val candidateIdxs = info.candidateIds.mapIndexed { idx, candidateId -> idx } // TODO use candidateIdToIndex?

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireContest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/RaireContest.kt
@@ -101,8 +101,7 @@ data class RaireContest(
 class RaireContestUnderAudit(
     contest: RaireContest,
     val rassertions: List<RaireAssertion>,
-    hasStyle: Boolean = true,  // TODO do we really support hasStyle == false? // TODO should pass in Npop
-): ContestUnderAudit(contest, isClca=true, hasStyle=hasStyle) {
+): ContestUnderAudit(contest, isClca=true) {
     val candidates =  contest.info.candidateIds
 
     init {
@@ -153,7 +152,6 @@ class RaireContestUnderAudit(
                  Ncast: Int,
                  undervotes: Int,
                  assertions: List<RaireAssertion>,
-                 hasStyle: Boolean,
          ): RaireContestUnderAudit {
 
             val winnerId = info.candidateIds[winnerIndex]
@@ -164,7 +162,7 @@ class RaireContestUnderAudit(
                 Ncast = Ncast,
                 undervotes = undervotes,
             )
-            return RaireContestUnderAudit(contest, assertions, hasStyle=hasStyle)
+            return RaireContestUnderAudit(contest, assertions)
         }
     }
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyContests.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyContests.kt
@@ -50,7 +50,7 @@ class VerifyContests(val auditRecordLocation: String, val show: Boolean = false)
         }
         allInfos = allContests?.map{ it.contest.info() }?.associateBy { it.id }
 
-        cardManifest = readCardManifest(publisher, allInfos!!)
+        cardManifest = readCardManifest(publisher)
     }
 
     fun verify() = verify( allContests!!, show = show)
@@ -400,7 +400,7 @@ fun verifyOAassortAvg(
                 val avg = cardAssortAvgs.getOrPut(contestUA.id) { mutableMapOf() }
                 contestUA.clcaAssertions.forEach { cassertion ->
                     if (cassertion.cassorter is ClcaAssorterOneAudit) { //  may be Raire
-                        val oaCassorter = cassertion.cassorter as ClcaAssorterOneAudit
+                        val oaCassorter = cassertion.cassorter
                         val passorter = oaCassorter.assorter
                         val assortAvg = avg.getOrPut(passorter) { AssortAvg() }
                         if (card.hasContest(contestUA.id)) {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaAssertionAuditor.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaAssertionAuditor.kt
@@ -35,7 +35,7 @@ fun runClcaAuditRound(
 class RunClcaContestTask(
     val config: AuditConfig,
     val contest: ContestRound,
-    val cvrPairs: List<Pair<CvrIF, CvrIF>>, // Pair(mvr, card)
+    val cvrPairs: List<Pair<CvrIF, AuditableCard>>, // Pair(mvr, card)
     val auditor: ClcaAssertionAuditorIF,
     val roundIdx: Int): ConcurrentTaskG<Boolean> {
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManager.kt
@@ -16,7 +16,7 @@ interface MvrManager {
     fun sortedCards(): CloseableIterable<AuditableCard>  // most uses will just need the first n samples
     fun populations(): List<PopulationIF>?
     // fun sortedCvrs(): CloseableIterable<CardIF> = CloseableIterable { AuditableCardToCvrAdapter(sortedCards().iterator()) }
-    fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, CvrIF>>  // Pair(mvr, cvr)
+    fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCard>>  // Pair(mvr, cvr)
 
     fun oapools(): List<OneAuditPoolIF>? {
         val pop = populations()

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManager.kt
@@ -30,7 +30,7 @@ open class PersistedMvrManager(val auditDir: String, val config: AuditConfig, va
         return readPopulations(publisher)
     }
 
-    override fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, CvrIF>>  {
+    override fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCard>>  {
         val mvrsForRound = readMvrsForRound(round)
         val sampleNumbers = mvrsForRound.map { it.prn }
 
@@ -66,7 +66,7 @@ open class PersistedMvrManager(val auditDir: String, val config: AuditConfig, va
     fun auditableCards(): CloseableIterator<AuditableCard> = readCardsCsvIterator(publisher.sortedCardsFile())
 }
 
-fun readCardManifest(publisher: Publisher, infos: Map<Int, ContestInfo>): CardManifest {
+fun readCardManifest(publisher: Publisher): CardManifest {
 
     if (Files.exists(Path(publisher.populationsFile()))) {
         val populations = readPopulationsJsonFileUnwrapped(publisher.populationsFile())

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/Sampling.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/Sampling.kt
@@ -1,6 +1,7 @@
 package org.cryptobiotic.rlauxe.workflow
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.cryptobiotic.rlauxe.audit.AuditableCard
 import org.cryptobiotic.rlauxe.core.*
 import kotlin.random.Random
 
@@ -67,7 +68,7 @@ class PollingSampling(
 //// For clca audits. Production RunClcaContestTask
 class ClcaSampling(
     val contestId: Int,
-    val cvrPairs: List<Pair<CvrIF, CvrIF>>, // Pair(mvr, card)
+    val cvrPairs: List<Pair<CvrIF, AuditableCard>>, // Pair(mvr, card)
     val cassorter: ClcaAssorter,
     val allowReset: Boolean,
 ): Sampling, Iterator<Double> {
@@ -87,7 +88,7 @@ class ClcaSampling(
             val (mvr, card) = cvrPairs[permutedIndex[idx]]
             idx++
             if (card.hasContest(contestId)) {
-                val result = cassorter.bassort(mvr, card)
+                val result = cassorter.bassort(mvr, card, card.exactContests())
                 count++
                 return result
             }
@@ -113,10 +114,4 @@ class ClcaSampling(
     override fun hasNext() = (count < maxSamples)
     override fun next() = sample()
 }
-
-fun makeClcaNoErrorSampler(contestId: Int, cvrs : List<Cvr>, cassorter: ClcaAssorter): Sampling {
-    val cvrPairs = cvrs.zip(cvrs)
-    return ClcaSampling(contestId, cvrPairs, cassorter, true)
-}
-
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestHasStyle.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestHasStyle.kt
@@ -367,7 +367,7 @@ class TestHasStyle {
 
         val contestsUA = contests.map {
             val Nb = tabs[it.id]?.ncards ?: throw RuntimeException("Contest ${it.id} not found")
-            ContestUnderAudit(it, true, hasStyle, NpopIn=Nb).addStandardAssertions()
+            ContestUnderAudit(it, true, NpopIn=Nb).addStandardAssertions()
         }
 
         val election =
@@ -402,7 +402,7 @@ class TestHasStyle {
         val contestsUA = contests.map {
             val Nb = tabs[it.id]?.ncards ?:
                 throw RuntimeException("Contest ${it.id} not found")
-            ContestUnderAudit(it, isClca=true, hasStyle=hasStyle, NpopIn=Nb).addStandardAssertions()
+            ContestUnderAudit(it, isClca=true, NpopIn=Nb).addStandardAssertions()
         }
 
         // class TestCreateElection (

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestAlphaMart.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestAlphaMart.kt
@@ -32,7 +32,7 @@ class TestAlphaMart {
         val test = MultiContestTestDataP(ncontests, nbs, N, marginRange, underVotePct, phantomRange)
 
         val contest = test.contests.first()
-        val contestUA = ContestUnderAudit(contest, isClca = false, hasStyle = true).addStandardAssertions()
+        val contestUA = ContestUnderAudit(contest, isClca = false).addStandardAssertions()
         val assorter = contestUA.minPollingAssertion()!!.assorter
 
         val cvrs = test.makeCvrsFromContests()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaAssortValues.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaAssortValues.kt
@@ -22,7 +22,7 @@ class TestClcaAssortValues {
         // val votes = mapOf(0 to 1010, 1 to 990) // Map<Int, Int>
         // data class DHondtAssorter(val info: ContestInfo, val winner: Int, val loser: Int, val lastSeatWon: Int, val firstSeatLost: Int): AssorterIF  {
         val assorter = DHondtAssorter(info, winner = 0, loser = 1, lastSeatWon=2, firstSeatLost=5).setDilutedMean(.55)
-        val cassorter = ClcaAssorter(info, assorter, hasUndervotes=hasStyle, dilutedMargin=assorter.dilutedMargin())
+        val cassorter = ClcaAssorter(info, assorter, dilutedMargin=assorter.dilutedMargin())
         println(cassorter)
 
         val winner = Cvr("winner", mapOf(0 to intArrayOf(0)))
@@ -85,7 +85,7 @@ class TestClcaAssortValues {
         val votes = mapOf(0 to 1010, 1 to 990) // Map<Int, Int>
         val contest =  Contest(info, votes, 2000, Ncast=2000)
         val assorter = PluralityAssorter.makeWithVotes(contest, winner = 0, loser = 1)
-        val cassorter = ClcaAssorter(info, assorter, hasUndervotes=hasStyle, dilutedMargin=assorter.dilutedMargin())
+        val cassorter = ClcaAssorter(info, assorter, dilutedMargin=assorter.dilutedMargin())
 
         val winner = Cvr("winner", mapOf(0 to intArrayOf(0)))
         val loser =  Cvr("loser", mapOf(0 to intArrayOf(1)))

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaAssorter.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaAssorter.kt
@@ -55,7 +55,7 @@ class TestClcaAssorter {
 
         ////////////////////////////////////////////////////////////////////////////////////////////////
 
-        val cassorter = ClcaAssorter(info, assorter, hasUndervotes=true, dilutedMargin=assorter.dilutedMargin())
+        val cassorter = ClcaAssorter(info, assorter, dilutedMargin=assorter.dilutedMargin())
         assertEquals(.01, mean2margin(awinnerAvg), doublePrecision)
         assertEquals(margin, cassorter.dilutedMargin, doublePrecision)
         assertEquals(0.0, cassorter.overstatementError(winnerCvr, winnerCvr, true))
@@ -113,7 +113,7 @@ class TestClcaAssorter {
 
         val awinner = PluralityAssorter.makeWithVotes(contest, winner = 0, loser = 1)
         val awinnerAvg = cvrs.map { awinner.assort(it) }.average()
-        val cwinner = ClcaAssorter(info, awinner, hasUndervotes=true, dilutedMargin=awinner.dilutedMargin())
+        val cwinner = ClcaAssorter(info, awinner, dilutedMargin=awinner.dilutedMargin())
         val cwinnerAvg = cvrs.map { cwinner.bassort(it, it) }.average()
         println("cwinnerAvg=$cwinnerAvg <= awinnerAvg=$awinnerAvg")
         assertTrue(cwinnerAvg <= awinnerAvg)
@@ -121,7 +121,7 @@ class TestClcaAssorter {
 
         val aloser = PluralityAssorter.makeWithVotes(contest, winner = 1, loser = 0)
         val aloserAvg = cvrs.map { aloser.assort(it) }.average()
-        val closer = ClcaAssorter(info, aloser, hasUndervotes=true, check=false, dilutedMargin=aloser.dilutedMargin())
+        val closer = ClcaAssorter(info, aloser, check=false, dilutedMargin=aloser.dilutedMargin())
         assertEquals(mean2margin(aloserAvg), closer.dilutedMargin, doublePrecision)
         assertEquals(aloserAvg, margin2mean(closer.dilutedMargin))
 
@@ -187,7 +187,7 @@ class TestClcaAssorter {
     fun testNwayPlurality(contest : Contest, cvrs: List<Cvr>, winner: Int, loser:Int): Double {
         val assort = PluralityAssorter.makeWithVotes(contest, winner, loser)
         val assortAvg = cvrs.map { assort.assort(it) }.average()
-        val cwinner = ClcaAssorter(contest.info, assort, hasUndervotes=true, check=false, dilutedMargin=assort.dilutedMargin())
+        val cwinner = ClcaAssorter(contest.info, assort, check=false, dilutedMargin=assort.dilutedMargin())
         val cwinnerAvg = cvrs.map { cwinner.bassort(it, it) }.average()
         assertEquals(assortAvg, margin2mean(cwinner.dilutedMargin), doublePrecision)
 
@@ -271,7 +271,7 @@ class TestClcaAssorter {
         assertEquals(0.0, assorter.assort(phantomCvr, true))  // cvr is a phantom
         // so assort in {0, .5, 1}
 
-        val cassorter = ClcaAssorter(info, assorter, hasUndervotes=true, dilutedMargin=assorter.dilutedMargin())
+        val cassorter = ClcaAssorter(info, assorter, dilutedMargin=assorter.dilutedMargin())
         assertEquals(margin, cassorter.dilutedMargin, doublePrecision)
         assertEquals(awinnerAvg, margin2mean(cassorter.dilutedMargin))
 
@@ -345,7 +345,7 @@ class TestClcaAssorter {
         val contest = makeContestFromCvrs(info, cvrs)
 
         val assorter = PluralityAssorter.makeWithVotes(contest, winner = 0, loser = 1)
-        val cassorterHasStyle = ClcaAssorter(info, assorter, hasUndervotes=true, dilutedMargin=assorter.dilutedMargin())
+        val cassorterHasStyle = ClcaAssorter(info, assorter, dilutedMargin=assorter.dilutedMargin())
         val noerror = cassorterHasStyle.noerror()
         println("  noerror = $noerror")
 
@@ -364,14 +364,14 @@ class TestClcaAssorter {
         assertEquals(1.0 * noerror, cassorterHasStyle.bassort(differentContest, loserCvr))
         assertEquals(0.5 * noerror, cassorterHasStyle.bassort(differentContest, otherCvr))
 
-
-        val cassorterNoStyle = ClcaAssorter(info, assorter, hasUndervotes=false, dilutedMargin=assorter.dilutedMargin())
+        // hasStyle = false
+        val cassorterNoStyle = ClcaAssorter(info, assorter, dilutedMargin=assorter.dilutedMargin())
         assertEquals(0.5, cassorterNoStyle.overstatementError(differentContest, winnerCvr, false))
         assertEquals(-0.5, cassorterNoStyle.overstatementError(differentContest, loserCvr, false))
         assertEquals(0.0, cassorterNoStyle.overstatementError(differentContest, otherCvr, false))
-        assertEquals(0.5 * noerror, cassorterNoStyle.bassort(differentContest, winnerCvr))
-        assertEquals(1.5 * noerror, cassorterNoStyle.bassort(differentContest, loserCvr))
-        assertEquals(1.0 * noerror, cassorterNoStyle.bassort(differentContest, otherCvr))
+        assertEquals(0.5 * noerror, cassorterNoStyle.bassort(differentContest, winnerCvr, false))
+        assertEquals(1.5 * noerror, cassorterNoStyle.bassort(differentContest, loserCvr, false))
+        assertEquals(1.0 * noerror, cassorterNoStyle.bassort(differentContest, otherCvr, false))
     }
 
     @Test

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestShangrlaAssertions.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestShangrlaAssertions.kt
@@ -194,71 +194,71 @@ class TestShangrlaAssertions {
         //                        - CVR.as_vote(c.get_vote_for("AvB", losr))
         //                        + 1)/2), upper_bound=1))
         val aliceVsBob = PluralityAssorter.makeWithVotes(plur_con_test, winner = 0, loser = 1)
-        val cassorter = ClcaAssorter(plur_con_test.info, aliceVsBob, hasUndervotes=true, dilutedMargin=aliceVsBob.dilutedMargin() )
+        val cassorter = ClcaAssorter(plur_con_test.info, aliceVsBob, dilutedMargin=aliceVsBob.dilutedMargin() )
 
         //        assert aVb.assorter.overstatement(mvrs[0], cvrs[0], use_style=True) == 0
         //        assert aVb.assorter.overstatement(mvrs[0], cvrs[0], use_style=False) == 0
-        assertEquals(0.0, cassorter.overstatementError(mvr0, cvr0, hasUndervotes = true))
-        assertEquals(0.0, cassorter.overstatementError(mvr0, cvr0, hasUndervotes = false))
+        assertEquals(0.0, cassorter.overstatementError(mvr0, cvr0, hasStyle = true))
+        assertEquals(0.0, cassorter.overstatementError(mvr0, cvr0, hasStyle = false))
 
         //
         //        assert aVb.assorter.overstatement(mvrs[0], cvrs[1], use_style=True) == -1
         //        assert aVb.assorter.overstatement(mvrs[0], cvrs[1], use_style=False) == -1
-        assertEquals(-1.0, cassorter.overstatementError(mvr0, cvr1, hasUndervotes = true))
-        assertEquals(-1.0, cassorter.overstatementError(mvr0, cvr1, hasUndervotes = false))
+        assertEquals(-1.0, cassorter.overstatementError(mvr0, cvr1, hasStyle = true))
+        assertEquals(-1.0, cassorter.overstatementError(mvr0, cvr1, hasStyle = false))
 
         //
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[0], use_style=True) == 1/2
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[0], use_style=False) == 1/2
-        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasUndervotes = true))
-        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasUndervotes = false))
+        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasStyle = true))
+        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasStyle = false))
 
         //
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[1], use_style=True) == -1/2
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[1], use_style=False) == -1/2
-        assertEquals(-0.5, cassorter.overstatementError(mvr2, cvr1, hasUndervotes = true))
-        assertEquals(-0.5, cassorter.overstatementError(mvr2, cvr1, hasUndervotes = false))
+        assertEquals(-0.5, cassorter.overstatementError(mvr2, cvr1, hasStyle = true))
+        assertEquals(-0.5, cassorter.overstatementError(mvr2, cvr1, hasStyle = false))
 
         //
         //
         //        assert aVb.assorter.overstatement(mvrs[1], cvrs[0], use_style=True) == 1
         //        assert aVb.assorter.overstatement(mvrs[1], cvrs[0], use_style=False) == 1
-        assertEquals(1.0, cassorter.overstatementError(mvr1, cvr0, hasUndervotes = true))
-        assertEquals(1.0, cassorter.overstatementError(mvr1, cvr0, hasUndervotes = false))
+        assertEquals(1.0, cassorter.overstatementError(mvr1, cvr0, hasStyle = true))
+        assertEquals(1.0, cassorter.overstatementError(mvr1, cvr0, hasStyle = false))
 
         //
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[0], use_style=True) == 1/2
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[0], use_style=False) == 1/2
-        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasUndervotes = true))
-        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasUndervotes = false))
+        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasStyle = true))
+        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasStyle = false))
 
         //
         //        assert aVb.assorter.overstatement(mvrs[3], cvrs[0], use_style=True) == 1
         //        assert aVb.assorter.overstatement(mvrs[3], cvrs[0], use_style=False) == 1/2
-        assertEquals(1.0, cassorter.overstatementError(wrongContestMvr, cvr0, hasUndervotes = true))
-        assertEquals(0.5, cassorter.overstatementError(wrongContestMvr, cvr0, hasUndervotes = false))
+        assertEquals(1.0, cassorter.overstatementError(wrongContestMvr, cvr0, hasStyle = true))
+        assertEquals(0.5, cassorter.overstatementError(wrongContestMvr, cvr0, hasStyle = false))
 
-        assertEquals(0.0, cassorter.overstatementError(wrongContestMvr, wrongContestMvr, hasUndervotes = false))
+        assertEquals(0.0, cassorter.overstatementError(wrongContestMvr, wrongContestMvr, hasStyle = false))
         val mess = assertFailsWith<RuntimeException>{
-            cassorter.overstatementError(wrongContestMvr, wrongContestMvr, hasUndervotes = true)
+            cassorter.overstatementError(wrongContestMvr, wrongContestMvr, hasStyle = true)
         }.message
         assertEquals("hasCompleteCvrs==True but cvr=wrongContest (false)  1: [1] does not contain contest AvB (0)", mess)
 
         //
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[4], use_style=True) == 1/2
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[4], use_style=False) == 1/2
-        assertEquals(0.5, cassorter.overstatementError(mvr4, cvr4, hasUndervotes = true))
-        assertEquals(0.5, cassorter.overstatementError(mvr4, cvr4, hasUndervotes = false))
+        assertEquals(0.5, cassorter.overstatementError(mvr4, cvr4, hasStyle = true))
+        assertEquals(0.5, cassorter.overstatementError(mvr4, cvr4, hasStyle = false))
 
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[0], use_style=True) == 1
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[0], use_style=False) == 1
-        assertEquals(1.0, cassorter.overstatementError(mvr4, cvr0, hasUndervotes = true))
-        assertEquals(1.0, cassorter.overstatementError(mvr4, cvr0, hasUndervotes = false))
+        assertEquals(1.0, cassorter.overstatementError(mvr4, cvr0, hasStyle = true))
+        assertEquals(1.0, cassorter.overstatementError(mvr4, cvr0, hasStyle = false))
 
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[1], use_style=True) == 0
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[1], use_style=False) == 0
-        assertEquals(0.0, cassorter.overstatementError(mvr4, cvr1, hasUndervotes = true))
-        assertEquals(0.0, cassorter.overstatementError(mvr4, cvr1, hasUndervotes = false))
+        assertEquals(0.0, cassorter.overstatementError(mvr4, cvr1, hasStyle = true))
+        assertEquals(0.0, cassorter.overstatementError(mvr4, cvr1, hasStyle = false))
     }
 
     // plurality assort = {1, 0, .5} if vote is for { winner, loser, neither}
@@ -294,79 +294,79 @@ class TestShangrlaAssertions {
     fun test_overstatement_plurality() { // agrees with SHANGRLA
         // winner = alice, loser = bob
         val aliceVsBobP = PluralityAssorter(plur_con_test.info, winner = 0, loser = 1).setDilutedMean(margin2mean(0.2))
-        val cassorterHasStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP, hasUndervotes=true, dilutedMargin=aliceVsBobP.dilutedMargin())
+        val cassorterHasStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP, dilutedMargin=aliceVsBobP.dilutedMargin())
 
         // mvr == cvr, always get noerror
-        assertEquals(0.0, cassorterHasStyle.overstatementError(aliceMvr, aliceMvr, hasUndervotes = true)) // 1
-        assertEquals(0.0, cassorterHasStyle.overstatementError(bobMvr, bobMvr, hasUndervotes = true))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, candyMvr, hasUndervotes = true))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, undervoteMvr, hasUndervotes = true))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(aliceMvr, aliceMvr, hasStyle = true)) // 1
+        assertEquals(0.0, cassorterHasStyle.overstatementError(bobMvr, bobMvr, hasStyle = true))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, candyMvr, hasStyle = true))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, undervoteMvr, hasStyle = true))
 
-        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, wrongContestMvr, hasUndervotes = false))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, wrongContestMvr, hasStyle = false))
         val mess1 = assertFailsWith<RuntimeException>{
             assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(wrongContestMvr, wrongContestMvr)) // ??, hasCompleteCvrs = false))
         }.message
         assertEquals("hasCompleteCvrs==True but cvr=wrongContest (false)  1: [1] does not contain contest AvB (0)", mess1)
 
         val mess = assertFailsWith<RuntimeException>{
-            cassorterHasStyle.overstatementError(wrongContestMvr, wrongContestMvr, hasUndervotes = true)
+            cassorterHasStyle.overstatementError(wrongContestMvr, wrongContestMvr, hasStyle = true)
         }.message
         assertEquals("hasCompleteCvrs==True but cvr=wrongContest (false)  1: [1] does not contain contest AvB (0)", mess)
 
-        assertEquals(1.0, cassorterHasStyle.overstatementError(bobMvr, aliceMvr, hasUndervotes = true)) // 2
-        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, candyMvr, hasUndervotes = true))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, undervoteMvr, hasUndervotes = true))
-        assertEquals(-1.0, cassorterHasStyle.overstatementError(aliceMvr, bobMvr, hasUndervotes = true))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, candyMvr, hasUndervotes = true))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, undervoteMvr, hasUndervotes = true))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(candyMvr, bobMvr, hasUndervotes = true))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(candyMvr, aliceMvr, hasUndervotes = true))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, danMvr, hasUndervotes = true))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(undervoteMvr, bobMvr, hasUndervotes = true)) // none = other
-        assertEquals(0.5, cassorterHasStyle.overstatementError(undervoteMvr, aliceMvr, hasUndervotes = true))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, danMvr, hasUndervotes = true))
+        assertEquals(1.0, cassorterHasStyle.overstatementError(bobMvr, aliceMvr, hasStyle = true)) // 2
+        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, candyMvr, hasStyle = true))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, undervoteMvr, hasStyle = true))
+        assertEquals(-1.0, cassorterHasStyle.overstatementError(aliceMvr, bobMvr, hasStyle = true))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, candyMvr, hasStyle = true))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, undervoteMvr, hasStyle = true))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(candyMvr, bobMvr, hasStyle = true))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(candyMvr, aliceMvr, hasStyle = true))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, danMvr, hasStyle = true))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(undervoteMvr, bobMvr, hasStyle = true)) // none = other
+        assertEquals(0.5, cassorterHasStyle.overstatementError(undervoteMvr, aliceMvr, hasStyle = true))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, danMvr, hasStyle = true))
 
         // exaclty the same as above, since hasStyle only has an effect when the contest is not in the MVR or CVR
-        assertEquals(1.0, cassorterHasStyle.overstatementError(bobMvr, aliceMvr, hasUndervotes = false)) // 3
-        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, candyMvr, hasUndervotes = false))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, undervoteMvr, hasUndervotes = false))
-        assertEquals(-1.0, cassorterHasStyle.overstatementError(aliceMvr, bobMvr, hasUndervotes = false))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, candyMvr, hasUndervotes = false))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, undervoteMvr, hasUndervotes = false))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(candyMvr, bobMvr, hasUndervotes = false))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(candyMvr, aliceMvr, hasUndervotes = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, danMvr, hasUndervotes = false))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(undervoteMvr, bobMvr, hasUndervotes = false))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(undervoteMvr, aliceMvr, hasUndervotes = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, danMvr, hasUndervotes = false))
+        assertEquals(1.0, cassorterHasStyle.overstatementError(bobMvr, aliceMvr, hasStyle = false)) // 3
+        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, candyMvr, hasStyle = false))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, undervoteMvr, hasStyle = false))
+        assertEquals(-1.0, cassorterHasStyle.overstatementError(aliceMvr, bobMvr, hasStyle = false))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, candyMvr, hasStyle = false))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, undervoteMvr, hasStyle = false))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(candyMvr, bobMvr, hasStyle = false))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(candyMvr, aliceMvr, hasStyle = false))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, danMvr, hasStyle = false))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(undervoteMvr, bobMvr, hasStyle = false))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(undervoteMvr, aliceMvr, hasStyle = false))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, danMvr, hasStyle = false))
 
         //// contest does not appear on the MVR, hasStyle = true
         // we get an overstatementError of {1, 0, 1/2} depending if the CVR showed a vote for the {winner, loser, other}
-        assertEquals(1.0, cassorterHasStyle.overstatementError(wrongContestMvr, aliceMvr, hasUndervotes = true)) // 4
-        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, bobMvr, hasUndervotes = true))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(wrongContestMvr, candyMvr, hasUndervotes = true))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(wrongContestMvr, undervoteMvr, hasUndervotes = true)) // none = other
+        assertEquals(1.0, cassorterHasStyle.overstatementError(wrongContestMvr, aliceMvr, hasStyle = true)) // 4
+        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, bobMvr, hasStyle = true))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(wrongContestMvr, candyMvr, hasStyle = true))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(wrongContestMvr, undervoteMvr, hasStyle = true)) // none = other
 
         //// contest does not appear on the MVR, hasStyle = false
         // we get an overstatementError of {1/2, -1/2, 0} depending if the CVR showed a vote for the {winner, loser, other}
-        assertEquals(0.5, cassorterHasStyle.overstatementError(wrongContestMvr, aliceMvr, hasUndervotes = false)) // 5
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(wrongContestMvr, bobMvr, hasUndervotes = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, candyMvr, hasUndervotes = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, undervoteMvr, hasUndervotes = false)) // none = other
+        assertEquals(0.5, cassorterHasStyle.overstatementError(wrongContestMvr, aliceMvr, hasStyle = false)) // 5
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(wrongContestMvr, bobMvr, hasStyle = false))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, candyMvr, hasStyle = false))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, undervoteMvr, hasStyle = false)) // none = other
 
         //// contest does not appear on the CVR, hasStyle = false
         // we get an overstatementError of {-1/2, 1/2, 0} depending if the MVR showed a vote for the {winner, loser, other}
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, wrongContestMvr, hasUndervotes = false)) // 6
-        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, wrongContestMvr, hasUndervotes = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, wrongContestMvr, hasUndervotes = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, wrongContestMvr, hasUndervotes = false)) // none = other
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, wrongContestMvr, hasStyle = false)) // 6
+        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, wrongContestMvr, hasStyle = false))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, wrongContestMvr, hasStyle = false))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, wrongContestMvr, hasStyle = false)) // none = other
     }
 
     @Test
     fun test_overstatement_plurality_assort() { // agrees with SHANGRLA
         // winner = alice, loser = bob
         val aliceVsBobP = PluralityAssorter(plur_con_test.info, winner = 0, loser = 1).setDilutedMean(margin2mean(0.2))
-        val cassorterHasStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP, hasUndervotes=true, dilutedMargin=aliceVsBobP.dilutedMargin())
+        val cassorterHasStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP, dilutedMargin=aliceVsBobP.dilutedMargin())
 
         // mvr == cvr, always get noerror
         assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(aliceMvr, aliceMvr)) // 1
@@ -397,32 +397,32 @@ class TestShangrlaAssertions {
         assertEquals("hasCompleteCvrs==True but cvr=wrongContest (false)  1: [1] does not contain contest AvB (0)", mess)
 
         /////////////
-        val cassorterNoStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP, hasUndervotes=false, dilutedMargin=aliceVsBobP.dilutedMargin())
+        val cassorterNoStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP, dilutedMargin=aliceVsBobP.dilutedMargin())
 
         // You have cvrs but use_style = false, which must mean that undervotes werent recorded. Now we examine an mvr
         // that doesnt have that contest on it, and neither does the cvr.
-        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, wrongContestMvr))
+        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, wrongContestMvr, hasStyle = false))
 
-        assertEquals(0.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, aliceMvr)) // 3
-        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, candyMvr))
-        assertEquals(2.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, bobMvr))
-        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, candyMvr))
-        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, bobMvr))
-        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, aliceMvr))
-        assertEquals(1.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, danMvr))
+        assertEquals(0.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, aliceMvr, hasStyle = false)) // 3
+        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, candyMvr, hasStyle = false))
+        assertEquals(2.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, bobMvr, hasStyle = false))
+        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, candyMvr, hasStyle = false))
+        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, bobMvr, hasStyle = false))
+        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, aliceMvr, hasStyle = false))
+        assertEquals(1.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, danMvr, hasStyle = false))
 
         //// contest does not appear on the MVR
         // we get an assort value of {0, noerror, noerror/2} depending if the CVR showed a vote for the {winner, loser, other},
 
         // we get an assort value of {noerror/2, 1.5 * noerror, noerror} depending if the CVR showed a vote for the {winner, loser, other},
-        assertEquals(cassorterNoStyle.noerror/2, cassorterNoStyle.bassort(wrongContestMvr, aliceMvr)) // 5
-        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, bobMvr))
-        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, candyMvr))
+        assertEquals(cassorterNoStyle.noerror/2, cassorterNoStyle.bassort(wrongContestMvr, aliceMvr, hasStyle = false)) // 5
+        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, bobMvr, hasStyle = false))
+        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, candyMvr, hasStyle = false))
 
         // we get an assort value of {1.5, noerror/2, noerror} depending if the MVR showed a vote for the {winner, loser, other},
-        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, wrongContestMvr))
-        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, wrongContestMvr))
-        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, wrongContestMvr))
+        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, wrongContestMvr, hasStyle = false))
+        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, wrongContestMvr, hasStyle = false))
+        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, wrongContestMvr, hasStyle = false))
     }
 
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMakeFuzzedCvrs.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMakeFuzzedCvrs.kt
@@ -1,5 +1,6 @@
 package org.cryptobiotic.rlauxe.estimate
 
+import org.cryptobiotic.rlauxe.audit.AuditableCard
 import org.cryptobiotic.rlauxe.core.ContestUnderAudit
 import org.cryptobiotic.rlauxe.core.PluralityErrorTracker
 import org.cryptobiotic.rlauxe.util.*
@@ -22,9 +23,10 @@ class TestMakeFuzzedCvrs {
         val assort = contestUA.clcaAssertions.first().cassorter
 
         val testMvrs = makeFuzzedCvrsFrom(listOf(contest), testCvrs, mvrsFuzzPct)
+        val testCards = testCvrs.mapIndexed { idx, cvr -> AuditableCard.fromCvr(cvr, idx, 0) }
         val sampler = ClcaSampling( // fuzz single contest OK
             contestUA.id,
-            testMvrs.zip(testCvrs),
+            testMvrs.zip(testCards),
             assort,
             allowReset = true
         )

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMultiContestTestData.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMultiContestTestData.kt
@@ -212,7 +212,7 @@ class TestMultiContestTestData {
             val contestUA = ContestUnderAudit(contest, isClca = true).addStandardAssertions()
             val cassorter = contestUA.minClcaAssertion()!!.cassorter
 
-            val sampler = ClcaSampling(contest.id, testCvrs.zip(testCvrs), cassorter, true) // TODO
+            val sampler = ClcaSampling(contest.id, testCvrs.zip(AuditableCard.fromCvrs(testCvrs)), cassorter, true) // TODO
             val tracker = PluralityErrorTracker(cassorter.noerror())
             while (sampler.hasNext()) { tracker.addSample(sampler.next()) }
             // println("   tracker.errorRates = ${tracker.errorRates()}")

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMultiContestTestDataP.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestMultiContestTestDataP.kt
@@ -212,7 +212,7 @@ class TestMultiContestTestDataP {
             val contestUA = ContestUnderAudit(contest, isClca = true).addStandardAssertions()
             val cassorter = contestUA.minClcaAssertion()!!.cassorter
 
-            val sampler = ClcaSampling(contest.id, testCvrs.zip(testCvrs), cassorter, true) // TODO
+            val sampler = ClcaSampling(contest.id, testCvrs.zip(AuditableCard.fromCvrs(testCvrs)), cassorter, true) // TODO
             val tracker = PluralityErrorTracker(cassorter.noerror())
             while (sampler.hasNext()) { tracker.addSample(sampler.next()) }
             // println("   tracker.errorRates = ${tracker.errorRates()}")

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestSamplers.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestSamplers.kt
@@ -1,5 +1,6 @@
 package org.cryptobiotic.rlauxe.estimate
 
+import org.cryptobiotic.rlauxe.audit.AuditableCard
 import org.cryptobiotic.rlauxe.core.Assertion
 import org.cryptobiotic.rlauxe.core.ClcaAssorter
 import org.cryptobiotic.rlauxe.core.ContestInfo
@@ -47,8 +48,9 @@ class TestSampler {
 
     @Test
     fun testClcaSampling() {
-        val cassorter =  ClcaAssorter(assertion.info, assertion.assorter, hasUndervotes=false, dilutedMargin=assertion.assorter.dilutedMargin(), true)
-        val cvrPairs = cvrs.zip( cvrs)
+        // was hasUndervotes=false
+        val cassorter =  ClcaAssorter(assertion.info, assertion.assorter, dilutedMargin=assertion.assorter.dilutedMargin(), true)
+        val cvrPairs = cvrs.zip( AuditableCard.fromCvrs(cvrs))
         val target = ClcaSampling(0, cvrPairs, cassorter, true) // single contest OK
 
         var count = 0
@@ -68,7 +70,8 @@ class TestSampler {
 
     @Test
     fun testClcaNoErrorIterator() {
-        val cassorter =  ClcaAssorter(assertion.info, assertion.assorter, hasUndervotes=false, dilutedMargin=assertion.assorter.dilutedMargin(), true)
+        // was hasUndervotes=false
+        val cassorter =  ClcaAssorter(assertion.info, assertion.assorter, dilutedMargin=assertion.assorter.dilutedMargin(), true)
 
         val target = ClcaNoErrorIterator(0, cvrs.size, cassorter, cvrs.iterator())
 
@@ -88,7 +91,8 @@ class TestSampler {
 
     @Test
     fun testOneAuditNoErrorIterator() {
-        val cassorter =  ClcaAssorter(assertion.info, assertion.assorter, hasUndervotes=false, dilutedMargin=assertion.assorter.dilutedMargin(), true)
+        // was hasUndervotes=false
+        val cassorter =  ClcaAssorter(assertion.info, assertion.assorter, dilutedMargin=assertion.assorter.dilutedMargin(), true)
 
         val target = OneAuditNoErrorIterator(0, cvrs.size, null, cassorter, cvrs.iterator())
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/corla/TestCorlaEstimateSampleSize.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/corla/TestCorlaEstimateSampleSize.kt
@@ -18,7 +18,7 @@ class TestCorlaEstimateSampleSize {
     @Test
     fun testFindSampleSizePolling() {
         val test = MultiContestTestDataP(20, 11, 20000)
-        val contestsUA: List<ContestUnderAudit> = test.contests.map { ContestUnderAudit(it, isClca = false, hasStyle = true).addStandardAssertions() } // CORLA does polling?
+        val contestsUA: List<ContestUnderAudit> = test.contests.map { ContestUnderAudit(it, isClca = false).addStandardAssertions() } // CORLA does polling?
 
         contestsUA.forEach { contest ->
             println("contest = $contest")
@@ -31,7 +31,7 @@ class TestCorlaEstimateSampleSize {
     @Test
     fun testFindSampleSize() {
         val test = MultiContestTestDataP(20, 11, 20000)
-        val contestsUAs: List<ContestUnderAudit> = test.contests.map { ContestUnderAudit( it, isClca = true, hasStyle = true).addStandardAssertions() }
+        val contestsUAs: List<ContestUnderAudit> = test.contests.map { ContestUnderAudit( it, isClca = true).addStandardAssertions() }
         val cvrs = test.makeCvrsFromContests()
 
         contestsUAs.forEach { contest ->

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOneAuditKalamazoo.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOneAuditKalamazoo.kt
@@ -8,7 +8,6 @@ import org.cryptobiotic.rlauxe.core.ContestInfo
 import org.cryptobiotic.rlauxe.core.ContestUnderAudit
 import org.cryptobiotic.rlauxe.core.Cvr
 import org.cryptobiotic.rlauxe.core.SocialChoiceFunction
-import org.cryptobiotic.rlauxe.util.ContestTabulation
 import org.cryptobiotic.rlauxe.util.Vunder
 import org.cryptobiotic.rlauxe.util.makeVunderCvrs
 import kotlin.Int
@@ -123,8 +122,8 @@ fun makeContestKalamazoo(nwinners:Int = 1): Triple<ContestUnderAudit, List<OneAu
     val cvrUndervotes = cvrNcards - cvrVotes.values.sum()
 
     val cvrs = makeTestMvrs(contest, cvrNcards = cvrNcards, cvrVotes, cvrUndervotes, listOf(cardPool))
-    val contestUA = ContestUnderAudit(contest, hasStyle=true).addStandardAssertions()
-    addOAClcaAssortersFromMargin(listOf(contestUA), listOf(cardPool), hasStyle=true)
+    val contestUA = ContestUnderAudit(contest, ).addStandardAssertions()
+    addOAClcaAssortersFromMargin(listOf(contestUA), listOf(cardPool))
 
     return Triple(contestUA, listOf(cardPool), cvrs)
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOneAuditPairFuzzer.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOneAuditPairFuzzer.kt
@@ -42,7 +42,6 @@ class TestOneAuditPairFuzzer {
                     cvrFraction = .70,
                     undervoteFraction = .01,
                     phantomFraction = .01,
-                    hasStyle=true,
                     extraInPool=0,
                 )
                 val ncands = contestOA.ncandidates
@@ -111,7 +110,6 @@ class TestOneAuditPairFuzzer {
         val fuzzPct = 0.001
         val extraPct = 0.01
         val Nc = 10000
-        val hasStyle = true
 
         val (contestOA, mvrs, cards, pools) =
             makeOneAuditTest(
@@ -120,7 +118,6 @@ class TestOneAuditPairFuzzer {
                 cvrFraction = .95,
                 undervoteFraction = 0.01,
                 phantomFraction = 0.005,
-                hasStyle=hasStyle,
                 extraInPool= (extraPct * Nc).toInt(), // this creates a second contest with only undervotes
             )
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAssertionJson.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAssertionJson.kt
@@ -24,7 +24,8 @@ class TestAssertionJson {
     @Test
     fun testClcaAssertionRoundtrip() {
         val assertion = makeAssertion()
-        val cassorter =  ClcaAssorter(assertion.info, assertion.assorter, hasUndervotes=false, dilutedMargin=.111)
+        // was hasUndervotes=false
+        val cassorter =  ClcaAssorter(assertion.info, assertion.assorter, dilutedMargin=.111)
         val target = ClcaAssertion(assertion.info, cassorter)
 
         val json = target.publishJson()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditRoundJson.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditRoundJson.kt
@@ -24,7 +24,7 @@ class TestAuditRoundJson {
     @Test
     fun testRoundtrip() {
         val testData = MultiContestTestDataP(11, 4, 50000)
-        val contestsUAs: List<ContestUnderAudit> = testData.contests. map { ContestUnderAudit(it, isClca=false, hasStyle=false).addStandardAssertions()}
+        val contestsUAs: List<ContestUnderAudit> = testData.contests. map { ContestUnderAudit(it, isClca=false, ).addStandardAssertions()}
         val contestRounds = contestsUAs.map{ contest ->
             val cr = ContestRound(contest, 1,)
             //     var actualMvrs = 0 // Actual number of ballots with this contest contained in this round's sample.
@@ -70,7 +70,7 @@ class TestAuditRoundJson {
     @Test
     fun testRoundtripIO() {
         val testData = MultiContestTestDataP(11, 4, 50000)
-        val contestsUAs: List<ContestUnderAudit> = testData.contests. map { ContestUnderAudit(it, isClca=false, hasStyle=false).addStandardAssertions()}
+        val contestsUAs: List<ContestUnderAudit> = testData.contests. map { ContestUnderAudit(it, isClca=false).addStandardAssertions()}
         val contestRounds = contestsUAs.map{ contest ->
             val cr = ContestRound(contest, 1)
             cr.actualMvrs = 420

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/verify/TestAvgAssortValues.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/verify/TestAvgAssortValues.kt
@@ -50,7 +50,7 @@ class TestAvgAssortValues {
             println()
         }
 
-        val contestsUA = ContestUnderAudit.make(listOf(contest), cardIterable.iterator(), isClca=true, hasStyle=true)
+        val contestsUA = ContestUnderAudit.make(listOf(contest), cardIterable.iterator(), isClca=true)
         val contestUA= contestsUA.first()
         println("contestUA = ${contestUA.show()}")
 
@@ -98,7 +98,7 @@ class TestAvgAssortValues {
             println()
         }
 
-        val contestsUA = ContestUnderAudit.make(listOf(contest), cardIterable.iterator(), isClca=true, hasStyle=true)
+        val contestsUA = ContestUnderAudit.make(listOf(contest), cardIterable.iterator(), isClca=true)
         val contestUA= contestsUA.first()
         println("contestUA = ${contestUA.show()}")
 
@@ -141,7 +141,7 @@ class TestAvgAssortValues {
             println()
         }
 
-        val contestsUA = ContestUnderAudit.make(test.contests, cardIterable.iterator(), isClca=true, hasStyle=true)
+        val contestsUA = ContestUnderAudit.make(test.contests, cardIterable.iterator(), isClca=true)
 
         val results = VerifyResults()
         verifyClcaAssortAvg(contestsUA, cardIterable.iterator(), results, show = false)
@@ -185,7 +185,7 @@ class TestAvgAssortValues {
             println()
         }
 
-        val contestsUA = ContestUnderAudit.make(test.contests, cardIterable.iterator(), isClca=true, hasStyle=false)
+        val contestsUA = ContestUnderAudit.make(test.contests, cardIterable.iterator(), isClca=true)
         contestsUA.forEach {
             println("$it : Npop diff = ${it.Npop != it.Nc}")
         }
@@ -234,7 +234,7 @@ class TestAvgAssortValues {
             println()
         }
 
-        val contestsUA = ContestUnderAudit.make(test.contests, cardIterable.iterator(), isClca=true, hasStyle=false)
+        val contestsUA = ContestUnderAudit.make(test.contests, cardIterable.iterator(), isClca=true)
         contestsUA.forEach {
             println("$it : Nb diff = ${it.Npop != it.Nc}")
         }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistedWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistedWorkflow.kt
@@ -33,7 +33,7 @@ class TestPersistedWorkflow {
 
         // Synthetic cvrs for testing reflecting the exact contest votes, already has undervotes and phantoms.
         val testMvrs = testData.makeCvrsFromContests()
-        val contestsUA = contests.map { ContestUnderAudit(it, isClca = true, hasStyle = config.hasStyle).addStandardAssertions() }
+        val contestsUA = contests.map { ContestUnderAudit(it, isClca = true).addStandardAssertions() }
 
         val election = CreateElectionFromCvrs(contestsUA, testMvrs, config=config)
         CreateAuditP("testPersistedSingleClca", config, election, auditDir = auditdir, clear = true)
@@ -58,7 +58,7 @@ class TestPersistedWorkflow {
 
         // Synthetic cvrs for testing reflecting the exact contest votes, already has undervotes and phantoms.
         val testMvrs = testData.makeCvrsFromContests()
-        val contestsUA = contests.map { ContestUnderAudit(it, isClca = true, hasStyle = config.hasStyle).addStandardAssertions() }
+        val contestsUA = contests.map { ContestUnderAudit(it, isClca = true).addStandardAssertions() }
 
         val election = CreateElectionFromCvrs(contestsUA, testMvrs, config=config)
         CreateAuditP("testPersistedAuditClca",  config, election, auditDir = auditdir,  clear = true)

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaCreateOneAudit.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaCreateOneAudit.kt
@@ -130,7 +130,7 @@ object RunRlaCreateOneAudit {
         // simulate the mvrs, write to private dir
         val contests = readContestsJsonFileUnwrapped(publisher.contestsFile())
         val infos = contests.map{ it.contest.info() }.associateBy { it.id }
-        val cardManifest = readCardManifest(publisher, infos)
+        val cardManifest = readCardManifest(publisher)
         val scardIter = cardManifest.cards.iterator()
         val sortedCards = mutableListOf<AuditableCard>()
         scardIter.forEach { sortedCards.add(it) }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaStartFuzz.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaStartFuzz.kt
@@ -146,7 +146,7 @@ class TestClcaElection(
             allCvrs.addAll(rcvrs)
         }
 
-        val regularContests = testData.contests.map { ContestUnderAudit(it, isClca=true, hasStyle=config.hasStyle).addStandardAssertions() }
+        val regularContests = testData.contests.map { ContestUnderAudit(it, isClca=true).addStandardAssertions() }
         contestsUA.addAll(regularContests)
         contestsUA.forEach { println("  $it") }
         println()
@@ -225,7 +225,7 @@ class TestPollingElection(
         cvrs = testData.makeCvrsFromContests()
         testMvrs = makeFuzzedCvrsFrom(contests.map{ it.info() }, cvrs, fuzzMvrs) // ??
 
-        val makum = ContestUnderAudit.make(testData.contests, cardManifest(), isClca=false, hasStyle=false)
+        val makum = ContestUnderAudit.make(testData.contests, cardManifest(), isClca=false)
         // not setting Npop, so it defaults to Nc
         //val regularContests = testData.contests.map {
         //    ContestUnderAudit(it, isClca=true, hasStyle=config.hasStyle).addStandardAssertions()

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/ClcaAttackSamplers.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/ClcaAttackSamplers.kt
@@ -21,6 +21,7 @@ data class ClcaAttackSampler(val cvrs : List<Cvr>, val cassorter: ClcaAssorter,
 
     private var idx = 0
     private var count = 0
+    val hasStyle = true
 
     init {
         reset()
@@ -34,7 +35,8 @@ data class ClcaAttackSampler(val cvrs : List<Cvr>, val cassorter: ClcaAssorter,
         }
         mvrs = mmvrs.toList()
 
-        sampleCount = cvrs.mapIndexed { idx, it -> cassorter.bassort(mvrs[idx], it)}.sum()
+        // TODO hasStyle ??
+        sampleCount = cvrs.mapIndexed { idx, it -> cassorter.bassort(mvrs[idx], it, hasStyle=hasStyle)}.sum()
         sampleMean = sampleCount / N
     }
 
@@ -44,12 +46,12 @@ data class ClcaAttackSampler(val cvrs : List<Cvr>, val cassorter: ClcaAssorter,
             val cvr = cvrs[permutedIndex[idx]]
             val mvr = mvrs[permutedIndex[idx]]
             idx++
-            cassorter.bassort(mvr, cvr)
+            cassorter.bassort(mvr, cvr, hasStyle=hasStyle)
         } else {
             val chooseIdx = Random.nextInt(N) // with Replacement
             val cvr = cvrs[chooseIdx]
             val mvr = mvrs[chooseIdx]
-            cassorter.bassort(mvr, cvr)
+            cassorter.bassort(mvr, cvr, hasStyle=hasStyle)
         }
         count++
         return assortVal
@@ -83,6 +85,7 @@ data class ClcaFlipErrorsSampler(val cvrs : List<Cvr>, val cassorter: ClcaAssort
 
     private var idx = 0
     private var count = 0
+    val hasStyle = true
 
     init {
         reset()
@@ -93,7 +96,7 @@ data class ClcaFlipErrorsSampler(val cvrs : List<Cvr>, val cassorter: ClcaAssort
         flippedVotes = flipExactVotes(mmvrs, mvrMean)
         mvrs = mmvrs.toList()
 
-        sampleCount = cvrs.mapIndexed { idx, it -> cassorter.bassort(mvrs[idx], it)}.sum()
+        sampleCount = cvrs.mapIndexed { idx, it -> cassorter.bassort(mvrs[idx], it, hasStyle=hasStyle)}.sum()
         sampleMean = sampleCount / cvrs.size
     }
 
@@ -103,12 +106,12 @@ data class ClcaFlipErrorsSampler(val cvrs : List<Cvr>, val cassorter: ClcaAssort
             val cvr = cvrs[permutedIndex[idx]]
             val mvr = mvrs[permutedIndex[idx]]
             idx++
-            cassorter.bassort(mvr, cvr)
+            cassorter.bassort(mvr, cvr, hasStyle=hasStyle)
         } else {
             val chooseIdx = Random.nextInt(cvrs.size) // with Replacement
             val cvr = cvrs[chooseIdx]
             val mvr = mvrs[chooseIdx]
-            cassorter.bassort(mvr, cvr)
+            cassorter.bassort(mvr, cvr, hasStyle=hasStyle)
         }
         count++
         return assortVal

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/GenerateClcaErrorTable.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/GenerateClcaErrorTable.kt
@@ -44,7 +44,7 @@ class GenerateClcaErrorTable {
 
                     repeat(auditConfig.nsimEst) {
                         val cvrs = sim.makeCvrs()
-                        val contestUA = ContestUnderAudit(contest, true, hasStyle = true).addStandardAssertions()
+                        val contestUA = ContestUnderAudit(contest, true).addStandardAssertions()
                         val minAssert = contestUA.minClcaAssertion()!!
                         val minAssort = minAssert.cassorter
 
@@ -108,7 +108,7 @@ class GenerateClcaErrorTable {
 
                     testPairs.forEach { (fcard, card) ->
                         if (card.hasContest(contestUA.id)) {
-                            samples.addSample(cassorter.bassort(fcard.cvr(), card.cvr()))
+                            samples.addSample(cassorter.bassort(fcard.cvr(), card.cvr(), card.exactContests()))
                         }
                     }
                     if (show) println("    errorCounts = ${samples.pluralityErrorCounts()}")
@@ -152,7 +152,7 @@ class GenerateClcaErrorTable {
 
                     repeat(auditConfig.nsimEst) {
                         val cvrs = sim.makeCvrs()
-                        val contestUA = ContestUnderAudit(contest, true, hasStyle = true).addStandardAssertions()
+                        val contestUA = ContestUnderAudit(contest, true).addStandardAssertions()
                         val minAssert = contestUA.minClcaAssertion()!!
                         val minAssort = minAssert.cassorter
 

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/MultiContestTestDataP.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/MultiContestTestDataP.kt
@@ -239,13 +239,13 @@ fun makeOneAuditTestContestsP(
 
     // TODO why  is this differrent ?
     val cards = Closer(cardManifest.iterator())
-    val contestsUA = ContestUnderAudit.make(contestsToAudit, cards, isClca=true, hasStyle=false)
+    val contestsUA = ContestUnderAudit.make(contestsToAudit, cards, isClca=true)
 
     // create from cardStyles and populate the pool counts from the mvrs
     val poolsFromCvrs = calcOneAuditPoolsFromMvrs(infos, cardStyles, mvrs)
 
     // The OA assort averages come from the mvrs
-    addOAClcaAssortersFromMargin(contestsUA, poolsFromCvrs, hasStyle=true)
+    addOAClcaAssortersFromMargin(contestsUA, poolsFromCvrs)
 
     // poolsFromCvrs record the complete pool contests,
     return Pair(contestsUA, poolsFromCvrs)

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditTest.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditTest.kt
@@ -26,14 +26,12 @@ fun makeOneAuditTest(
     cvrFraction: Double,
     undervoteFraction: Double,
     phantomFraction: Double,
-    hasStyle: Boolean = true,
     extraInPool: Int = 0,
 ): ContestMvrCardAndPools {
     val nvotes = roundToClosest(Nc * (1.0 - undervoteFraction - phantomFraction))
     val winner = roundToClosest((margin * Nc + nvotes) / 2)
     val loser = nvotes - winner
-    return makeOneAuditTest(winner, loser, cvrFraction, undervoteFraction, phantomFraction,
-        hasStyle, extraInPool)
+    return makeOneAuditTest(winner, loser, cvrFraction, undervoteFraction, phantomFraction, extraInPool)
 }
 
 // two candidate contest, with specified total votes
@@ -44,7 +42,6 @@ fun makeOneAuditTest(
     cvrFraction: Double,
     undervoteFraction: Double,
     phantomFraction: Double,
-    hasStyle: Boolean = true,
     extraInPool: Int = 0,
 ): ContestMvrCardAndPools {
 
@@ -132,7 +129,7 @@ fun makeOneAuditTest(
     // val oaUAold = makeContestUA(contest, cardManifest, infos, listOf(pool), hasStyle)
 
     val (oaUA, cardPools) = makeOneAuditTestContests(
-        hasStyle, infos, listOf(contest), listOf(pool), cardManifest, mvrs)
+        infos, listOf(contest), listOf(pool), cardManifest, mvrs)
 
     return ContestMvrCardAndPools(oaUA.first(), mvrs, cardManifest, cardPools)
 }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/oneaudit/makeOneAuditTestContests.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/oneaudit/makeOneAuditTestContests.kt
@@ -19,7 +19,6 @@ import org.cryptobiotic.rlauxe.util.tabulateAuditableCards
 private const val debug = false
 
 fun makeOneAuditTestContests(
-    hasStyle: Boolean,
     infos: Map<Int, ContestInfo>, // all the contests in the pools
     contestsToAudit: List<Contest>, // the contests you want to audit
     cardStyles: List<CardStyleIF>,
@@ -32,7 +31,7 @@ fun makeOneAuditTestContests(
     val Nbs = manifestTabs.mapValues { it.value.ncards }
 
     val contestsUA = contestsToAudit.map {
-        val cua = ContestUnderAudit(it, true, hasStyle = hasStyle, NpopIn=Nbs[it.id])
+        val cua = ContestUnderAudit(it, true, NpopIn=Nbs[it.id])
         if (it is DHondtContest) {
             cua.addAssertionsFromAssorters(it.assorters)
         } else {
@@ -68,7 +67,7 @@ fun makeOneAuditTestContests(
     } */
 
     // The OA assort averages come from the mvrs
-    addOAClcaAssortersFromMargin(contestsUA, poolsFromCvrs, hasStyle=true)
+    addOAClcaAssortersFromMargin(contestsUA, poolsFromCvrs)
 
     // poolsFromCvrs record the complete pool contests,
     return Pair(contestsUA, poolsFromCvrs)
@@ -96,7 +95,7 @@ fun makeTestContestOAIrv(): RaireContestUnderAudit {
         listOf(2), mapOf(1 to 1, 2 to 2, 3 to 3)
     )
 
-    val oaIrv = RaireContestUnderAudit(rcontest, hasStyle = true, rassertions = listOf(assert1, assert2))
+    val oaIrv = RaireContestUnderAudit(rcontest, rassertions = listOf(assert1, assert2))
 
     // add pools
 
@@ -124,7 +123,7 @@ fun makeTestContestOAIrv(): RaireContestUnderAudit {
             Pair(pool.poolId, 0.55)
         }
         val poolAvgs = AssortAvgsInPools(pairs.toMap())
-        val clcaAssertion = ClcaAssorterOneAudit(assertion.info, passort, true, oaIrv.makeDilutedMargin(passort), poolAvgs)
+        val clcaAssertion = ClcaAssorterOneAudit(assertion.info, passort, oaIrv.makeDilutedMargin(passort), poolAvgs)
         ClcaAssertion(assertion.info, clcaAssertion)
     }
     oaIrv.clcaAssertions = clcaAssertions

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/raire/SimulateRaireTestContest.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/raire/SimulateRaireTestContest.kt
@@ -113,7 +113,6 @@ private fun trytoMakeRaireContest(N: Int, contestId: Int, ncands:Int, minMargin:
         Ncast = testContest.Nc - testContest.phantomCount,
         undervotes=testContest.underCount,
         raireAssertions,
-        hasStyle,
     )
 
     return Pair(rcontestUA, testCvrs)

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/util/ContestsForTesting.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/util/ContestsForTesting.kt
@@ -88,7 +88,7 @@ fun makeContestFromFakeCvrs(info: ContestInfo, ncvrs: Int): Contest {
 }
 
 fun makeContestUAfromCvrs(info: ContestInfo, cvrs: List<Cvr>, isComparison: Boolean=true, hasStyle: Boolean=true) : ContestUnderAudit {
-    return ContestUnderAudit( makeContestFromCvrs(info, cvrs), isClca=isComparison, hasStyle=hasStyle).addStandardAssertions()
+    return ContestUnderAudit( makeContestFromCvrs(info, cvrs), isClca=isComparison).addStandardAssertions()
 }
 
 fun makeContestUAFromCvrs(contests: List<Contest>, cvrs: List<Cvr>, hasStyle: Boolean=true): List<ContestUnderAudit> {
@@ -110,7 +110,7 @@ fun makeContestUAFromCvrs(contests: List<Contest>, cvrs: List<Cvr>, hasStyle: Bo
         if (contest == null)
             throw RuntimeException("no contest for contest id= $conId")
         val accumVotes = allVotes[conId]!!
-        val contestUA = ContestUnderAudit(contest, isClca=true, hasStyle=hasStyle).addStandardAssertions()
+        val contestUA = ContestUnderAudit(contest, isClca=true).addStandardAssertions()
         require(checkEquivilentVotes((contestUA.contest as Contest).votes, accumVotes))
         contestUA
     }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/ContestAuditTaskGeneratorOA.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/ContestAuditTaskGeneratorOA.kt
@@ -136,7 +136,6 @@ class OneAuditSingleRoundWithDilutedMargin(
                 cvrFraction = cvrPercent,
                 undervoteFraction = underVotePct,
                 phantomFraction = phantomPct,
-                hasStyle = config.hasStyle,
                 extraInPool = extraInPool
             )
 

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManagerForTesting.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManagerForTesting.kt
@@ -33,7 +33,7 @@ class MvrManagerForTesting(
         return pools
     }
 
-    override fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, CvrIF>>  {
+    override fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCard>>  {
         if (mvrsRound.isEmpty()) {
             return mvrsUA.zip(sortedCards) // all of em, for SingleRoundAudit
         }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManagerFromManifest.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManagerFromManifest.kt
@@ -43,7 +43,7 @@ class MvrManagerFromManifest(
         return pools
     }
 
-    override fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, CvrIF>>  {
+    override fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCard>>  {
         if (mvrsRound.isEmpty()) {  // for SingleRoundAudit.
             val sampledMvrs = if (simFuzzPct == null) {
                 sortedMvrs // use the mvrs as they are - ie, no errors

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/TestSampling.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/TestSampling.kt
@@ -34,7 +34,7 @@ class ClcaNoErrorIterator(
             val cvr = cvrIterator.next()
             idx++
             if (cvr.hasContest(contestId)) {
-                val result = cassorter.bassort(cvr, cvr)
+                val result = cassorter.bassort(cvr, cvr, hasStyle=true)
                 count++
                 return result
             }
@@ -91,7 +91,7 @@ class OneAuditNoErrorIterator(
         while (idx < cvrs.size) {
             val cvr = cvrs[permutedIndex[idx]]
             idx++
-            val result = cassorter.bassort(cvr, cvr)
+            val result = cassorter.bassort(cvr, cvr, hasStyle=true)
             count++
             return result
         }
@@ -187,7 +187,7 @@ class ClcaSimulatedErrorRates(
             val mvr = mvrs[permutedIndex[idx]]
             idx++
             if (cvr.hasContest(contest.id)) { // TODO ??
-                val result = cassorter.bassort(mvr, cvr)
+                val result = cassorter.bassort(mvr, cvr, hasStyle=true)
                 count++
                 return result
             }
@@ -235,7 +235,7 @@ class ClcaSimulatedErrorRates(
                 if (bassort != 0.0 * cassorter.noerror()) { // p1
                     cassorter.bassort(alteredMvr, cvr)
                 } */
-                require(cassorter.bassort(alteredMvr, cvr) == 0.0 * cassorter.noerror())
+                require(cassorter.bassort(alteredMvr, cvr, hasStyle=true) == 0.0 * cassorter.noerror())
                 changed++
             }
             cardIdx++
@@ -274,7 +274,7 @@ class ClcaSimulatedErrorRates(
                 if (bassort != 2.0 * cassorter.noerror()) { // p1
                     cassorter.bassort(alteredMvr, cvr) // mvr, cvr
                 } */
-                require(cassorter.bassort(alteredMvr, cvr) == 2.0 * cassorter.noerror())
+                require(cassorter.bassort(alteredMvr, cvr, hasStyle=true) == 2.0 * cassorter.noerror())
                 changed++
             }
             cardIdx++
@@ -314,7 +314,7 @@ class ClcaSimulatedErrorRates(
                 if (bassort != 0.5 * cassorter.noerror()) { // p1
                     cassorter.bassort(alteredMvr, cvr)
                 } */
-                require(cassorter.bassort(alteredMvr, cvr) == 0.5 * cassorter.noerror())
+                require(cassorter.bassort(alteredMvr, cvr, hasStyle=true) == 0.5 * cassorter.noerror())
                 changed++
             }
             cardIdx++
@@ -344,11 +344,11 @@ class ClcaSimulatedErrorRates(
                 val alteredMvr = makeNewCvr(cvr, votes)
                 mcvrs[cardIdx] = alteredMvr
                 require(cassorter.assorter().assort(alteredMvr) == 1.0)
-                val bassort = cassorter.bassort(alteredMvr, cvr)
+                val bassort = cassorter.bassort(alteredMvr, cvr, hasStyle=true)
                 if (bassort != 1.5 * cassorter.noerror()) { // p3
-                    cassorter.bassort(alteredMvr, cvr)
+                    cassorter.bassort(alteredMvr, cvr, hasStyle=true)
                 }
-                require(cassorter.bassort(alteredMvr, cvr) == 1.5 * cassorter.noerror())
+                require(cassorter.bassort(alteredMvr, cvr, hasStyle=true) == 1.5 * cassorter.noerror())
                 changed++
             }
             cardIdx++
@@ -377,11 +377,11 @@ class ClcaSimulatedErrorRates(
 
                 val alteredCvr = makeNewCvr(mvr, votes)
                 require(cassorter.assorter().assort(alteredCvr) == 0.5)
-                val bassort = cassorter.bassort(mvr, alteredCvr)
+                val bassort = cassorter.bassort(mvr, alteredCvr, hasStyle=true)
                 if (bassort != 1.5 * cassorter.noerror()) { // p3
-                    cassorter.bassort(mvr, alteredCvr)
+                    cassorter.bassort(mvr, alteredCvr, hasStyle=true)
                 }
-                require(cassorter.bassort(mvr, alteredCvr) == 1.5 * cassorter.noerror())
+                require(cassorter.bassort(mvr, alteredCvr, hasStyle=true) == 1.5 * cassorter.noerror())
                 cvrs[cardIdx] = alteredCvr // Note we are changing the cvr, not the mvr
                 changed++
             }
@@ -481,7 +481,7 @@ class ClcaCardSimulatedErrorRates(
             val mvr = mvrs[permutedIndex[idx]]
             idx++
             if (card.hasContest(contest.id)) {
-                val result = cassorter.bassort(mvr.cvr(), card.cvr())
+                val result = cassorter.bassort(mvr.cvr(), card.cvr(), card.exactContests())
                 count++
                 return result
             }
@@ -728,7 +728,7 @@ class ClcaFuzzSampler(
             val (mvr, cvr) = cvrPairs[permutedIndex[idx]]
             idx++
             if (cvr.hasContest(contest.id)) {
-                val result = cassorter.bassort(mvr, cvr)
+                val result = cassorter.bassort(mvr, cvr, hasStyle=true)
                 welford.update(result)
                 return result
             }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/WorkflowTesterClca.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/WorkflowTesterClca.kt
@@ -3,8 +3,11 @@ package org.cryptobiotic.rlauxe.workflow
 import org.cryptobiotic.rlauxe.audit.AuditConfig
 import org.cryptobiotic.rlauxe.audit.AuditRound
 import org.cryptobiotic.rlauxe.audit.AuditType
+import org.cryptobiotic.rlauxe.audit.AuditableCard
+import org.cryptobiotic.rlauxe.core.ClcaAssorter
 import org.cryptobiotic.rlauxe.core.Contest
 import org.cryptobiotic.rlauxe.core.ContestUnderAudit
+import org.cryptobiotic.rlauxe.core.Cvr
 import org.cryptobiotic.rlauxe.dhondt.DHondtContest
 import org.cryptobiotic.rlauxe.raire.RaireContestUnderAudit
 
@@ -23,7 +26,7 @@ class WorkflowTesterClca(
         require (auditConfig.auditType == AuditType.CLCA)
 
         val regularContests = contestsToAudit.map {
-            val cua = ContestUnderAudit(it, true, hasStyle = auditConfig.hasStyle, NpopIn=Npops[it.id])
+            val cua = ContestUnderAudit(it, true, NpopIn=Npops[it.id])
             if (it is DHondtContest) {
                 cua.addAssertionsFromAssorters(it.assorters)
             } else {
@@ -47,4 +50,10 @@ class WorkflowTesterClca(
     override fun auditRounds() = auditRounds
     override fun contestsUA(): List<ContestUnderAudit> = contestsUA
     override fun mvrManager() = mvrManager
+}
+
+fun makeClcaNoErrorSampler(contestId: Int, cvrs : List<Cvr>, cassorter: ClcaAssorter): Sampling {
+    val cards = cvrs.mapIndexed { idx, it -> AuditableCard.fromCvr(it, idx, 0) }
+    val cvrPairs = cvrs.zip(cards)
+    return ClcaSampling(contestId, cvrPairs, cassorter, true)
 }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/WorkflowTesterPolling.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/WorkflowTesterPolling.kt
@@ -11,7 +11,7 @@ class WorkflowTesterPolling(
     contestsToAudit: List<ContestIF>, // the contests you want to audit
     val mvrManager: MvrManager,
 ): AuditWorkflow() {
-    private val contestsUA: List<ContestUnderAudit> = contestsToAudit.map { ContestUnderAudit(it, isClca=false, hasStyle=auditConfig.hasStyle).addStandardAssertions() }
+    private val contestsUA: List<ContestUnderAudit> = contestsToAudit.map { ContestUnderAudit(it, isClca=false).addStandardAssertions() }
     private val auditRounds = mutableListOf<AuditRound>()
 
     init {

--- a/docs/SamplePopulations.md
+++ b/docs/SamplePopulations.md
@@ -1,5 +1,5 @@
 # What does hasStyle mean?
-_12/17/25_
+_12/18/25_
 
 # TL;DR
 
@@ -105,9 +105,11 @@ Define:
 * CardStyle = the full and exact list of contests on a card.
 * card.exactContests = list of contests that are on this card = CardStyle = "we know exactly what contests are on this card".
 * card.possibleContests = list of contests that might be on this card.
+
 * "population" = a distinct container of cards, from which we can retreive named cards (even if its just by an index into a ordered list).
 * population.possibleContests = list of contests that are in this population.
 * population.hasCardStyle = true if all cards in the population have a single known CardStyle = "we know exactly what contests are on each card".
+* population.exactContests = population.hasCardStyle
 
 Populations describe the containers that the physical cards are kept in.
 

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/CompareAlphaPaper.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/CompareAlphaPaper.kt
@@ -37,10 +37,10 @@ class CompareAlphaPaper {
             val pairs = cvrs.zip(cvrs)
 
             val contest = makeContestFromCvrs(info, cvrs)
-            val contestUA = ContestUnderAudit(contest, isClca = false, hasStyle = true).addStandardAssertions()
+            val contestUA = ContestUnderAudit(contest, isClca = false).addStandardAssertions()
             val pollingAssertion = contestUA.pollingAssertions.first()
 
-            val contestUAc = ContestUnderAudit(contest, isClca = true, hasStyle = true).addStandardAssertions()
+            val contestUAc = ContestUnderAudit(contest, isClca = true).addStandardAssertions()
             val compareAssertion = contestUAc.clcaAssertions.first()
 
             for (eta in etas) {

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/CompareAlphaPaperUsingMasses.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/CompareAlphaPaperUsingMasses.kt
@@ -91,7 +91,7 @@ class CompareAlphaPaperUsingMasses {
 
         val cvrs = makeCvrsByExactMean(N, cvrMean)
         val contest = makeContestsFromCvrs(cvrs).first()
-        val contestUA = ContestUnderAudit(contest, isClca=true, hasStyle=true).addStandardAssertions()
+        val contestUA = ContestUnderAudit(contest, isClca=true).addStandardAssertions()
         val compareAssorter = contestUA.clcaAssertions.first().cassorter
 
         // sanity checks

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/CardManifestAttack.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/CardManifestAttack.kt
@@ -179,7 +179,7 @@ class CardManifestAttack {
         val realContests = makeContestsFromCvrs(mvrs)
         val realNps = mvrTabs.mapValues { it.value.ncards }
         val realcontestUA = realContests.map {
-            ContestUnderAudit(it, true, hasStyle = hasStyle, NpopIn=realNps[it.id]).addStandardAssertions()
+            ContestUnderAudit(it, true, NpopIn=realNps[it.id]).addStandardAssertions()
         }
         println("true Contest totals")
         realcontestUA.forEach { contestUA -> println(contestUA.showSimple())}
@@ -211,10 +211,10 @@ class CardManifestAttack {
         val Npops = manifestTabs.mapValues { it.value.ncards }
 
         val contestsUA = contests.map {
-            ContestUnderAudit(it, true, hasStyle = hasStyle, NpopIn=Npops[it.id]).addStandardAssertions()
+            ContestUnderAudit(it, true, NpopIn=Npops[it.id]).addStandardAssertions()
         }
         // The OA assort averages come from the card Pools
-        addOAClcaAssortersFromMargin(contestsUA, cardPools, hasStyle=hasStyle)
+        addOAClcaAssortersFromMargin(contestsUA, cardPools)
 
         println("false Contest totals")
         contestsUA.forEach { contestUA -> println(contestUA.showSimple())}

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/CobraAudit.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/CobraAudit.kt
@@ -67,7 +67,7 @@ class CobraAudit(
 
     init {
         require(auditConfig.auditType == AuditType.CLCA)
-        contestsUA = contestsToAudit.map { ContestUnderAudit(it, isClca = true, hasStyle=auditConfig.hasStyle).addStandardAssertions() }
+        contestsUA = contestsToAudit.map { ContestUnderAudit(it, isClca = true,).addStandardAssertions() }
     }
 
     override fun runAuditRound(auditRound: AuditRound, quiet: Boolean): Boolean  {

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/ReproduceCobraResults.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/ReproduceCobraResults.kt
@@ -404,5 +404,5 @@ fun optimal_comparison(alpha: Double, u: Double, rate_error_2: Double = 1e-4): D
 // deprecated
 private fun makeStandardComparisonAssorter(avgCvrAssortValue: Double, Nc: Int): ClcaAssorter {
     val assort = makeStandardPluralityAssorter(Nc)
-    return ClcaAssorter(makeStandardContest(Nc).info, assort, hasUndervotes=true, dilutedMargin=assort.dilutedMargin(), check=false)
+    return ClcaAssorter(makeStandardContest(Nc).info, assort, dilutedMargin=assort.dilutedMargin(), check=false)
 }

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaAudit.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaAudit.kt
@@ -93,7 +93,7 @@ class CorlaAudit(
 
     init {
         require (auditConfig.auditType == AuditType.CLCA)
-        contestsUA = contestsToAudit.map { ContestUnderAudit(it, isClca=true, hasStyle=auditConfig.hasStyle).addStandardAssertions() }
+        contestsUA = contestsToAudit.map { ContestUnderAudit(it, isClca=true, ).addStandardAssertions() }
     }
 
     override fun runAuditRound(auditRound: AuditRound, quiet: Boolean): Boolean  {

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/PlotDistributions.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/PlotDistributions.kt
@@ -113,9 +113,10 @@ class PlotDistributions {
             // heres the ConsistentSample permutation
             //             val sortedIndices = cvrsUA.indices.sortedBy { cvrsUA[it].sampleNumber() }
             val sortedIndices = ballotCards.sortedCards.indices.sortedBy { ballotCards.sortedCards[it].prn } // TODO?
-            val sortedCvrs = sortedIndices.map { testCvrs[it] }
+            val sortedCards = sortedIndices.map { AuditableCard.fromCvr(testCvrs[it], it, 0) }
             val sortedMvrs = sortedIndices.map { testMvrs[it] }
-            val sortedPairs: List<Pair<Cvr, Cvr>> = sortedMvrs.zip(sortedCvrs)
+
+            val sortedPairs: List<Pair<Cvr, AuditableCard>> = sortedMvrs.zip(sortedCards)
 
             // "oracle" audit
             val contestUA = workflow.contestsUA().first()

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SFoaSingleRoundAuditTaskGenerator.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SFoaSingleRoundAuditTaskGenerator.kt
@@ -7,7 +7,6 @@ import org.cryptobiotic.rlauxe.audit.ContestRound
 import org.cryptobiotic.rlauxe.core.Cvr
 import org.cryptobiotic.rlauxe.core.TestH0Result
 import org.cryptobiotic.rlauxe.estimate.ConcurrentTaskG
-import org.cryptobiotic.rlauxe.oneaudit.OneAuditPoolIF
 import org.cryptobiotic.rlauxe.util.CloseableIterable
 import kotlin.use
 
@@ -70,7 +69,7 @@ class SfoaSingleRoundAuditTask(
                         mvrManager.sortedCards().iterator(),
                     )
 
-                val runner = OneAuditAssertionAuditor(mvrManager.populations()!!, true)
+                val runner = OneAuditAssertionAuditor(mvrManager.populations()!!)
 
                 val result: TestH0Result = runner.run(
                     rlauxAudit.auditConfig(),
@@ -105,9 +104,9 @@ class MvrManagerClcaSingleRound(val sortedCards: CloseableIterable<AuditableCard
 
     override fun sortedCards() = sortedCards
 
-    override fun populations() = null
+    override fun populations() = null // TODO
 
-    override fun makeMvrCardPairsForRound(round: Int): List<Pair<Cvr, Cvr>> {
+    override fun makeMvrCardPairsForRound(round: Int): List<Pair<Cvr, AuditableCard>> {
         val cvrs = mutableListOf<Cvr>()
         var count = 0
         var countPool = 0
@@ -120,7 +119,7 @@ class MvrManagerClcaSingleRound(val sortedCards: CloseableIterable<AuditableCard
             }
         }
         println("makeCvrPairsForRound: count=$count poolCount=$countPool")
-        return cvrs.zip(cvrs)
+        return cvrs.zip(AuditableCard.fromCvrs(cvrs))
     }
 
 }


### PR DESCRIPTION
add AuditCard.exactContests (= hasStyle)
remove ClcaAssorter.hasUndervotes, hasCompleteCvrs 
add bassort(.., hasStyle)
remove ContestUnderAudit.hasStyle,
ClcaSampling needs List<Pair<CvrIF, AuditableCard>>
MvrManager.makeMvrCardPairsForRound: List<Pair<CvrIF, AuditableCard>>