### PR TITLE
Improve Estimations

### DIFF
--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestColoradoElectionCsv.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestColoradoElectionCsv.kt
@@ -1,5 +1,6 @@
 package org.cryptobiotic.rlauxe.corla
 
+import org.cryptobiotic.rlauxe.betting.ClcaErrorCounts
 import org.cryptobiotic.rlauxe.betting.ClcaErrorTracker
 import org.cryptobiotic.rlauxe.betting.GeneralAdaptiveBetting
 import org.cryptobiotic.rlauxe.betting.populationMeanIfH0
@@ -54,7 +55,9 @@ fun betPayoffSamples(N: Int, risk: Double, assorterMargin: Double, error: Double
     val avgCvrAssortValue = margin2mean(assorterMargin)
     val assorterMargin2 = 2.0 * avgCvrAssortValue - 1.0 // reported assorter margin, not clca margin
     // val noerror = 1.0 / (2.0 - assorterMargin / assorter.upperBound())
-    val noerror = 1 / (2 - assorterMargin2) // assumes upperBound = 1.0
+    val noerror = 1 / (2 - assorterMargin2)
+
+    // assumes upperBound = 1.0
     // class GeneralAdaptiveBetting(
     //    val Npop: Int, // population size for this contest
     //    // val accumErrorCounts: ClcaErrorCounts, // propable illegal to do (cant use prior knowlege of the sample)
@@ -65,6 +68,8 @@ fun betPayoffSamples(N: Int, risk: Double, assorterMargin: Double, error: Double
     //    val debug: Boolean = false,
     val bettingFn = GeneralAdaptiveBetting(
         Npop = N,
+        startingErrors = ClcaErrorCounts.empty(noerror, 1.0),
+        nphantoms=0,
         oaAssortRates = null,
         d = 100,
         maxRisk = .99,

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/raire/AssertionRLAipynb.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/raire/AssertionRLAipynb.kt
@@ -1,6 +1,7 @@
 package org.cryptobiotic.rlauxe.raire
 
 import org.cryptobiotic.rlauxe.audit.*
+import org.cryptobiotic.rlauxe.betting.ClcaErrorCounts
 import org.cryptobiotic.rlauxe.betting.ClcaErrorTracker
 import org.cryptobiotic.rlauxe.betting.GeneralAdaptiveBetting
 import org.cryptobiotic.rlauxe.core.*
@@ -652,7 +653,10 @@ fun calc_sample_sizes(
 
     val tracker = ClcaErrorTracker(cassorter.noerror(), cassorter.assorter.upperBound())
     val sampler: Sampler = makeClcaNoErrorSampler(contest.id, cvrs, cassorter)
-    val betFn = GeneralAdaptiveBetting(N, oaAssortRates = null, d = 100, maxRisk = .99)
+    val betFn = GeneralAdaptiveBetting(N,
+        startingErrors = ClcaErrorCounts.empty(noerror = cassorter.noerror(), upper = cassorter.assorter.upperBound()),
+        contest.contest.Nphantoms(),
+        oaAssortRates = null, d = 100, maxRisk = .99)
     val betta = BettingMart(bettingFn = betFn, N = N, sampleUpperBound = cassorter.upperBound(), withoutReplacement = false,
         tracker = tracker)
 

--- a/cases/src/test/kotlin/org/cryptobiotic/util/TestRunCli.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/util/TestRunCli.kt
@@ -26,7 +26,7 @@ class TestRunCli {
             arrayOf(
                 "-in", topdir,
                 "-minMargin", "0.01",
-                "-fuzzMvrs", ".0123",
+                "-fuzzMvrs", ".0",
                 "-ncards", "10000",
                 "-ncontests", "11",
             )

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAudit.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAudit.kt
@@ -123,7 +123,7 @@ fun runRoundAgain(auditDir: String, contestRound: ContestRound, assertionRound: 
                 append(" i, ${sfn("xs", 6)}, ${sfn("bet", 6)}, ${sfn("tj", 6)}, ${sfn("Tj", 6)}, ${sfn("pvalue", 8)}, ")
                 appendLine("${sfn("location", 10)}, ${sfn("mvr votes", 10)}, ${sfn("card", 10)}")
                 repeat(count) {
-                    append("${nfn(it, 2)}, ${df(seq.xs[it])}, ${df(seq.bets[it])}, ${df(seq.tjs[it])}")
+                    append("${nfn(it+1, 2)}, ${df(seq.xs[it])}, ${df(seq.bets[it])}, ${df(seq.tjs[it])}")
                     append(", ${trunc(seq.testStatistics[it].toString(), 6)}, ${trunc(pvalues[it].toString(), 8)}")
                     val pair = sampler.next()
                     val mvrVotes = pair.first.votes(contestId)?.contentToString() ?: "missing"

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/betting/ClcaErrorCounts.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/betting/ClcaErrorCounts.kt
@@ -8,7 +8,7 @@ import org.cryptobiotic.rlauxe.util.doubleIsClose
 data class ClcaErrorCounts(val errorCounts: Map<Double, Int>, val totalSamples: Int, val noerror: Double, val upper: Double) {
     val taus = Taus(upper)
 
-    fun errorRates() = errorCounts.mapValues { if (totalSamples == 0) 0.0 else it.value / totalSamples.toDouble() }  // bassortValue -> rate
+    fun errorRates() : Map<Double, Double> = errorCounts.mapValues { if (totalSamples == 0) 0.0 else it.value / totalSamples.toDouble() }  // bassortValue -> rate
     fun errorCounts() = errorCounts // bassortValue -> count
 
     fun bassortValues(): List<Double> {
@@ -18,6 +18,11 @@ data class ClcaErrorCounts(val errorCounts: Map<Double, Int>, val totalSamples: 
     fun clcaErrorRate(): Double {
         val clcaErrors = errorCounts.toList().filter { (key, value) -> taus.isClcaError(key / noerror) }.sumOf { it.second }
         return clcaErrors / totalSamples.toDouble()
+    }
+
+    fun isPhantom(bassort: Double): Boolean {
+        val tau = bassort / noerror
+        return taus.desc(tau) == "oth-los"
     }
 
     fun show() = buildString {
@@ -30,11 +35,19 @@ data class ClcaErrorCounts(val errorCounts: Map<Double, Int>, val totalSamples: 
                 if (desc != null) append("$desc=$count, ")
             }
             append("]")
+        } else {
+            append("no errors")
         }
     }
 
-    override fun toString(): String {
-        return "ClcaErrorCounts(errorCounts=$errorCounts, totalSamples=$totalSamples, noerror=$noerror, upper=$upper, bassortValues=${bassortValues()})"
+    override fun toString() = buildString {
+        appendLine("ClcaErrorCounts(totalSamples=$totalSamples, noerror=$noerror, upper=$upper")
+        appendLine("  bassortValues=${bassortValues()}")
+        appendLine("    errorCounts=$errorCounts")
+    }
+
+    companion object {
+        fun empty(noerror: Double, upper: Double) = ClcaErrorCounts(emptyMap(), 0, noerror, upper)
     }
 
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ClcaAssorter.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ClcaAssorter.kt
@@ -3,6 +3,8 @@ package org.cryptobiotic.rlauxe.core
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.util.dfn
 import org.cryptobiotic.rlauxe.util.margin2mean
+import org.cryptobiotic.rlauxe.util.roundUp
+import kotlin.math.ln
 
 private val logger = KotlinLogging.logger("ClcaAssorter")
 
@@ -63,6 +65,20 @@ open class ClcaAssorter(
     fun noerror() = noerror
     fun upperBound() = upperBound  // upper bound of clca assorter; betting functions may need to know this
     fun assorter() = assorter
+
+    // expected sample size of there are no errors
+    fun sampleSizeNoErrors(maxRisk: Double, alpha: Double): Int {
+        val maxBet = 2 * maxRisk
+
+        // payoff = 1 + λ_i * (x - mui)
+        val payoff = 1 + maxBet * (noerror - 0.5)  // mui ~= 1/2
+
+        // t_i = 1 + λ_i * (X_i − µ_i) ; T_i = Prod(t_i) > 1/alpha
+        // if X_i always equals noerror:
+        // (payoff)^sampleSize = 1 / alpha
+        // sampleSize = -ln(alpha) / ln(payoff)
+        return roundUp((-ln(alpha) / ln(payoff)))
+    }
 
     // B(bi, ci) = (1-o/u)/(2-v/u), where
     //                o is the overstatement

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Contest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Contest.kt
@@ -94,7 +94,6 @@ interface ContestIF {
     fun losers(): List<Int>
 
     fun undervotePct() = roundToClosest(100.0 * Nundervotes() / (info().voteForN * Nc())) // for viewer
-    fun phantomRate() = Nphantoms() / Nc().toDouble()
     fun isIrv() = choiceFunction == SocialChoiceFunction.IRV
     fun show() : String = toString()
     fun showCandidates(): String
@@ -419,6 +418,8 @@ open class ContestWithAssertions(
         return if (minAssertion != null)  contest.showAssertionDifficulty(minAssertion.assorter) else "N/A"
     }
 
+    fun phantomRate() = contest.Nphantoms() / Npop.toDouble()
+
     override fun toString() = showShort()
 
     open fun show() = buildString {
@@ -429,6 +430,7 @@ open class ContestWithAssertions(
             append("   ${contest.showAssertionDifficulty(minAssertion.assorter)}")
             append(" Npop=$Npop dilutedMargin=${pfn(minAssorter.dilutedMargin())}")
             appendLine(" reportedMargin=${pfn(minAssorter.dilutedMargin())} recountMargin=${pfn(contest.recountMargin(minAssorter))} ")
+            appendLine()
         }
         append(contest.showCandidates())
     }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/SimulateIrvTestData.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/SimulateIrvTestData.kt
@@ -64,6 +64,6 @@ data class SimulateIrvTestData(
     }
 
     override fun toString() = buildString {
-        append("SimulateIrvTestData(${contest.id}} phantomPct=${df(contest.phantomRate())} ncards=${ncards}")
+        append("SimulateIrvTestData(${contest.id}} phantoms=${contest.Nphantoms()} ncards=${ncards}")
     }
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/CheckContestsCorrectlyFormed.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/CheckContestsCorrectlyFormed.kt
@@ -27,9 +27,9 @@ fun checkContestsCorrectlyFormed(config: AuditConfig, contestsUA: List<ContestWi
             } else {
                 // see if too many phantoms
                 val minMargin = contestUA.minDilutedMargin() ?: 0.0
-                val adjustedMargin = minMargin - contestUA.contest.phantomRate()
+                val adjustedMargin = minMargin - contestUA.phantomRate()
                 if (config.removeTooManyPhantoms && adjustedMargin <= 0.0) {
-                    logger.warn{"***TooManyPhantoms contest ${contestUA} adjustedMargin ${adjustedMargin} == $minMargin - ${contestUA.contest.phantomRate()} < 0.0"}
+                    logger.warn{"***TooManyPhantoms contest ${contestUA} adjustedMargin ${adjustedMargin} == $minMargin - ${contestUA.phantomRate()} < 0.0"}
                     contestUA.preAuditStatus = TestH0Status.TooManyPhantoms
                 }
             }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyAuditRecord.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyAuditRecord.kt
@@ -109,7 +109,7 @@ class VerifyAuditRecord(val auditRecordLocation: String) {
         val firstRound = auditRecord.rounds.first()
         val contestRound = firstRound.contestRounds.find { it.id == contest.contest.id }
         if (contestRound == null) return
-        val estCards = contestRound.estSampleSize
+        val estCards = contestRound.estMvrs
 
         result.addMessage(" verify sampling for contest ${contest.id}")
         val cards = readAuditableCardCsvFile(publisher.sampleCardsFile(firstRound.roundIdx))
@@ -118,7 +118,7 @@ class VerifyAuditRecord(val auditRecordLocation: String) {
             val nextRound = auditRecord.rounds[nextRoundIdx]
             val nextContestRound = nextRound.contestRounds.find { it.id == contest.contest.id }
             if (nextContestRound == null) break
-            val estCardsNext = nextContestRound.estSampleSize
+            val estCardsNext = nextContestRound.estMvrs
 
             if (!existsOrZip(publisher.sampleCardsFile(nextRound.roundIdx))) return
             val nextCards = readAuditableCardCsvFile(publisher.sampleCardsFile(nextRound.roundIdx))

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaAssertionAuditor.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaAssertionAuditor.kt
@@ -2,7 +2,6 @@ package org.cryptobiotic.rlauxe.workflow
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.audit.*
-import org.cryptobiotic.rlauxe.betting.BettingFn
 import org.cryptobiotic.rlauxe.betting.ClcaErrorCounts
 import org.cryptobiotic.rlauxe.betting.ClcaErrorTracker
 import org.cryptobiotic.rlauxe.betting.GeneralAdaptiveBetting
@@ -91,11 +90,14 @@ class ClcaAssertionAuditor(val quiet: Boolean = true): ClcaAssertionAuditorIF {
         val cassorter = cassertion.cassorter
         val clcaConfig = config.clcaConfig
 
-        val prevRounds: ClcaErrorCounts = assertionRound.accumulatedErrorCounts(contestRound)
-        //prevRounds.setPhantomRate(contest.phantomRate()) // TODO ??
-
-        val bettingFn: BettingFn = // if (clcaConfig.strategy == ClcaStrategyType.generalAdaptive) {
-            GeneralAdaptiveBetting(contestUA.Npop, oaAssortRates = null, d = clcaConfig.d, maxRisk = clcaConfig.maxRisk)
+        val bettingFn = // if (clcaConfig.strategy == ClcaStrategyType.generalAdaptive) {
+            GeneralAdaptiveBetting(
+                contestUA.Npop,
+                startingErrors = ClcaErrorCounts.empty(cassorter.noerror(), cassorter.assorter.upperBound()),
+                contest.Nphantoms(),
+                oaAssortRates = null,
+                d = clcaConfig.d,
+                maxRisk = clcaConfig.maxRisk)
 
         val tracker = ClcaErrorTracker(
             cassorter.noerror(),
@@ -125,7 +127,7 @@ class ClcaAssertionAuditor(val quiet: Boolean = true): ClcaAssertionAuditorIF {
             pvalue = testH0Result.pvalueLast,
             samplesUsed = testH0Result.sampleCount,
             status = testH0Result.status,
-            startingRates = prevRounds,
+            // startingRates = bettingFn.startingErrorRates(),
             measuredCounts = measuredCounts,
         )
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAuditAssertionAuditor.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAuditAssertionAuditor.kt
@@ -31,12 +31,11 @@ class OneAuditAssertionAuditor(val pools: List<OneAuditPoolIF>, val quiet: Boole
         val oneAuditErrorsFromPools = OneAuditRatesFromPools(pools)
         val oaErrorRates = oneAuditErrorsFromPools.oaErrorRates(contestUA, oaCassorter)
 
-        val accumErrorCounts: ClcaErrorCounts = assertionRound.accumulatedErrorCounts(contestRound)
-        //accumErrorCounts.setPhantomRate(contestUA.contest.phantomRate()) // TODO ??
-
-        val bettingFn: BettingFn = // if (clcaConfig.strategy == ClcaStrategyType.generalAdaptive) {
+        val bettingFn = // if (clcaConfig.strategy == ClcaStrategyType.generalAdaptive) {
             GeneralAdaptiveBetting(
                 Npop = contestUA.Npop,
+                startingErrors = ClcaErrorCounts.empty(oaCassorter.noerror(), oaCassorter.assorter.upperBound()),
+                contestUA.contest.Nphantoms(),
                 oaAssortRates = oaErrorRates,
                 d = clcaConfig.d,
                 maxRisk = clcaConfig.maxRisk
@@ -52,7 +51,7 @@ class OneAuditAssertionAuditor(val pools: List<OneAuditPoolIF>, val quiet: Boole
             pvalue = testH0Result.pvalueLast,
             samplesUsed = testH0Result.sampleCount,
             status = testH0Result.status,
-            startingRates = accumErrorCounts,
+            // startingRates = bettingFn.startingErrorRates(),
             measuredCounts = measuredCounts,
             // params = mapOf("poolAvg" to poolAvg)
         )

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManager.kt
@@ -29,6 +29,7 @@ open class PersistedMvrManager(val auditDir: String, val config: AuditConfig, va
         return readPopulations(publisher)
     }
 
+    // TODO I think we need to read previous rounds in, and merge/sort with this round's mvrs.
     override fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCard>>  {
         val mvrsForRound = readMvrsForRound(round)
         val sampleNumbers = mvrsForRound.map { it.prn }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManagerTest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManagerTest.kt
@@ -35,8 +35,8 @@ class PersistedMvrManagerTest(auditDir: String, config: AuditConfig, contestsUA:
         require(previousPrns.size == previousMvrs.size)
         require(previousPrnsSet.size == previousMvrs.size)
 
-        val simFuzzPct = config.simFuzzPct()
-        val sampledMvrs = if (simFuzzPct == null) {
+        val mvrFuzzPct = config.mvrFuzzPct() // TODO should be independent of the simulation
+        val sampledMvrs = if (mvrFuzzPct == 0.0) {
             cards // use the cvrs - ie, no errors
         } else { // fuzz the new cvrs only; doesnt work for polling since we dont have cvrs
             if (config.isPolling) {
@@ -52,7 +52,7 @@ class PersistedMvrManagerTest(auditDir: String, config: AuditConfig, contestsUA:
             val newCards = cards.filter{ !previousPrnsSet.contains(it.prn) }
 
             // and fuzz them
-            val newFuzzedCards = makeFuzzedCardsFrom(contestsUA.map { it.contest.info() }, newCards, simFuzzPct)
+            val newFuzzedCards = makeFuzzedCardsFrom(contestsUA.map { it.contest.info() }, newCards, mvrFuzzPct)
 
             // then the cards we want are the previous cards and the new fuzzed cards
             // cant assume they are sorted by prn

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditRound.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditRound.kt
@@ -22,7 +22,7 @@ class TestAuditRound {
         val mvrManager = MvrManagerForTesting(testCvrs, testCvrs, Random.nextLong())
 
         val contestRounds = contestsUAs.map { contest -> ContestRound(contest, 1) }
-        contestRounds.forEach { it.estSampleSize = it.Npop / 11 } // random
+        contestRounds.forEach { it.estMvrs = it.Npop / 11 } // random
 
         val prng = Prng(Random.nextLong())
         testCvrs.mapIndexed { idx, it -> AuditableCard.fromCvr(it, idx, prng.next()) }
@@ -31,11 +31,11 @@ class TestAuditRound {
         consistentSampling(auditRound, mvrManager)
 
         contestRounds.forEach { contestRound ->
-            assertEquals(contestRound.estSampleSize, contestRound.wantSampleSize(0))
-            assertEquals(contestRound.estSampleSize, contestRound.estSampleSizeEligibleForRemoval())
+            assertEquals(contestRound.estMvrs, contestRound.wantSampleSize(0))
+            assertEquals(contestRound.estMvrs, contestRound.estSampleSizeEligibleForRemoval())
 
             val firstAssertion = contestRound.assertionRounds.first()
-            assertEquals(0, firstAssertion.estSampleSize)
+            assertEquals(0, firstAssertion.estMvrs)
             assertNotEquals(firstAssertion.assertion.loser, firstAssertion.assertion.winner) // wtf?
         }
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestHasStyle.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestHasStyle.kt
@@ -74,7 +74,7 @@ class TestHasStyle {
         println("==========================")
         println("testHasStyleClcaSingleCard hasStyle=${hasStyle} audit estimates we need ${auditRound.nmvrs}")
         auditRound.contestRounds.forEach { round ->
-            println(" *** contest ${round.contestUA.name} wants ${round.estSampleSize} mvrs")
+            println(" *** contest ${round.contestUA.name} wants ${round.estMvrs} mvrs")
         }
 
         // testHasStyleClcaSingleCard hasStyle=false audit estimates we need 550
@@ -169,7 +169,7 @@ class TestHasStyle {
         println("==========================")
         println("testHasStyleClcaMultiCard hasStyle=${hasStyle} audit estimates we need ${auditRound.nmvrs}")
         auditRound.contestRounds.forEach { round ->
-            println(" *** contest ${round.contestUA.name} wants ${round.estSampleSize} mvrs")
+            println(" *** contest ${round.contestUA.name} wants ${round.estMvrs} mvrs")
         }
 
         // testHasStyleClcaMultiCard hasStyle=false audit estimates we need 830
@@ -235,7 +235,7 @@ class TestHasStyle {
         println("==========================")
         println("testHasStylePollingSingleCard hasStyle=${hasStyle} audit estimates we need ${auditRound.nmvrs}")
         auditRound.contestRounds.forEach { round ->
-            println(" *** contest ${round.contestUA.name} wants ${round.estSampleSize} mvrs")
+            println(" *** contest ${round.contestUA.name} wants ${round.estMvrs} mvrs")
         }
         //testHasStylePollingSingleCard hasStyle=false audit estimates we need 2061
         // *** contest B wants 872 mvrs
@@ -321,7 +321,7 @@ class TestHasStyle {
         println("==========================")
         println("testHasStylePollingMultiCard hasStyle=${hasStyle} audit estimates we need ${auditRound.nmvrs}")
         auditRound.contestRounds.forEach { round ->
-            println(" *** contest ${round.contestUA.name} wants ${round.estSampleSize} mvrs")
+            println(" *** contest ${round.contestUA.name} wants ${round.estMvrs} mvrs")
         }
         // testHasStylePollingMultiCard hasStyle=false audit estimates we need 2769
         // *** contest B wants 2275 mvrs

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/betting/TestGAOneAuditBetting.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/betting/TestGAOneAuditBetting.kt
@@ -71,10 +71,17 @@ class TestGeneralAdaptiveBetting2 {
             assorts.add(assortValue)
         }
 
-        val betFn = GeneralAdaptiveBetting(N, oaErrorRates, d=0,  maxRisk = maxRisk, debug=true)
-        val tracker = ClcaErrorTracker(noerror, upper)
+        val betFn = GeneralAdaptiveBetting(
+            N,
+            startingErrors = ClcaErrorCounts.empty(noerror, upper),
+            nphantoms = oaContest.contest.Nphantoms(),
+            oaErrorRates,
+            d=0,
+            maxRisk = maxRisk,
+            debug=true)
 
         // bet from first half
+        val tracker = ClcaErrorTracker(noerror, upper)
         assorts.subList(0, N/2).forEach{ tracker.addSample(it) }
         println(tracker.measuredClcaErrorCounts().show())
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/betting/TestGAWithLamda.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/betting/TestGAWithLamda.kt
@@ -27,9 +27,13 @@ class TestGAWithLamda {
         maxRisk: Double,
         oaErrorRates: OneAuditAssortValueRates? = null
     ) {
-        val betFn = GeneralAdaptiveBetting(N, oaErrorRates, d=0,  maxRisk = maxRisk, debug=false)
-
         val noerror: Double = 1.0 / (2.0 - margin / upper)
+
+        val betFn = GeneralAdaptiveBetting(N,
+            startingErrors = ClcaErrorCounts.empty(noerror, upper),
+            nphantoms = 0,
+            oaErrorRates, d=0,  maxRisk = maxRisk, debug=false)
+
         val tracker = ClcaErrorTracker(noerror, upper)
         repeat(1000) { tracker.addSample(noerror) }
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/betting/TestGeneralAdaptiveBetting1.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/betting/TestGeneralAdaptiveBetting1.kt
@@ -14,7 +14,7 @@ class TestGeneralAdaptiveBetting1 {
 
     @Test
     fun makeBet() {
-        makeBet(N = 10000, margin = .02, upper = 1.0, maxRisk = .9)
+        makeBet(N = 10000, margin = .01, upper = 1.0, maxRisk = .9)
     }
 
     fun makeBet(
@@ -38,7 +38,14 @@ class TestGeneralAdaptiveBetting1 {
         assorts.forEach{ tracker.addSample(it) }
         println(tracker.measuredClcaErrorCounts().show())
 
-        val betFn = GeneralAdaptiveBetting(N, oaErrorRates, d=0,  maxRisk = maxRisk, debug=true)
+        val betFn = GeneralAdaptiveBetting(N,
+            startingErrors = ClcaErrorCounts.empty(noerror, upper),
+            nphantoms = 2,
+            oaErrorRates, d=0,  maxRisk = maxRisk, debug=true)
+
+        val starting = betFn.startingErrorRates()
+        println("starting = $starting maxRisk")
+
         val bet = betFn.bet(tracker)
         println("bet = $bet maxRisk = $maxRisk")
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaAssorter.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaAssorter.kt
@@ -98,6 +98,9 @@ class TestClcaAssorter {
 
         val assortValuesN = assortValues.map { it / noerror / 2 }
         println(" assortValuesN in $assortValuesN")
+
+        val sampleSize = cassorter.sampleSizeNoErrors(0.9, .05);
+        println(" sampleSize = $sampleSize")
     }
 
     @Test

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestContest.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestContest.kt
@@ -134,9 +134,6 @@ class TestContest {
         assertEquals( """'testContestInfo' (0) PLURALITY voteForN=1 votes={1=108, 0=100, 2=0} undervotes=2, voteForN=1
    winners=[1] Nc=211 Nphantoms=1 Nu=2 sumVotes=208""",
             contest.show())
-
-        // assertEquals((211-208-1)/211.toDouble(), contest.undervoteRate())
-        assertEquals(1/211.toDouble(), contest.phantomRate())
     }
 
     @Test

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestClcaCardSimulationErrorRates.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestClcaCardSimulationErrorRates.kt
@@ -80,7 +80,7 @@ class TestClcaCardSimulationErrorRates {
     fun runClcaSimulation(cards: List<AuditableCard>, contestUA: ContestWithAssertions, assorter: ClcaAssorter) {
         println("\n${assorter.assorter.desc()}")
 
-        val phantomRate = contestUA.contest.phantomRate()
+        val phantomRate = contestUA.phantomRate()
         val errorRates = PluralityErrorRates(0.0, phantomRate, 0.0, 0.0)
         val sampler = ClcaCardSimulatedErrorRates(cards, contestUA.contest, assorter, errorRates)
         sampler.reset()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestClcaSimulationErrorRates.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestClcaSimulationErrorRates.kt
@@ -65,7 +65,7 @@ class TestClcaSimulationErrorRates {
     fun runClcaSimulation(cvrs: List<Cvr>, contestUA: ContestWithAssertions, assorter: ClcaAssorter) {
         println("\n${assorter.assorter.desc()}")
 
-        val phantomRate = contestUA.contest.phantomRate()
+        val phantomRate = contestUA.phantomRate()
         val errorRates = PluralityErrorRates(0.0, phantomRate, 0.0, 0.0)
         val sampler = ClcaSimulatedErrorRates(cvrs, contestUA.contest, assorter, errorRates)
         sampler.reset()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampler.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampler.kt
@@ -24,7 +24,7 @@ class TestConsistentSampler {
         val mvrManager = MvrManagerForTesting(testCvrs, testCvrs, Random.nextLong())
 
         val contestRounds = contestsUAs.map{ contest -> ContestRound(contest, 1) }
-        contestRounds.forEach { it.estSampleSize = it.Npop / 11 } // random
+        contestRounds.forEach { it.estMvrs = it.Npop / 11 } // random
 
         val prng = Prng(Random.nextLong())
         val cards = testCvrs.mapIndexed { idx, it -> AuditableCard.fromCvr( it, idx, prng.next()) }
@@ -47,14 +47,14 @@ class TestConsistentSampler {
         }
 
         contestRounds.forEach { contest ->
-            println(" ${contest.name} (${contest.id}) estSampleSize=${contest.estSampleSize}")
+            println(" ${contest.name} (${contest.id}) estSampleSize=${contest.estMvrs}")
         }
 
         // double check the number of cvrs == sampleSize, and the cvrs are marked as sampled
         println("contest.name (id) == sampleSize")
         contestRounds.forEach { contest ->
             val cvrs = cards.filter { it.hasContest(contest.id) }
-            assertTrue(contest.estSampleSize <= cvrs.size)
+            assertTrue(contest.estMvrs <= cvrs.size)
             // TODO what else can we check ??
         }
     }
@@ -64,7 +64,7 @@ class TestConsistentSampler {
         val test = MultiContestTestData(20, 11, 20000)
         val contestsUAs: List<ContestWithAssertions> = test.contests.map { ContestWithAssertions(it, isClca = false).addStandardAssertions() }
         val contestRounds = contestsUAs.map{ contest -> ContestRound(contest, 1) }
-        contestRounds.forEach { it.estSampleSize = it.Npop / 11 } // random
+        contestRounds.forEach { it.estMvrs = it.Npop / 11 } // random
 
         val cvrs = test.makeCvrsFromContests()
         val mvrManager = MvrManagerForTesting(cvrs, cvrs, Random.nextLong())
@@ -81,13 +81,13 @@ class TestConsistentSampler {
         }
 
         contestRounds.forEach { contest ->
-            println(" ${contest.name} (${contest.id}) estSampleSize=${contest.estSampleSize}")
+            println(" ${contest.name} (${contest.id}) estSampleSize=${contest.estMvrs}")
         }
         // double check the number of cvrs == sampleSize
         println("contest.name (id) == sampleSize")
         contestRounds.forEach { contest ->
             val ballotsForContest = mvrManager.mvrsUA.count { it.hasContest(contest.id) }
-            assertTrue(contest.estSampleSize <= ballotsForContest)
+            assertTrue(contest.estMvrs <= ballotsForContest)
         }
     }
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/corla/TestCorlaEstimateSampleSize.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/corla/TestCorlaEstimateSampleSize.kt
@@ -76,8 +76,8 @@ class TestCorlaEstimateSampleSize {
                 simSize
             }
             val estSize = if (estSizes.isEmpty()) 0 else estSizes.max()
-            contestRound.estSampleSize = if (sampleSizes.isEmpty()) 0 else sampleSizes.max()
-            println("${contestRound.name} estSize=$estSize  simSize=${contestRound.estSampleSize}\n")
+            contestRound.estMvrs = if (sampleSizes.isEmpty()) 0 else sampleSizes.max()
+            println("${contestRound.name} estSize=$estSize  simSize=${contestRound.estMvrs}\n")
         }
     }
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOneAuditAdaptiveBetting.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOneAuditAdaptiveBetting.kt
@@ -84,6 +84,8 @@ class TestOneAuditAdaptiveBetting {
             sampler.reset()
             val betFun = GeneralAdaptiveBetting(
                 contestUA.Npop,
+                startingErrors = ClcaErrorCounts.empty(oaCassorter.noerror(), oaCassorter.assorter.upperBound()),
+                nphantoms=contestUA.contest.Nphantoms(),
                 oaAssortRates = oaErrorRates,
                 d = 100,
                 maxRisk = 0.90,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditRoundJson.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditRoundJson.kt
@@ -40,8 +40,8 @@ class TestAuditRoundJson {
             //    var status = TestH0Status.InProgress
             cr.actualMvrs = 420
             cr.actualNewMvrs = 42
-            cr.estNewSamples = 66
-            cr.estSampleSize = 77
+            cr.estNewMvrs = 66
+            cr.estMvrs = 77
             // cr.estSampleSizeNoStyles = 88
             cr.auditorWantNewMvrs = 88
             cr.done = true
@@ -75,8 +75,8 @@ class TestAuditRoundJson {
             val cr = ContestRound(contest, 1)
             cr.actualMvrs = 420
             cr.actualNewMvrs = 42
-            cr.estNewSamples = 66
-            cr.estSampleSize = 77
+            cr.estNewMvrs = 66
+            cr.estMvrs = 77
             // cr.estSampleSizeNoStyles = 88
             cr.auditorWantNewMvrs = 88
             cr.done = true
@@ -315,8 +315,8 @@ fun check(c1: ContestRound, c2: ContestRound): Boolean {
     assertEquals(c1.id, c2.id)
     assertEquals(c1.roundIdx, c2.roundIdx)
     assertEquals(c1.actualNewMvrs, c2.actualNewMvrs)
-    assertEquals(c1.estNewSamples, c2.estNewSamples)
-    assertEquals(c1.estSampleSize, c2.estSampleSize)
+    assertEquals(c1.estNewMvrs, c2.estNewMvrs)
+    assertEquals(c1.estMvrs, c2.estMvrs)
     assertEquals(c1.auditorWantNewMvrs, c2.auditorWantNewMvrs)
     assertEquals(c1.done, c2.done)
     assertEquals(c1.included, c2.included)
@@ -346,8 +346,8 @@ fun check(c1: ContestRound, c2: ContestRound): Boolean {
 fun check(a1: AssertionRound, a2: AssertionRound): Boolean {
     assertEquals(a1.assertion.assorter.hashcodeDesc(), a2.assertion.assorter.hashcodeDesc())
     assertEquals(a1.roundIdx, a2.roundIdx)
-    assertEquals(a1.estSampleSize, a2.estSampleSize)
-    assertEquals(a1.estNewSampleSize, a2.estNewSampleSize)
+    assertEquals(a1.estMvrs, a2.estMvrs)
+    assertEquals(a1.estNewMvrs, a2.estNewMvrs)
     assertEquals(a1.estimationResult, a2.estimationResult)
     assertEquals(a1.status, a2.status)
     assertEquals(a1.roundProved, a2.roundProved)
@@ -383,7 +383,6 @@ fun check(a1: AuditRoundResult, a2: AuditRoundResult): Boolean {
     assertEquals(a1.pvalue, a2.pvalue)
     assertEquals(a1.samplesUsed, a2.samplesUsed)
     assertEquals(a1.status, a2.status)
-    assertEquals(a1.startingRates, a2.startingRates)
     assertEquals(a1.measuredCounts, a2.measuredCounts)
     assertEquals(a1.params, a2.params)
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestRaireContest.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestRaireContest.kt
@@ -32,9 +32,6 @@ class TestRaireContest {
         assertEquals( "RaireContest(info='testContestInfo' (0) candidates=[0, 1, 2, 3, 4, 42] choiceFunction=IRV nwinners=1 voteForN=1, winners=[1], Nc=211, Ncast=210, undervotes=1)",
             contest.toString()
         )
-
-        // assertEquals(-1, contest.undervotes) // TODO
-        assertEquals(1/211.toDouble(), contest.phantomRate())
     }
 
     @Test

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/TestConsistentSamplerFromShangrla.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/TestConsistentSamplerFromShangrla.kt
@@ -47,8 +47,8 @@ class TestConsistentSamplerFromShangrla {
             makeContestUAfromCvrs( it, cvrs)
         }
         val contestRounds = contestsUA.map{ contest -> ContestRound(contest, 1) }
-        contestRounds[0].estSampleSize = 3
-        contestRounds[1].estSampleSize = 4
+        contestRounds[0].estMvrs = 3
+        contestRounds[1].estMvrs = 4
 
         val auditRound = AuditRound(1, contestRounds, samplePrns = emptyList())
 
@@ -89,9 +89,9 @@ class TestConsistentSamplerFromShangrla {
         val contests = makeContestsFromCvrs(cvrs)
         val contestsUA = contests.mapIndexed { idx, it -> ContestWithAssertions( it).addStandardAssertions() }
         val contestRounds = contestsUA.map{ contest -> ContestRound(contest, 1) }
-        contestRounds[0].estSampleSize = 3
-        contestRounds[1].estSampleSize = 3
-        contestRounds[2].estSampleSize = 2
+        contestRounds[0].estMvrs = 3
+        contestRounds[1].estMvrs = 3
+        contestRounds[2].estMvrs = 2
 
         // val ncvrs = makeNcvrsPerContest(contests, cvrs)
         val phantomCVRs = makePhantomCvrs(contests)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistentConsistentSampling.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistentConsistentSampling.kt
@@ -2,7 +2,6 @@ package org.cryptobiotic.rlauxe.workflow
 
 import org.cryptobiotic.rlauxe.audit.previousSamples
 import org.cryptobiotic.rlauxe.estimate.consistentSampling
-import kotlin.test.Test
 
 class TestPersistentConsistentSampling {
 

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/ContestAuditTaskGeneratorClca.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/ContestAuditTaskGeneratorClca.kt
@@ -159,7 +159,7 @@ class ClcaSingleRoundWorkflowTask(
                 if (lastRound.status != TestH0Status.StatRejectNull) 100.0 else 0.0,
                 mvrMargin=mvrMargin,
 
-                startingRates=lastRound.startingRates,
+                startingRates=null,
                 measuredCounts=lastRound.measuredCounts,
             )
         }
@@ -177,7 +177,7 @@ fun runClcaSingleRoundAudit(workflow: AuditWorkflow, contestRounds: List<Contest
     var maxSamples = 0
     contestRounds.forEach { contest->
         contest.assertionRounds.forEach { assertion ->
-            maxSamples = max( maxSamples, assertion.estSampleSize)
+            maxSamples = max( maxSamples, assertion.estMvrs)
         }
     }
     return maxSamples

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/ContestAuditTaskGeneratorPolling.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/ContestAuditTaskGeneratorPolling.kt
@@ -93,7 +93,7 @@ class PollingSingleRoundAuditTask(
         var maxSamples = 0
         contestRounds.forEach { contest->
             contest.assertionRounds.forEach { assertion ->
-                maxSamples = max( maxSamples, assertion.estSampleSize)
+                maxSamples = max( maxSamples, assertion.estMvrs)
             }
         }
         val nmvrs = maxSamples

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/betting/BettingPayoffOld.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/betting/BettingPayoffOld.kt
@@ -22,7 +22,9 @@ class BettingPayoffOld {
                 // ClcaErrorCounts(val errorCounts: Map<Double, Int>, val totalSamples: Int, val noerror: Double, val upper: Double): ClcaErrorRatesIF {
                 //val errorCounts = ClcaErrorCounts(emptyMap(), 0, noerror, 1.0)
                 //val optimal = GeneralAdaptiveBettingOld(N = N, errorCounts, d = 100)
-                val betFn = GeneralAdaptiveBetting(N, oaAssortRates = null, d = 100, maxRisk = .99)
+                val betFn = GeneralAdaptiveBetting(N,
+                    startingErrors = ClcaErrorCounts.empty(noerror, 1.0),
+                    nphantoms=0, oaAssortRates = null, d = 100, maxRisk = .99)
                 val samples = ClcaErrorTracker(noerror, 1.0)
                 repeat(100) { samples.addSample(noerror) }
                 println(" margin=$margin, noerror=$noerror bet = ${betFn.bet(samples)}")
@@ -55,6 +57,8 @@ class BettingPayoffOld {
                 //) : BettingFn {
                 val bettingFn = GeneralAdaptiveBetting(
                     Npop = N,
+                    startingErrors = ClcaErrorCounts.empty(noerror, 1.0),
+                    nphantoms=0,
                     oaAssortRates = null,
                     d = 0,
                     maxRisk = .90,

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/betting/PlotBettingPayoff.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/betting/PlotBettingPayoff.kt
@@ -4,6 +4,7 @@ import org.cryptobiotic.rlauxe.testdataDir
 import org.cryptobiotic.rlauxe.persist.validateOutputDir
 import org.cryptobiotic.rlauxe.rlaplots.genericPlotter
 import org.cryptobiotic.rlauxe.util.df
+import org.cryptobiotic.rlauxe.util.dfn
 
 import org.junit.jupiter.api.Test
 import kotlin.io.path.Path
@@ -29,14 +30,14 @@ class PlotBettingPayoff {
         // data class PluralityErrorRates(val p2o: Double, val p1o: Double, val p1u: Double, val p2u: Double) {
         val taus = mapOf("p2o" to 0.0, "p1o" to 0.5, "p1u" to 1.5, "p2u" to 2.0)
         val margin = .01
-        val noerror = 1 / (2 - margin)
+        val noerror = 1 / (2 - margin) // upper = 1.0
 
         val p = .001
-        val p0 = 1.0 - taus.size * p
+        val p0 = 1.0 - taus.size * p // each error type is .001
 
         val results = mutableListOf<BettingPayoff>()
             repeat(nsteps) { step ->
-                val lamda = (step + 1) * 1.9 / nsteps
+                val lamda = (step + 1) * 1.9 / nsteps   // 1.9 is the arbitrary upper limit for plotting lamda
 
                 val t0 = ln(1.0 + lamda * (noerror - 0.5)) * p0
                 results.add(BettingPayoff("noerror", lamda, t0))
@@ -59,7 +60,7 @@ class PlotBettingPayoff {
 
         genericPlotter(
             "BettingPayoff",
-            "margin=$margin noerror=${df(noerror)} errRate=${df(p2)}",
+            "margin=$margin noerror=${df(noerror)} errRate=${dfn(p2, 3)}",
             "$dirName/$filename",
             data,
             "lamda", "ln(payoff)*rate", "cat",

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/betting/PlotWithAssortValues.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/betting/PlotWithAssortValues.kt
@@ -1,13 +1,11 @@
 package org.cryptobiotic.rlauxe.betting
 
 import org.cryptobiotic.rlauxe.testdataDir
-import org.cryptobiotic.rlauxe.audit.*
 import org.cryptobiotic.rlauxe.estimate.ConcurrentTaskG
 import org.cryptobiotic.rlauxe.concur.RepeatedWorkflowRunner
 import org.cryptobiotic.rlauxe.persist.validateOutputDir
 import org.cryptobiotic.rlauxe.rlaplots.*
 import org.cryptobiotic.rlauxe.util.Stopwatch
-import org.cryptobiotic.rlauxe.workflow.ClcaSingleRoundAuditTaskGenerator
 import org.cryptobiotic.rlauxe.workflow.WorkflowResult
 import org.cryptobiotic.rlauxe.workflow.runRepeatedWorkflowsAndAverage
 import org.cryptobiotic.rlauxe.workflow.sampleSizesVsFuzzPctStdDev
@@ -77,7 +75,7 @@ class PlotWithAssortValues {
         rates.forEach { rate ->
             maxRisk.forEach { maxRisk ->
                 val clcaGenerator = ClcaSingleRoundAssortTaskGenerator(
-                    N, margin, upper = 1.0, maxRisk = maxRisk, rate=rate,
+                    N, margin, upper = 1.0, maxRisk = maxRisk, errorRates=rate,
                     parameters = mapOf("margin" to margin, "fuzzPct" to rate, "cat" to maxRisk)
                 )
                 tasks.add(RepeatedWorkflowRunner(nruns, clcaGenerator))

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaAudit.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaAudit.kt
@@ -119,7 +119,7 @@ class CorlaAudit(
 class AuditCorlaAssertion(val quiet: Boolean = true): ClcaAssertionAuditorIF {
 
     override fun run(
-        auditConfig: AuditConfig,
+        config: AuditConfig,
         contestRound: ContestRound,
         assertionRound: AssertionRound,
         sampling: Sampler,
@@ -134,7 +134,7 @@ class AuditCorlaAssertion(val quiet: Boolean = true): ClcaAssertionAuditorIF {
         //    val p1: Double, val p2: Double, val p3: Double, val p4: Double): RiskTestingFn
         val testFn = Corla(
             N = contestUA.Npop,
-            riskLimit = auditConfig.riskLimit,
+            riskLimit = config.riskLimit,
             reportedMargin = cassertion.assorter.dilutedMargin(),
             noerror = cassorter.noerror(),
             p1 = 0.0, p2 = 0.0, p3 = 0.0, p4 = 0.0, // TODO

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestClcaEstimationFailure.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/unittest/TestClcaEstimationFailure.kt
@@ -46,9 +46,9 @@ class TestClcaEstimationFailure {
     val debug = false
     fun runClcaSimulation(cvrs: List<Cvr>, contestUA: ContestWithAssertions, cassorter: ClcaAssorter) {
         val contest = contestUA.contest as Contest
-        if (debug) println("\n$contest phantomRate=${contest.phantomRate()}")
+        if (debug) println("\n$contest phantomRate=${contestUA.phantomRate()}")
 
-        val phantomRate = contest.phantomRate()
+        val phantomRate = contestUA.phantomRate()
         val errorRates = PluralityErrorRates(0.0, phantomRate, 0.0, 0.0)
         val sampler = ClcaSimulatedErrorRates(cvrs, contestUA.contest, cassorter, errorRates)
         // if (debug) print(sampler.showFlips())
@@ -60,7 +60,7 @@ class TestClcaEstimationFailure {
 
         val assorter = cassorter.assorter
         val contestMargin = contest.reportedMargin(assorter.winner(), assorter.loser())
-        val adjustedMargin = contestMargin - contest.phantomRate()
+        val adjustedMargin = contestMargin - contestUA.phantomRate()
 
         val noerror = 1.0 / (2.0 - adjustedMargin)
         val expectedMargin = mean2margin(noerror)

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SfAuditVarianceScatter.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SfAuditVarianceScatter.kt
@@ -64,7 +64,7 @@ class SfAuditVarianceScatter {
             yname = "estimated samples",
             catName = "type",
             xfld = { it.margin },
-            yfld = { it.assertion.estSampleSize.toDouble() },
+            yfld = { it.assertion.estMvrs.toDouble() },
             catfld = { it.cat },
             scaleType=scaleType,
         )


### PR DESCRIPTION
GeneralAdaptiveBetting integrates phantomRate into starting errors. 
GeneralAdaptiveBetting always pass in startingErrors, counts are zero for audits.
move phantomRate() to CountestWithAssertions

ContestRound.estSampleSize -> estMvrs, estNewSamples -> estNewMvrs 
EstimationRoundResult.startingRates -> startingErrorRates 
AuditRoundResult.startingRates removed
ClcaErrorCounts.isPhantom(), empty()

ClcaAssorter.sampleSizeNoErrors()

mvrFuzzPct() uses clca.fuzz, not simFuzz
clca.d default is 1 (no trunc slide in)