### PR TITLE
Estimation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **rlauxe ("r-lux")**
 
 WORK IN PROGRESS
-_last changed: 01/08/2025_
+_last changed: 01/18/2026_
 
 A library for [Risk Limiting Audits](https://en.wikipedia.org/wiki/Risk-limiting_audit) (RLA), based on Philip Stark's SHANGRLA framework and related code.
 The Rlauxe library is an independent implementation of the SHANGRLA framework, based on the
@@ -55,7 +55,7 @@ Click on plot images to get an interactive html plot. You can also read this doc
     * [OneAudit Card Style Data](#oneaudit-card-style-data)
     * [Multicontest audits](#multicontest-audits)
   * [Unanswered Questions](#unanswered-questions)
-    * [Use has_style for polling](#use-has_style-for-polling)
+    * [Contest is missing in the MVR](#contest-is-missing-in-the-mvr)
   * [Also See:](#also-see)
 <!-- TOC -->
 
@@ -84,7 +84,8 @@ in a risk-limiting audit with risk limit α:
 | bettingFn | decides how much to bet for each sample. (BettingMart)                                       |
 | riskFn    | the statistical method to test if the assertion is true.                                     |
 | Nc        | a trusted, independent bound on the number of valid cards cast in the contest c.             |
-| Ncast     | the number of ballot cards validly cast in the contest                                       |
+| Ncast     | the number of cards validly cast in the contest                                              |
+| Npop      | the number of cards that might contain the contest                                           |
 
 
 # Audit Workflow Overview
@@ -146,6 +147,7 @@ Each round generates samplePrns.json, sampleCards.csv, sampleMvrs.csv, and audit
 ## Verification
 
 Independently written verifiers can read the Audit Record and verify that the audit was correctly performed.
+See [Verification](docs/Verification.md).
 
 # Audit Types
 
@@ -297,14 +299,22 @@ Varying phantom percent, up to and over the margin of 4.5%, with errors generate
 
 Once we have all of the contests' estimated sample sizes, we next choose which ballots/cards to sample.
 This step depends on the CardManifest and Population information, which tells which cards
-have which contests. When you know exactly what contests are on each card, the contest margin is at a maximum, and the samplesNeeded
-are at a minimum. If you dont know exactly what contests are on each card, the cards may be divided up into populations in a
+may have which contests. The number of cards that may have a contest on it is called the population size (Npop)
+and is used as the denominator of the _diluted margin_ for the contest. The sampling must be uniform over the 
+contests' population for a statistically valid audit.
+
+The Population objects are a generalization of SHANGRLA's Card Style Data, allowing for partial information about which cards
+have which contests.
+
+When you know exactly what contests are on each card, the diluted margin is at a maximum, and the samples needed
+is at a minimum. If you dont know exactly what contests are on each card, the cards may be divided up into populations in a
 way that minimizes the number of cards that might have the contest.
 See [SamplePopulations](docs/SamplePopulations.md) for more explanation and current thinking.
 
-For CLCA audits, the generated Cast Vote Records (CVRs) comprise the Card Style Data, as long as the CVR records the undervotes
-(contests where no vote was cast). For Polling audits and OneAudit pools, the Populations describe 
-which contests are on which cards.
+For CLCA audits, the generated Cast Vote Records (CVRs) tell you exactly which cards have which
+contests, as long as the CVR records the undervotes (contests where no vote was cast). 
+For Polling audits and OneAudit pools (and the case where _cvrsContainUndervotes_ = false), 
+the Populations describe which contests are on which cards.
 
 
 # Estimating Sample Batch sizes

--- a/cases/src/test/kotlin/org/cryptobiotic/util/TestRunCli.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/util/TestRunCli.kt
@@ -8,10 +8,8 @@ import org.cryptobiotic.rlauxe.cli.RunRlaStartFuzz
 import org.cryptobiotic.rlauxe.cli.RunVerifyAuditRecord
 import org.cryptobiotic.rlauxe.cli.RunVerifyContests
 import org.cryptobiotic.rlauxe.audit.runRound
-import org.cryptobiotic.rlauxe.audit.writeMvrsForRound
 import org.cryptobiotic.rlauxe.persist.Publisher
 import org.cryptobiotic.rlauxe.persist.json.readAuditConfigJsonFile
-import org.cryptobiotic.rlauxe.workflow.PersistedWorkflowMode
 import kotlin.test.Test
 import kotlin.test.fail
 
@@ -34,7 +32,6 @@ class TestRunCli {
         val publisher = Publisher(auditdir)
         val config = readAuditConfigJsonFile(publisher.auditConfigFile()).unwrap()
         writeSortedCardsInternalSort(publisher, config.seed)
-        val writeMvrs = config.persistedWorkflowMode == PersistedWorkflowMode.testPrivateMvrs
 
         println("============================================================")
         RunVerifyContests.main(arrayOf("-in", auditdir))
@@ -44,7 +41,6 @@ class TestRunCli {
         while (!done) {
             val lastRound = runRound(inputDir = auditdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
-            if (!done && writeMvrs) writeMvrsForRound(publisher, lastRound!!.roundIdx)
         }
 
         println("============================================================")
@@ -71,13 +67,11 @@ class TestRunCli {
         val publisher = Publisher(auditdir)
         val config = readAuditConfigJsonFile(publisher.auditConfigFile()).unwrap()
         writeSortedCardsInternalSort(publisher, config.seed)
-        val writeMvrs = config.persistedWorkflowMode == PersistedWorkflowMode.testPrivateMvrs
 
         var done = false
         while (!done) {
             val lastRound = runRound(inputDir = auditdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 7
-            if (!done && writeMvrs) writeMvrsForRound(publisher, lastRound!!.roundIdx) // cabt use test for polling because cards dont have the votes
         }
 
         println("============================================================")
@@ -112,7 +106,6 @@ class TestRunCli {
         val publisher = Publisher(auditdir)
         val config = readAuditConfigJsonFile(publisher.auditConfigFile()).unwrap()
         writeSortedCardsInternalSort(publisher, config.seed)
-        val writeMvrs = config.persistedWorkflowMode == PersistedWorkflowMode.testPrivateMvrs
 
         println("============================================================")
         RunVerifyContests.main(arrayOf("-in", auditdir))
@@ -122,7 +115,6 @@ class TestRunCli {
         while (!done) {
             val lastRound = runRound(inputDir = auditdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
-            if (!done && writeMvrs) writeMvrsForRound(publisher, lastRound!!.roundIdx) // TODO add this to runRound; dont need when useTest = true?
         }
 
         println("============================================================")
@@ -154,7 +146,6 @@ class TestRunCli {
         )
         val publisher = Publisher(auditdir)
         val config = readAuditConfigJsonFile(publisher.auditConfigFile()).unwrap()
-        val writeMvrs = config.persistedWorkflowMode == PersistedWorkflowMode.testPrivateMvrs
 
         println("============================================================")
         val resultsvc = RunVerifyContests.runVerifyContests(auditdir, null, false)
@@ -167,7 +158,6 @@ class TestRunCli {
         while (!done) {
             val lastRound = runRound(inputDir = auditdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
-            if (!done && writeMvrs) writeMvrsForRound(publisher, lastRound!!.roundIdx) // RunRlaCreateOneAudit writes the mvrs
         }
 
         println("============================================================")

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRound.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRound.kt
@@ -48,7 +48,7 @@ data class AuditRound(
     //// called from viewer
     override fun mvrsUsed(): Int {
         var result = 0
-        contestRounds.forEach { contest ->
+        contestRounds.filter{ it.included }.forEach { contest ->
             contest.assertionRounds.forEach { assertion ->
                 result = max(result, assertion.auditResult?.maxBallotIndexUsed ?: 0)
             }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCard.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCard.kt
@@ -153,7 +153,7 @@ class CvrsWithPopulationsToCardManifest(
         val org = allCvrs.next()
         val pop = if (popMap == null) null else popMap[org.poolId] // hijack poolId
         val hasCvr = type.isClca() || (type.isOA() && org.poolId == null)
-        val votes = if (hasCvr) org.votes else null
+        val votes = if (hasCvr) org.votes else null  // removes votes for pooled data
 
         // if you havent specified a population or votes, then the population = all contests
         val cardStyle = if (votes == null && pop == null) "all" else pop?.name()

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CreateAudit.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CreateAudit.kt
@@ -125,7 +125,7 @@ fun writeExternalSortedCards(topdir: String, outputFile: String, unsortedCards: 
 }
 
 // uses private/sortedMvrs.cvs
-fun writeMvrsForRound(publisher: Publisher, round: Int) {
+fun writeMvrsForRound(publisher: Publisher, round: Int): Int {
     val resultSamples = readSamplePrnsJsonFile(publisher.samplePrnsFile(round))
     if (resultSamples is Err) logger.error{"$resultSamples"}
     require(resultSamples is Ok)
@@ -140,8 +140,7 @@ fun writeMvrsForRound(publisher: Publisher, round: Int) {
         require(mvr.prn == sampleNumbers[index])
     }
 
-    val countCards = writeAuditableCardCsvFile(Closer(sampledMvrs.iterator()), publisher.sampleMvrsFile(round))
-    logger.info{"writeMvrsForRound ${countCards} cards to ${publisher.sampleMvrsFile(round)}"}
+    return writeAuditableCardCsvFile(Closer(sampledMvrs.iterator()), publisher.sampleMvrsFile(round))
 }
 
 fun writePrivateMvrs(publisher: Publisher, sortedMvrs: List<AuditableCard>) {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/betting/BettingMart.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/betting/BettingMart.kt
@@ -28,7 +28,7 @@ class BettingMart(
     // run until sampleNumber == maxSample (batch mode) or terminateOnNullReject (ballot at a time)
     override fun testH0(maxSamples: Int,
                         terminateOnNullReject: Boolean,
-                        startingTestStatistic: Double,
+                        startingTestStatistic: Double,  // T, must grow to 1/riskLimit
                         drawSample : () -> Double) : TestH0Result {
 
         var sampleNumber = 0        // – j ← 0: sample number

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/betting/RiskMeasuringFn.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/betting/RiskMeasuringFn.kt
@@ -23,7 +23,7 @@ interface RiskMeasuringFn {
     fun testH0(
         maxSamples: Int,
         terminateOnNullReject: Boolean,
-        startingTestStatistic: Double = 1.0,
+        startingTestStatistic: Double = 1.0, // T, must grow to 1/riskLimit
         drawSample: () -> Double,
     ): TestH0Result
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Assorter.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/Assorter.kt
@@ -29,7 +29,6 @@ interface AssorterIF {
     // usePhantoms=true for polling assort value
     fun assort(cvr: CvrIF, usePhantoms: Boolean = false) : Double
 
-    fun lowerBound() = 0.0  // makes life easier; do an affine tranform if needed to make this true
     fun upperBound(): Double
     fun desc(): String
     fun winner(): Int  // candidate id

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ClcaAssorter.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ClcaAssorter.kt
@@ -194,10 +194,10 @@ open class ClcaAssorter(
         // if hasU = hasStyle, we use the cvr as the pcontests, so how did this happen?
         if (hasStyle and !cvr.hasContest(info.id)) {
             val trace = Throwable().stackTraceToString()
-            logger.error { "hasStyle==True but cvr=${cvr} does not contain contest ${info.name} (${info.id})\n$trace" }
+            logger.error { "hasCompleteCvrs==True but cvr=${cvr} does not contain contest ${info.name} (${info.id})\n$trace" }
             // TODO core dump not a good option.
             //    if we were using hasStyle is assorter.assort(), it would return 0.0 for cvr_assort
-            // throw RuntimeException("hasStyle==True but cvr=${cvr} does not contain contest ${info.name} (${info.id})")
+            throw RuntimeException("hasCompleteCvrs==True but cvr=${cvr} does not contain contest ${info.name} (${info.id})")
         }
 
         // If use_style, then if the CVR contains the contest but the MVR does not, treat the MVR as having a vote for

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/RunRepeated.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/RunRepeated.kt
@@ -20,7 +20,7 @@ fun runRepeated(
     testFn: RiskMeasuringFn,
     testParameters: Map<String, Double>,
     terminateOnNullReject: Boolean = true,
-    startingTestStatistic: Double = 1.0,
+    startingTestStatistic: Double = 1.0, // T, must grow to 1/riskLimit
     tracker: SampleTracker,
     N:Int, // maximum cards in the contest (diluted)
 ): RunRepeatedResult {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/SamplingForEstimation.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/SamplingForEstimation.kt
@@ -8,7 +8,7 @@ import kotlin.random.Random
 
 private const val debug = false
 
-// for one contest, this takes a list of cards and fuzzes them for the mvrs.
+// for one contest, this takes a list of cards and fuzzes them to use as the mvrs.
 // Only used for estimateClcaAssertionRound, estimateOneAuditAssertionRound, not auditing.
 class ClcaCardFuzzSampler(
     val fuzzPct: Double,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditPool.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditPool.kt
@@ -40,7 +40,7 @@ interface OneAuditPoolIF: PopulationIF {
     val poolId: Int
     fun assortAvg(): MutableMap<Int, MutableMap<AssorterIF, AssortAvg>>  // contestId -> assorter -> average in the pool
     fun regVotes(): Map<Int, RegVotesIF> // contestId -> RegVotes, regular contests only, not IRV
-    fun votesAndUndervotes(contestId: Int, voteForN: Int): Vunder  // TODO candidate for removal
+    fun votesAndUndervotes(contestId: Int, voteForN: Int): Vunder
     // fun contestTab(contestId: Int): ContestTabulation? need this for IRV
 
     fun show() = buildString {
@@ -74,7 +74,7 @@ data class OneAuditPool(override val poolName: String, override val poolId: Int,
 
     // candidate for removal, assumes voteForN == 1, perhaps we need to save that ??
     override fun votesAndUndervotes(contestId: Int, voteForN: Int): Vunder {
-        val regVotes = regVotes[contestId]!!
+        val regVotes = regVotes[contestId]!!         // empty for IRV ...
         val poolUndervotes = ncards * voteForN - regVotes.votes.values.sum()
         return Vunder(regVotes.votes, poolUndervotes, voteForN)
     }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/Publisher.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/Publisher.kt
@@ -21,9 +21,9 @@ private val logger = KotlinLogging.logger("Publisher")
 
         roundX/
             auditStateX.json     // AuditRoundJson,  the state of the audit for this round
-            sampleCardsX.csv     // AuditableCardCsv, complete cards used for this round; matches samplePrnsX.csv
-            sampleMvrsX.csv      // AuditableCardCsv, complete mvrs used for this round; matches samplePrnsX.csv
-            samplePrnsX.json     // SamplePrnsJson, complete sample prns for this round, in order
+            sampleCardsX.csv     // AuditableCardCsv, complete cards used for this round; MvrManager called from runClcaAuditRound, runPollingAuditRound
+            sampleMvrsX.csv      // AuditableCardCsv, complete mvrs used for this round; PersistedWorkflow runAuditRound, startNewRound
+            samplePrnsX.json     // SamplePrnsJson, complete sample prns for this round, in order;
 
         private/
             sortedMvrs.csv       // AuditableCardCsv, sorted by prn, matches sortedCards.csv, may be zipped
@@ -78,7 +78,7 @@ class Publisher(val auditDir: String) {
 }
 
 /** Make sure output directories exists; delete existing files in them.  */
-fun clearDirectory(path: Path): Boolean {
+fun clearDirectory(path: Path) {
     if (!Files.exists(path)) {
         Files.createDirectories(path)
     } else {
@@ -87,7 +87,6 @@ fun clearDirectory(path: Path): Boolean {
             .map { obj: Path -> obj.toFile() }
             .forEach { obj: File -> obj.delete() }
     }
-    return true
 }
 
 /** Make sure output directories exist and are writeable.  */

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/MakeRaireContest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/MakeRaireContest.kt
@@ -23,9 +23,10 @@ import kotlin.collections.forEach
 private val quiet = true
 private val logger = KotlinLogging.logger("MakeRaireContest")
 
-// make RaireContestUnderAudit from ContestTabulation; get RaireAssertions from raire-java libray
+// make RaireContestWithAssertions from ContestTabulation; get RaireAssertions from raire-java libray
 // note ivrRoundsPaths are filled in
-fun makeRaireContestUA(info: ContestInfo, contestTab: ContestTabulation, Nc: Int, Nbin: Int): RaireContestWithAssertions {
+// used by CreateSfElection
+fun makeRaireContest(info: ContestInfo, contestTab: ContestTabulation, Nc: Int, Nbin: Int): RaireContestWithAssertions {
     // TODO consistency checks on voteConsolidator
     // all candidate indexes
     val vc = contestTab.irvVotes
@@ -111,7 +112,7 @@ fun makeRaireContestUA(info: ContestInfo, contestTab: ContestTabulation, Nc: Int
         info,
         winnerIndex = raireResult.winner,
         Nc = Nc,
-        Ncast = contestTab.ncards,
+        Ncast = Nc - contestTab.nphantoms,
         undervotes = contestTab.undervotes,
         raireAssertions,
         Nbin,
@@ -132,7 +133,7 @@ fun makeRaireContestUA(info: ContestInfo, contestTab: ContestTabulation, Nc: Int
 }
 
 // contestTab.irvVotes must include the pooled data, since we generate the RaireAssertions from them.
-fun makeRaireContestIrv(info: ContestInfo, contestTab: ContestTabulation, Nc: Int, Nbin: Int, oneAuditPools: List<OneAuditPoolFromCvrs>): RaireContestWithAssertions {
+fun makeRaireOneAuditContest(info: ContestInfo, contestTab: ContestTabulation, Nc: Int, Nbin: Int, oneAuditPools: List<OneAuditPoolFromCvrs>): RaireContestWithAssertions {
     val vc = contestTab.irvVotes
     val startingVotes = vc.makeVoteList()
     val votes = vc.makeVotes(info.candidateIds.size)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/SimulateIrvTestData.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/SimulateIrvTestData.kt
@@ -5,9 +5,7 @@ import org.cryptobiotic.rlauxe.util.df
 import kotlin.math.min
 import kotlin.random.Random
 
-// simulate cvrs for a RaireContest
-// TODO not called from estimateSampleSize.
-//     also see simulateRaireTestContest
+// simulate cvrs for a RaireContest, doesnt call raire-java for the assertions
 data class SimulateIrvTestData(
     val contest: RaireContest,
     val minMargin: Double,
@@ -22,6 +20,8 @@ data class SimulateIrvTestData(
         var count = 0
         val cvrs = mutableListOf<Cvr>()
 
+        // TODO just makes sure the winner is chosen first ncards * minMargin more than any other candidate.
+        //    kinda primitive; something better ??
         val excess = excessVotes ?: (ncards * minMargin).toInt()
         repeat(excess) {
             cvrs.add(makeCvrWithLeading0(count++))

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/VoteConsolidator.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/raire/VoteConsolidator.kt
@@ -19,7 +19,7 @@ import kotlin.collections.getOrPut
 class VoteConsolidator {
     private val votes = mutableMapOf<HashableIntArray, Int>() // candidate ranks -> nvotes
 
-    fun nvotes() = votes.size
+    fun nvotes() = votes.values.sum()
 
     fun addVote(pref: IntArray) {
         val key = HashableIntArray(pref)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Vunder.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Vunder.kt
@@ -65,7 +65,6 @@ class VunderPicker(val vunder: Vunder) {
     fun chooseCandidateAndDecrement(randomChoice: Int): Int {
         val check = vunderRemaining.sumOf { it.second }
         require(check == vunderLeft)
-        require(randomChoice in 0 until vunderLeft)
 
         var sum = 0
         var nvotesLeft = 0

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyContests.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyContests.kt
@@ -67,7 +67,7 @@ class VerifyContests(val auditRecordLocation: String, val show: Boolean = false)
         // all
         val infos = allInfos ?: contests.associate { it.id to it.contest.info() }
         checkContestsCorrectlyFormed(config, contests, results)
-        val contestSummary = verifyManifest(config, contests, cardManifest.cards, infos, results, show = show)
+        val contestSummary = verifyManifest(config, contests, cardManifest.cards, infos, results)
 
         // OA
         if (config.isOA) {
@@ -117,7 +117,6 @@ fun verifyManifest(
     cards: CloseableIterable<AuditableCard>,
     infos: Map<Int, ContestInfo>,
     results: VerifyResults,
-    show: Boolean = false
 ): ContestSummary {
     results.addMessage("VerifyManifest")
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedWorkflow.kt
@@ -1,20 +1,17 @@
 package org.cryptobiotic.rlauxe.workflow
 
-import com.github.michaelbull.result.Ok
-import com.github.michaelbull.result.unwrap
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.audit.*
 import org.cryptobiotic.rlauxe.betting.TestH0Status
 import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.persist.AuditRecord
-import org.cryptobiotic.rlauxe.persist.AuditRecord.Companion.readFromResult
 import org.cryptobiotic.rlauxe.persist.AuditRecordIF
 import org.cryptobiotic.rlauxe.persist.CompositeRecord
 import org.cryptobiotic.rlauxe.persist.Publisher
 import org.cryptobiotic.rlauxe.persist.json.writeAuditRoundJsonFile
 import org.cryptobiotic.rlauxe.persist.json.writeSamplePrnsJsonFile
 
-private val logger = KotlinLogging.logger("PersistentAudit")
+private val logger = KotlinLogging.logger("PersistedWorkflow")
 
 enum class PersistedWorkflowMode {
     real,           // use PersistedMvrManager;  sampleMvrs$round.csv must be written from external program.
@@ -73,10 +70,10 @@ class PersistedWorkflow(
             }
 
             writeAuditRoundJsonFile(nextRound, publisher.auditStateFile(nextRound.roundIdx))
-            logger.info {"   writeAuditStateJsonFile ${publisher.auditStateFile(nextRound.roundIdx)}"}
+            logger.info {"startNewRound writeAuditState ${publisher.auditStateFile(nextRound.roundIdx)}"}
 
             writeSamplePrnsJsonFile(nextRound.samplePrns, publisher.samplePrnsFile(nextRound.roundIdx))
-            logger.info {"   writeSampleIndicesJsonFile ${publisher.samplePrnsFile(nextRound.roundIdx)}"}
+            logger.info {"startNewRound writeSamplePrns ${publisher.samplePrnsFile(nextRound.roundIdx)}"}
         }
 
         return nextRound
@@ -103,13 +100,13 @@ class PersistedWorkflow(
         auditRound.auditIsComplete = complete
 
         writeAuditRoundJsonFile(auditRound, publisher.auditStateFile(roundIdx)) // replace auditState
-        logger.info {"writeAuditRoundJsonFile to '${publisher.auditStateFile(roundIdx)}'"}
+        logger.info {"runAuditRound writeAuditState to '${publisher.auditStateFile(roundIdx)}'"}
 
         return complete
     }
 
     override fun toString(): String {
-        return "PersistentWorkflow(auditDir='$auditDir', mode=$mode, mvrManager=$mvrManager)"
+        return "PersistentWorkflow(auditDir='$auditDir', mode=$mode, mvrManager=${mvrManager.javaClass.simpleName})"
     }
 
     companion object {

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunCliInTemp.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunCliInTemp.kt
@@ -3,10 +3,8 @@ package org.cryptobiotic.rlauxe.cli
 import com.github.michaelbull.result.unwrap
 import org.cryptobiotic.rlauxe.audit.writeSortedCardsInternalSort
 import org.cryptobiotic.rlauxe.audit.runRound
-import org.cryptobiotic.rlauxe.audit.writeMvrsForRound
 import org.cryptobiotic.rlauxe.persist.Publisher
 import org.cryptobiotic.rlauxe.persist.json.readAuditConfigJsonFile
-import org.cryptobiotic.rlauxe.workflow.PersistedWorkflowMode
 import kotlin.io.path.ExperimentalPathApi
 import kotlin.io.path.createTempDirectory
 import kotlin.io.path.deleteRecursively
@@ -35,7 +33,6 @@ class TestRunCliInTemp {
         val publisher = Publisher(auditdir)
         val config = readAuditConfigJsonFile(publisher.auditConfigFile()).unwrap()
         writeSortedCardsInternalSort(publisher, config.seed)
-        val writeMvrs = config.persistedWorkflowMode == PersistedWorkflowMode.testPrivateMvrs
 
         println("============================================================")
         RunVerifyContests.main(arrayOf("-in", auditdir))
@@ -51,7 +48,6 @@ class TestRunCliInTemp {
         while (!done) {
             val lastRound = runRound(inputDir = auditdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
-            if (!done && writeMvrs) writeMvrsForRound(publisher, lastRound!!.roundIdx) // cant use test for polling because cards dont have the votes
         }
 
         println("============================================================")
@@ -83,13 +79,11 @@ class TestRunCliInTemp {
         val publisher = Publisher(auditdir)
         val config = readAuditConfigJsonFile(publisher.auditConfigFile()).unwrap()
         writeSortedCardsInternalSort(publisher, config.seed)
-        val writeMvrs = config.persistedWorkflowMode == PersistedWorkflowMode.testPrivateMvrs
 
         var done = false
         while (!done) {
             val lastRound = runRound(inputDir = auditdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 7
-            if (!done && writeMvrs) writeMvrsForRound(publisher, lastRound!!.roundIdx) // cant use test for polling because cards dont have the votes
         }
 
         println("============================================================")
@@ -126,7 +120,6 @@ class TestRunCliInTemp {
         val publisher = Publisher(auditdir)
         val config = readAuditConfigJsonFile(publisher.auditConfigFile()).unwrap()
         writeSortedCardsInternalSort(publisher, config.seed)
-        val writeMvrs = config.persistedWorkflowMode == PersistedWorkflowMode.testPrivateMvrs
 
         println("============================================================")
         val results = RunVerifyContests.runVerifyContests(auditdir, null, false)
@@ -136,7 +129,6 @@ class TestRunCliInTemp {
         while (!done) {
             val lastRound = runRound(inputDir = auditdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
-            if (!done && writeMvrs) writeMvrsForRound(publisher, lastRound!!.roundIdx) // cant use test for polling because cards dont have the votes
         }
 
         println("============================================================")
@@ -164,7 +156,6 @@ class TestRunCliInTemp {
         val publisher = Publisher(auditdir)
         val config = readAuditConfigJsonFile(publisher.auditConfigFile()).unwrap()
         writeSortedCardsInternalSort(publisher, config.seed)
-        val writeMvrs = config.persistedWorkflowMode == PersistedWorkflowMode.testPrivateMvrs
 
         println("============================================================")
         val resultsvc = RunVerifyContests.runVerifyContests(auditdir, null, false)
@@ -176,7 +167,6 @@ class TestRunCliInTemp {
         while (!done) {
             val lastRound = runRound(inputDir = auditdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
-            if (!done && writeMvrs) writeMvrsForRound(publisher, lastRound!!.roundIdx) // cant use test for polling because cards dont have the votes
         }
 
         println("============================================================")

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRoundCli.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRoundCli.kt
@@ -8,7 +8,7 @@ class TestRunRoundCli {
 
     @Test
     fun testRunRoundCli() {
-        val topdir = "$testdataDir/cases/boulder24/clca"
+        val topdir = "$testdataDir/cases/sf2024/oa"
         val auditdir = "$topdir/audit"
 
         RunRlaRoundCli.main(

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestThresholdAssorters.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestThresholdAssorters.kt
@@ -189,7 +189,7 @@ class TestThresholdAssorters {
         ) // bi has a mark for exactly one candidate and not Alice
         assertEquals(massorter.upperBound(), massorter.assort(makeCvr(1))) // // bi has a mark for Alice and no one else
         assertEquals(
-            massorter.lowerBound(),
+            0.0,
             massorter.assort(makeCvr(2))
         ) // // bi has a mark for exactly one candidate and not Alice
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestSimulateIrvTestData.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/raire/TestSimulateIrvTestData.kt
@@ -1,0 +1,89 @@
+package org.cryptobiotic.rlauxe.raire
+
+import org.cryptobiotic.rlauxe.core.ContestInfo
+import org.cryptobiotic.rlauxe.core.Cvr
+import org.cryptobiotic.rlauxe.core.SocialChoiceFunction
+import org.cryptobiotic.rlauxe.util.mean2margin
+import org.cryptobiotic.rlauxe.util.tabulateCvrs
+import kotlin.random.Random
+import kotlin.test.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertEquals
+
+class TestSimulateIrvTestData {
+    val N = 50000
+    val marginRange = 0.01..0.50
+    val undervotePct = 0.0
+    val Np = 10
+
+    val target: RaireContestWithAssertions
+    val targetContest: RaireContest
+    val cvrs: List<Cvr>
+    val infos: Map<Int, ContestInfo>
+
+    init {
+        val minMargin = marginRange.start + Random.nextDouble(marginRange.endInclusive - marginRange.start)
+
+        val info = ContestInfo(
+            "testContestInfo",
+            0,
+            mapOf("cand0" to 0, "cand1" to 1, "cand2" to 2, "cand3" to 3, "cand4" to 4, "cand42" to 42),
+            SocialChoiceFunction.IRV
+        )
+        // data class RaireContest(
+        //    val info: ContestInfo,
+        //    val winners: List<Int>, // actually only one winner is allowed
+        //    val Nc: Int,
+        //    val Ncast: Int,
+        //    val undervotes: Int,
+        //)
+        //)
+        val raireContest = RaireContest(info, winners=listOf(42), N, N-Np, (undervotePct * N).toInt())
+
+        // data class SimulateIrvTestData(
+        //    val contest: RaireContest,
+        //    val minMargin: Double,
+        //    val sampleLimits: Int?,
+        //    val excessVotes: Int? = null,
+        //    val quiet: Boolean = true
+        //)
+        val sim = SimulateIrvTestData(raireContest, minMargin, sampleLimits=null, quiet=false )
+        assertEquals("SimulateIrvTestData(0} phantoms=$Np ncards=$N", sim.toString())
+
+        cvrs = sim.makeCvrs()
+        infos = mapOf(raireContest.id to raireContest.info())
+        val tabs = tabulateCvrs(cvrs.iterator(), infos)
+        val contestTab = tabs[raireContest.id]
+        assertNotNull(contestTab)
+
+        //println(contestTab.irvVotes)
+        println("nvotes = ${contestTab.irvVotes.nvotes()}")
+        val nvotes = contestTab.irvVotes.nvotes()
+        target = makeRaireContest(info, contestTab, N, N)
+        targetContest = target.contest as RaireContest
+    }
+
+    @Test
+    fun testBasics() {
+        assertEquals(N, target.Nc)
+        assertEquals(N, cvrs.size)
+
+        assertEquals(Np, target.Nphantoms)
+        val np = cvrs.count { it.phantom }
+        assertEquals(Np, np)
+
+        target.rassertions.forEach { println("  $it marginPct=${it.marginInVotes / N.toDouble()}") }
+
+        val minAssertion = target.minClcaAssertion()!!
+        println(minAssertion)
+        val cassorter = minAssertion.cassorter
+        println("cassorter dilutedMargin = ${cassorter.dilutedMargin}")
+
+        val rassorter = minAssertion.assorter as RaireAssorter
+        println("rassorter dilutedMargin = ${mean2margin(rassorter.dilutedMean)}")
+
+        val cvrTab = tabulateCvrs(cvrs.iterator(), infos).values.first()
+        val irvVotes = cvrTab.irvVotes.makeVotes(target.ncandidates)
+        println("rassorter calcMargin = ${rassorter.calcMargin(irvVotes, N)}")
+    }
+}

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCardBuilders.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCardBuilders.kt
@@ -29,9 +29,6 @@ class TestCardBuilders {
         // same order
         roundtrip.forEach{
             val orgCard = cardMap[it.location]!!
-            if (orgCard != it) {
-                orgCard.equals(it)
-            }
             assertEquals(orgCard, it)
         }
     }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistedWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistedWorkflow.kt
@@ -144,7 +144,6 @@ fun runPersistedAudit(topdir: String, test:Boolean) {
     val publisher = Publisher(auditdir)
     val config = readAuditConfigJsonFile(publisher.auditConfigFile()).unwrap()
     writeSortedCardsExternalSort(topdir, publisher, config.seed)
-    val writeMvrs = config.persistedWorkflowMode == PersistedWorkflowMode.testPrivateMvrs
 
     val verifyResults = RunVerifyContests.runVerifyContests(auditdir, null, show = true)
     println()
@@ -167,7 +166,6 @@ fun runPersistedAudit(topdir: String, test:Boolean) {
         } */
 
         done = lastRound.auditIsComplete || lastRound.roundIdx > 5
-        if (!done && writeMvrs) writeMvrsForRound(publisher, lastRound!!.roundIdx) // RunRlaCreateOneAudit writes the mvrs
     }
 
     if (lastRound != null) {

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaCreateOneAudit.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaCreateOneAudit.kt
@@ -92,7 +92,7 @@ object RunRlaCreateOneAudit {
     fun startTestElectionOneAudit(
         topdir: String,
         minMargin: Double,
-        fuzzMvrs: Double,
+        fuzzPct: Double,
         cvrFraction: Double,
         ncards: Int,
         extraPct: Double,
@@ -101,7 +101,7 @@ object RunRlaCreateOneAudit {
         clearDirectory(Path(auditDir))
 
         val config = AuditConfig(
-            AuditType.ONEAUDIT, contestSampleCutoff = 20000, nsimEst = 10, simFuzzPct = fuzzMvrs,
+            AuditType.ONEAUDIT, contestSampleCutoff = 20000, nsimEst = 10, simFuzzPct = fuzzPct,
             persistedWorkflowMode = PersistedWorkflowMode.testPrivateMvrs,
             oaConfig = OneAuditConfig(OneAuditStrategyType.clca)
         )
@@ -130,10 +130,11 @@ object RunRlaCreateOneAudit {
         val sortedCards = mutableListOf<AuditableCard>()
         scardIter.forEach { sortedCards.add(it) }
 
-        // TODO test OneAuditVunderBarFuzzer
-        val vunderFuzz = OneAuditVunderFuzzer(cardManifest.populations as List<OneAuditPoolIF>, infos, fuzzMvrs, sortedCards)
+        // OneAuditVunderFuzzer creates fuzzed mvrs (non-pooled) and simulated mvrs (pooled)
+        val vunderFuzz = OneAuditVunderFuzzer(cardManifest.populations as List<OneAuditPoolIF>, infos, fuzzPct, sortedCards)
         val oaFuzzedPairs: List<Pair<AuditableCard, AuditableCard>> = vunderFuzz.fuzzedPairs
         val sortedMvrs = oaFuzzedPairs.map { it.first }
+
         // have to write this here, where we know the mvrs
         writePrivateMvrs(publisher, sortedMvrs)
     }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/Cvrs.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/Cvrs.kt
@@ -149,7 +149,7 @@ fun add2voteOverstatements(cvrs: MutableList<Cvr>, needToChangeVotesFromA: Int):
 
 // This only agrees with reportedMargin when the cvrs are complete with undervotes and phantoms.
 // Note that we rely on it.hasContest(contestId), assumes undervotes are in the cvr, ie hasStyle = true.
-fun AssorterIF.calcAssorterMargin(contestId: Int, cvrs: Iterable<Cvr>, usePhantoms: Boolean = false, show: Boolean= false): Double {
+fun AssorterIF.calcAssorterMargin(contestId: Int, cvrs: Iterable<Cvr>, usePhantoms: Boolean = false): Double {
     return mean2margin(calcAssortAvgFromCvrs(contestId, cvrs, usePhantoms))
 }
 

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/raire/SimulateOneAuditRaire.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/raire/SimulateOneAuditRaire.kt
@@ -7,8 +7,7 @@ import org.cryptobiotic.rlauxe.oneaudit.calcOneAuditPoolsFromMvrs
 import org.cryptobiotic.rlauxe.util.tabulateCvrs
 import kotlin.random.Random
 
-// TODO not done; do we want to support OA IRV ??
-// Try using in San Francisco, since we coul generate the VoteConsolidators from the cvrs in the pool
+// Try using in San Francisco, since we could generate the VoteConsolidators from the cvrs in the pool
 fun simulateOneAuditRaire(N: Int, contestId: Int, ncands:Int, minMargin: Double, poolPct: Int,
                              undervotePct: Double = .05, phantomPct: Double = .005, quiet: Boolean = true)
         : Triple<RaireContestWithAssertions, List<Cvr>, List<OneAuditPoolFromCvrs>> {
@@ -40,7 +39,7 @@ fun simulateOneAuditRaire(N: Int, contestId: Int, ncands:Int, minMargin: Double,
         cvrsWithPools,
     )
 
-    val raireOAUA = makeRaireContestIrv(info, cvrTab, N, Nbin=N, pools)
+    val raireOAUA = makeRaireOneAuditContest(info, cvrTab, N, Nbin=N, pools)
     println(raireOAUA)
 
     return Triple(raireOAUA, cvrsWithPools, pools)

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/raire/SimulateRaireTestContest.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/raire/SimulateRaireTestContest.kt
@@ -18,6 +18,7 @@ import kotlin.random.Random
 
 // Simulation of Raire Contest; pass in the parameters to make RaireContest with and simulate the cvrs;
 // then call raire library to generate the assertions to get  RaireContestUnderAudit
+// used for testing only
 fun simulateRaireTestContest(N: Int, contestId: Int, ncands:Int, minMargin: Double,
                              undervotePct: Double = .05, phantomPct: Double = .005, quiet: Boolean = true)
 : Pair<RaireContestWithAssertions, List<Cvr>> {
@@ -263,6 +264,7 @@ fun findMinAssertion(
         null,
         null,
     )
+    if (!quiet) println("call problem.solve in raire library")
     val solution: RaireSolution = problem.solve()
     if (solution.solution.Err != null) {
         println("solution.solution.Err=${solution.solution.Err}")

--- a/docs/Clca.md
+++ b/docs/Clca.md
@@ -165,7 +165,7 @@ u > 1, win-los, win-oth < 0
 Plots 1-5 shows the betting payoffs when the error rates are all equal to {0.0, 0.0001, .001, .005, .01}
 
 <a href="https://johnlcaron.github.io/rlauxe/docs/plots2/betting/payoff/BettingPayoff0.0.html" rel="BettingPayoff0">![BettingPayoff0](plots2/betting/payoff/BettingPayoff0.0.png)</a>
-<a href="https://johnlcaron.github.io/rlauxe/docs/plots2/betting/payoff/BettingPayoff1.0E-4.html" rel="BettingPayoff1.0E-4">![BettingPayoff1.0E-4](plots2/betting/payoff/BettingPayoff1.0E-4.png)</a>
+<a href="https://johnlcaron.github.io/rlauxe/docs/plots2/betting/payoff/BettingPayoff5.0E-4.html" rel="BettingPayoff5.0E-4">![BettingPayoff5.0E-4](plots2/betting/payoff/BettingPayoff5.0E-4.png)</a>
 <a href="https://johnlcaron.github.io/rlauxe/docs/plots2/betting/payoff/BettingPayoff0.001.html" rel="BettingPayoff0.001">![BettingPayoff0.001](./plots2/betting/payoff/BettingPayoff0.001.png)</a>
 <a href="https://johnlcaron.github.io/rlauxe/docs/plots2/betting/payoff/BettingPayoff0.005.html" rel="BettingPayoff0.005">![BettingPayoff0.005](plots2/betting/payoff/BettingPayoff0.005.png)</a>
 <a href="https://johnlcaron.github.io/rlauxe/docs/plots2/betting/payoff/BettingPayoff0.01.html" rel="BettingPayoff01">![BettingPayoff01](plots2/betting/payoff/BettingPayoff0.01.png)</a>

--- a/docs/Developer.md
+++ b/docs/Developer.md
@@ -1,5 +1,5 @@
 # Developer Notes
-_12/23/2025_
+_01/18/2026_
 
 ## Prerequisites
 
@@ -158,19 +158,19 @@ before viewing them.
 | 12/23/2025 | 83.9 % | 5393/6431       |
 | 01/07/2026 | 84.5 % | 5344/6327       |
 | 01/16/2026 | 87.5 % | 5417/6190       |
-| 01/16/2026 | 87.7 % | 5554/6333       |
+| 01/18/2026 | 90.2 % | 5677/6294       |
 
  **core + cases test coverage** 
 
 | date       | pct    | cover/total LOC |
-|------------|--------|----------------|
-| 11/28/2025 | 79.3 % | 6417/8094      |
-| 11/29/2025 | 79.6 % | 6434/8087      |
-| 11/29/2025 | 81.4 % | 6479/7962      |
-| 12/04/2025 | 81.7 % | 6530/7994      |
-| 12/10/2025 | 78.4 % | 6597/8412      |
-| 12/13/2025 | 80.7 % | 6606/8187      |
-| 12/23/2025 | 81.0 % | 6634/8186      |
+|------------|--------|-----------------|
+| 11/28/2025 | 79.3 % | 6417/8094       |
+| 11/29/2025 | 79.6 % | 6434/8087       |
+| 11/29/2025 | 81.4 % | 6479/7962       |
+| 12/04/2025 | 81.7 % | 6530/7994       |
+| 12/10/2025 | 78.4 % | 6597/8412       |
+| 12/13/2025 | 80.7 % | 6606/8187       |
+| 12/23/2025 | 81.0 % | 6634/8186       |
 
 
 ## UML
@@ -183,7 +183,6 @@ last changed: 01/07/2026
 
 # TODO 12/11/25 (Belgium)
 
-* consolidate over counties
 * include undervotes
 * assertions that look at coalitions of parties. (Vanessa)
 * choose an audit size and measure the risk.
@@ -197,35 +196,11 @@ last changed: 01/07/2026
 
 # TODO 01/04/26
 
-* OneAudit GABetting
 * maxRisk does it help? reduce lamda tradeoff 
 * 2D plotting
 * betting on the error rate
 * mix_betting_mart: "Finds a simple discrete mixture martingale as a (flat) average of D TSMs each with fixed bet 'lam'"
 * review COBRA 3.2, 4.3 (Diversified betting)
-
-````
-// generalize AdaptiveBetting for any clca assorter, including OneAudit
-
-log T_i = ln(1.0 + lamda * (noerror - mui)) * p0  + Sum { ln(1.0 + lamda * (assortValue_k - mui)) * p_k }
-  + Sum { ln(1.0 + lamda * (assortValue_pk - mui)) * p_pk; over pools and pool types }              (eq 2)
-where
-  upper > 1/2
-  noerror > 1/2
-  mui ~ 1/2  
-  
-  ln(1) = 0
-  ln(x), x > 1 is positive
-  ln(x), x < 1 is negetive
-  
-  could group into + and - terms ?
-  clca:
-    val u12 = 1.0 / (2 * upper)  // (2 * upper) > 1, u12 < 1
-    val name = mapOf(0.0 to "0", u12 to "1/2u", 1 - u12 to "1-1/2u",   // value - 1/2 is negetive
-        1.0 to "noerror", 2 - u12 to "2-1/2u", 1 + u12 to "1+1/2u", 2.0 to "2")  // value - 1/2 is positive
-
- 
-````
  
 ////////////////////////////////////////////
 Simulation

--- a/docs/RlauxeSpec.md
+++ b/docs/RlauxeSpec.md
@@ -1,7 +1,7 @@
 **Rlauxe Implementation Specification**
-_last changed: 9/20/25_
+_last changed: 01/18/2026_
 
-See [references](../papers/papers.txt) for reference papers.
+See [references](papers/papers.txt) for reference papers.
 
 <!-- TOC -->
 * [Missing Ballots](#missing-ballots)
@@ -460,8 +460,7 @@ We use BettingMart to implement AlphaMart, by setting the betting function
 
 as described in ALPHA section 2.3.
 
-See [AlphaMart risk function](../AlphaMart.md) for more details.
-See [AlphaMart implementation](../../core/src/main/kotlin/org/cryptobiotic/rlauxe/core/AlphaMart.kt).
+See [AlphaMart risk function](AlphaMart.md) for more details.
 
 
 ### Truncated shrinkage estimate of the population mean
@@ -503,10 +502,7 @@ the outcome of the ith wager. The value Mj is the gambler’s wealth after the j
 gambler is not permitted to borrow money, so to ensure that when X_i = 0 (corresponding to
 losing the ith bet) the gambler does not end up in debt (Mi < 0), λi cannot exceed 1/µi.
 
-See Cobra section 4.2 and SHANGRLA Section 3.2. See [CLCA Risk function](../ClcaRiskFunction.md) for more algorithm details.
-
-See [BettingRiskFunction implementation](../../core/src/main/kotlin/org/cryptobiotic/rlauxe/core/BettingMart.kt) for
-implementation details.
+See Cobra section 4.2 and SHANGRLA Section 3.2. See [CLCA Risk function](Clca.md) for more algorithm details.
 
 
 ### The CLCA betting function
@@ -546,10 +542,9 @@ EF[Ti] = p0 [1 + λ(a − mu_i)] + p1 [1 + λ(a/2 − mu_i)] + p2 [1 − λ*mu_i
 We follow the code in https://github.com/spertus/comparison-RLA-betting/blob/main/comparison_audit_simulations.R, to
 find the value of lamda that maximizes EF\[Ti], _using org.apache.commons.math3.optim.univariate.BrentOptimizer_.
 
-See [OptimalComparison implementation](../../core/src/main/kotlin/org/cryptobiotic/rlauxe/core/OptimalComparison.kt)
-for details on the AdaptiveBetting implementation.
+See [CLCA AdaptiveBetting](AdaptiveBetting.md) for details on the AdaptiveBetting algorithm.
 
-See [CLCA AdaptiveBetting](../AdaptiveBetting.md) for details on the AdaptiveBetting algorithm.
+See [Generalized AdaptiveBetting](GeneralizedAdaptiveBetting.md) for details on our extensions on the AdaptiveBetting algorithm.
 
 ## OneAudit
 

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/CardManifestAttack.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/CardManifestAttack.kt
@@ -9,7 +9,6 @@ import org.cryptobiotic.rlauxe.audit.CreateElection
 import org.cryptobiotic.rlauxe.audit.OneAuditConfig
 import org.cryptobiotic.rlauxe.audit.OneAuditStrategyType
 import org.cryptobiotic.rlauxe.audit.Population
-import org.cryptobiotic.rlauxe.audit.writeMvrsForRound
 import org.cryptobiotic.rlauxe.audit.writeSortedCardsInternalSort
 import org.cryptobiotic.rlauxe.cli.RunVerifyContests
 import org.cryptobiotic.rlauxe.audit.runRound
@@ -262,7 +261,6 @@ class CardManifestAttack {
         while (!done) {
             val lastRound = runRound(inputDir = auditdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
-            if (!done) writeMvrsForRound(publisher, lastRound!!.roundIdx)
         }
     }
 }

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/ReproduceCobraResults.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/ReproduceCobraResults.kt
@@ -406,8 +406,6 @@ fun optimal_comparison(alpha: Double, u: Double, rate_error_2: Double = 1e-4): D
     val p2 = rate_error_2 // getattr(self, "rate_error_2", 1e-4)  // rate of 2-vote overstatement errors
     val bet = (1 - u * (1 - p2)) / (2 - 2 * u) + u * (1 - p2) - .5
     // 1 / alpha = bet ^ size
-    -ln(alpha)
-    ln(bet)
     val size = -ln(alpha) / ln(bet)
     return size
 }

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/plots/PctMinRatio.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/plots/PctMinRatio.kt
@@ -26,14 +26,10 @@ fun createPctRatio(dlcalcs: Map<Int, List<SRT>>, thetas: List<Double>, ns: List<
                 val dmap = mmap[N]
                 val pct = if (dmap != null) extractPct(dmap[margin]) else 100.0
                 pct / pctMin
-                // (val N: Int, val theta: Double, val nsamples: Double, val pct: Double, val stddev: Double,
-                //               val reportedMeanDiff: Double, val d: Int, val eta0: Double, val hist: Histogram?)
-                // data class SRT(val N: Int, val theta: Double, val reportedMeanDiff: Double, val d: Int, val eta0: Double,
-                //               val failPct: Double, val nsamples: Double, val stddev: Double)
                 val sr = SRT(
                     N, margin, 0.0, emptyMap(), 0, 0, 0,
-                    stddev = TODO(),
-                ) // TODO
+                    stddev = 0.0, // TODO
+                )
                 val newsrs = newdlc.getOrPut(d) { mutableListOf() }
                 newsrs.add(sr)
             }


### PR DESCRIPTION
Use simple Estimation for OneAudit IRV
use SimulateIrvTestData for polling IRV estimation 
add tests for SimulateIrvTestData, makeRaireContest 

SF oneaudit must write private mvrs
runRoundResult writes sampleMvrsFile of next round if needed

VoteConsolidator.nvotes was wrong
improve logging
core coverage over 90%
