### PR TITLE
tweak AuditRound for viewer

### DIFF
--- a/cases/src/test/resources/logback.xml
+++ b/cases/src/test/resources/logback.xml
@@ -11,7 +11,7 @@
             <pattern>%date [%10r] %-5level %logger{15} - %msg %n</pattern>
         </encoder>
     </appender>
-    <root level="DEBUG">
+    <root level="INFO">
         <appender-ref ref="STDOUT"/>
         <appender-ref ref="FILE"/>
     </root>

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRound.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRound.kt
@@ -26,7 +26,7 @@ data class AuditRound(
     }
 
     //// called from viewer
-    fun maxBallotsUsed(): Int {
+    fun mvrsUsed(): Int {
         var result = 0
         contestRounds.forEach { contest ->
             contest.assertionRounds.forEach { assertion ->
@@ -51,13 +51,13 @@ data class ContestRound(val contestUA: ContestWithAssertions, val assertionRound
     val name = contestUA.name
     val Npop = contestUA.Npop
 
-    var estCardsNeeded = 0 // initial estiimate of cards for the contests
-
-    var actualMvrs = 0 // Actual number of ballots with this contest contained in this round's sample.
-    var actualNewMvrs = 0 // Actual number of new ballots with this contest contained in this round's sample.
-
+    var estCardsNeeded = 0 // initial estimate of cards for the contest
+    var estSampleSize = 0 // TODO CANDIDATE FOR REMOVAL // number of total samples estimated needed
     var estNewSamples = 0 // Estimate of the new sample size required to confirm the contest
-    var estSampleSize = 0 // number of total samples estimated needed
+
+    var actualMvrs = 0    // Actual number of ballots with this contest contained in this round's sample.
+    var actualNewMvrs = 0 // TODO CANDIDATE FOR REMOVAL Actual number of new ballots with this contest contained in this round's sample.
+
     var auditorWantNewMvrs: Int = -1 // Auditor has set the new sample size for this audit round. rlauxe-viewer
 
     var done = false
@@ -183,7 +183,7 @@ data class EstimationRoundResult(
     val strategy: String,
     val fuzzPct: Double?,
     val startingTestStatistic: Double,
-    val startingRates: Map<Double, Double>? = null, // error rates used for estimation
+    val startingRates: Map<Double, Double>? = null, // error rates used for estimation TODO
     val estimatedDistribution: List<Int>,   // distribution of estimated sample size; currently deciles
     val firstSample: Int,
 ) {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/betting/ClcaErrorCounts.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/betting/ClcaErrorCounts.kt
@@ -21,16 +21,15 @@ data class ClcaErrorCounts(val errorCounts: Map<Double, Int>, val totalSamples: 
     }
 
     fun show() = buildString {
-        appendLine("totalSamples=$totalSamples, noerror=$noerror, upper=$upper")
-
+        // appendLine("totalSamples=$totalSamples, noerror=$noerror, upper=$upper")
         if (errorCounts.isNotEmpty()) {
             val sorted = errorCounts.toSortedMap()
-            append("    cvr counts= [")
+            append("[")
             sorted.forEach { (bassort, count) ->
                 val desc = taus.desc(bassort / noerror)
                 if (desc != null) append("$desc=$count, ")
             }
-            appendLine("]")
+            append("]")
         }
     }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedWorkflow.kt
@@ -12,7 +12,11 @@ import org.cryptobiotic.rlauxe.persist.json.writeSamplePrnsJsonFile
 
 private val logger = KotlinLogging.logger("PersistentAudit")
 
-enum class PersistedWorkflowMode { real, testSimulated, testPrivateMvrs }
+enum class PersistedWorkflowMode {
+    real,           // use PersistedMvrManager;  sampleMvrs$round.csv must be written from external program.
+    testSimulated,  // use PersistedMvrManagerTest which fuzzes the cvrs on the fly
+    testPrivateMvrs  // use PersistedMvrManager; use private/sortedMvrs.csv to write sampleMvrs$round.csv
+}
 
 /** AuditWorkflow with persistent state. */
 class PersistedWorkflow(
@@ -81,7 +85,7 @@ class PersistedWorkflow(
     override fun runAuditRound(auditRound: AuditRound, quiet: Boolean): Boolean  { // return complete
         val roundIdx = auditRound.roundIdx
 
-        //   in a real audit, upi need to set the real mvrs externally with EnterMvrsCli, which calls auditRecord.enterMvrs(mvrs)
+        //   in a real audit, need to set the real mvrs externally with EnterMvrsCli, which calls auditRecord.enterMvrs(mvrs)
         //   in a test audit, the test mvrs are generated from the cardManifest, with optional fuzzing
         if (mvrManager is PersistedMvrManagerTest) {
             val sampledMvrs = mvrManager.setMvrsForRoundIdx(roundIdx)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditRound.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditRound.kt
@@ -39,7 +39,7 @@ class TestAuditRound {
             assertNotEquals(firstAssertion.assertion.loser, firstAssertion.assertion.winner) // wtf?
         }
 
-        assertEquals(0, auditRound.maxBallotsUsed())
+        assertEquals(0, auditRound.mvrsUsed())
     }
 
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRoundCli.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRoundCli.kt
@@ -8,7 +8,7 @@ class TestRunRoundCli {
 
     @Test
     fun testRunRoundCli() {
-        val topdir = "$testdataDir/cases/boulder24/clca"
+        val topdir = "$testdataDir/persist/testRunCli/clca"
         val auditdir = "$topdir/audit"
 
         RunRlaRoundCli.main(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-rlauxe = "0.7.2"
+rlauxe = "0.7.3"
 
 # main dependency versions
 kotlin = "2.1.21"


### PR DESCRIPTION
fix bug in PersistedMvrManagerTest.setMvrsBySampleNumber that was crashing CLCA audits. 
ConsistentSampling uses wantSampleSizeSimple
bump 0.7.3