### PR TITLE
option to use calcMvrsNeeded for first round

### DIFF
--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/boulder/CreateBoulderElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/boulder/CreateBoulderElection.kt
@@ -334,7 +334,6 @@ fun createBoulderElection(
         else if (auditType.isOA())
             AuditConfig( // TODO hasStyle=false ?
                 AuditType.ONEAUDIT, riskLimit=riskLimit, minRecountMargin=minRecountMargin, nsimEst=10,
-                oaConfig = OneAuditConfig(OneAuditStrategyType.generalAdaptive, useFirst = false)
             )
     else throw RuntimeException("unsupported audit type $auditType")
 

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoElection.kt
@@ -274,7 +274,6 @@ fun createColoradoElectionP(
 
         else -> AuditConfig( // // TODO hasStyle=false
             AuditType.ONEAUDIT, riskLimit = .03, nsimEst = 10,
-            oaConfig = OneAuditConfig(OneAuditStrategyType.generalAdaptive, useFirst = false)
         )
     }
     val election = CreateColoradoElection(electionDetailXmlFile, contestRoundFile, precinctFile, config, poolsHaveOneCardStyle)

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElection.kt
@@ -348,7 +348,7 @@ fun createSfElection(
         (auditType ==  AuditType.ONEAUDIT) -> AuditConfig(
             AuditType.ONEAUDIT, riskLimit = .05, nsimEst = 20,
             persistedWorkflowMode = PersistedWorkflowMode.testPrivateMvrs,  // write mvrs to private
-            oaConfig = OneAuditConfig(OneAuditStrategyType.generalAdaptive, useFirst = false)
+            oaConfig = OneAuditConfig(OneAuditStrategyType.calcMvrsNeeded)
         )
 
         else -> AuditConfig(AuditType.POLLING, riskLimit = .05, contestSampleCutoff = 10000, nsimEst = 20)

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/MakeSfElection.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/MakeSfElection.kt
@@ -16,8 +16,8 @@ class MakeSfElection {
     val cvrExportCsv = "$sfDir/$cvrExportCsvFile"
 
     @Test
-    fun createSFElectionOA() {
-        val topdir = "$testdataDir/cases/sf2024/oa"
+    fun createSFElectionOAcalc() {
+        val topdir = "$testdataDir/cases/sf2024/oacalc"
 
         createSfElection(
             topdir,

--- a/cases/src/test/kotlin/org/cryptobiotic/util/TestRunCli.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/util/TestRunCli.kt
@@ -167,4 +167,43 @@ class TestRunCli {
         if (results.hasErrors) fail()
     }
 
+    @Test
+    fun testCliOneAuditCalc() {
+        val topdir = "$testdataDir/persist/testRunCli/oneauditcalc"
+        val auditdir = "$topdir/audit"
+
+        RunRlaCreateOneAudit.main(
+            arrayOf(
+                "-in", topdir,
+                "-minMargin", "0.04",
+                "-fuzzMvrs", "0.001",
+                "-cvrFraction", "0.95",
+                "-ncards", "50000",
+                "-extraPct", "0.01",
+                "-calc",
+            )
+        )
+        val publisher = Publisher(auditdir)
+        val config = readAuditConfigJsonFile(publisher.auditConfigFile()).unwrap()
+
+        println("============================================================")
+        val resultsvc = RunVerifyContests.runVerifyContests(auditdir, null, false)
+        println()
+        print(resultsvc)
+        if (resultsvc.hasErrors) fail()
+
+        println("============================================================")
+        var done = false
+        while (!done) {
+            val lastRound = runRound(inputDir = auditdir)
+            done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
+        }
+
+        println("============================================================")
+        val results = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir = auditdir)
+        println(results)
+
+        if (results.hasErrors) fail()
+    }
+
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditConfig.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditConfig.kt
@@ -30,7 +30,7 @@ data class AuditConfig(
 
     val pollingConfig: PollingConfig = PollingConfig(),
     val clcaConfig: ClcaConfig = ClcaConfig(),
-    val oaConfig: OneAuditConfig = OneAuditConfig(OneAuditStrategyType.clca, useFirst = false),
+    val oaConfig: OneAuditConfig = OneAuditConfig(),
 
     val persistedWorkflowMode: PersistedWorkflowMode =  PersistedWorkflowMode.testSimulated,
     val skipContests: List<Int> = emptyList(),
@@ -62,7 +62,6 @@ data class AuditConfig(
             AuditType.CLCA -> appendLine("  $clcaConfig")
             AuditType.ONEAUDIT -> {
                 appendLine("  $oaConfig")
-                if (oaConfig.strategy== OneAuditStrategyType.clca) appendLine("  $clcaConfig")
             }
         }
     }
@@ -102,16 +101,10 @@ data class ClcaConfig(
     val cvrsContainUndervotes: Boolean = true,
 )
 
-// clca: use ClcaConfig and bettingMart
-// optimalComparison = uses bettingMart with OptimalComparisonNoP1
-// bet99: eta0 = reportedMean, 99% max bet
-// eta0Eps: eta0 = upper*(1 - eps), shrinkTrunk
-// note OneAudit uses ClcaConfig for error estimation
-// TODO only generalAdaptive is currently used
-enum class OneAuditStrategyType { clca, generalAdaptive, bet99, eta0Eps }
+// simulate: simulate for estimation
+// calcMvrsNeeded: calculate for estimation
+enum class OneAuditStrategyType { simulate, calcMvrsNeeded }
 data class OneAuditConfig(
-    val strategy: OneAuditStrategyType = OneAuditStrategyType.generalAdaptive, // TODO
-    val d: Int = 100,  // shrinkTrunc weight
-    val useFirst: Boolean = false, // use actual cvrs for estimation
+    val strategy: OneAuditStrategyType = OneAuditStrategyType.simulate,
 )
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAuditRound.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAuditRound.kt
@@ -114,7 +114,7 @@ fun runRoundAgain(auditDir: String, contestRound: ContestRound, assertionRound: 
         if (auditRecord == null) {
             return "directory '$auditDir' does not contain an audit record"
         }
-        logger.info { "runAudit in $auditDir for round $roundIdx, contest $contestId, and assertion $assertion" }
+        logger.info { "runRoundAgain in $auditDir for round $roundIdx, contest $contestId, and assertion $assertion" }
 
         val workflow = PersistedWorkflow(auditRecord, mvrWrite = false)
         val cvrPairs = workflow.mvrManager().makeMvrCardPairsForRound(roundIdx)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/CalculateSampleSizes.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/CalculateSampleSizes.kt
@@ -1,0 +1,35 @@
+package org.cryptobiotic.rlauxe.estimate
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.cryptobiotic.rlauxe.audit.AuditConfig
+import org.cryptobiotic.rlauxe.audit.AuditRoundIF
+import kotlin.math.max
+import kotlin.math.min
+
+private val logger = KotlinLogging.logger("CalculateSampleSizes")
+
+// not setting assertionRound.estNewMvrs, contestRound.estNewMvrs; maybe only informative ??
+fun calculateSampleSizes(
+    config: AuditConfig,
+    auditRound: AuditRoundIF,
+) {
+    require(config.isOA) // currently only for OneAudit
+
+    auditRound.contestRounds.filter { !it.done }.forEach { contestRound ->
+        var maxEstMvrs = 0
+        var maxNewEstMvrs = 0
+        contestRound.assertionRounds.forEach { assertionRound ->
+
+            val (calcNewSamples, optimalBet) = assertionRound.calcMvrsNeeded(contestRound.contestUA, config.clcaConfig.maxLoss, config.riskLimit,)
+            assertionRound.estNewMvrs = calcNewSamples
+
+            val prevSampleSize = assertionRound.prevAuditResult?.samplesUsed ?: 0
+            assertionRound.estMvrs = min(calcNewSamples + prevSampleSize, contestRound.contestUA.Npop)
+
+            maxNewEstMvrs = max( maxNewEstMvrs, calcNewSamples)
+            maxEstMvrs = max( maxNewEstMvrs, assertionRound.estMvrs)
+        }
+        contestRound.estNewMvrs = maxNewEstMvrs
+        contestRound.estMvrs = maxEstMvrs
+    }
+}

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/RunRepeated.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/RunRepeated.kt
@@ -53,7 +53,7 @@ fun runRepeated(
         // this can fail when you have limited the number of samples
         if (testH0Result.status == TestH0Status.LimitReached) {
             fail++
-            logger.warn { "$name:  $trial failed in sampling max= ${samplerTracker.maxSamples()} samples" }
+            logger.debug { "$name:  $trial failed in sampling max= ${samplerTracker.maxSamples()} samples" }
         } else {
             nsuccess++
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AuditConfigJson.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AuditConfigJson.kt
@@ -261,15 +261,11 @@ fun ClcaConfigJson.import() = ClcaConfig(
 @Serializable
 data class OneAuditConfigJson(
     val strategy: String,
-    val d: Int,
-    val useFirst: Boolean,
 )
 
-fun OneAuditConfig.publishJson() = OneAuditConfigJson(this.strategy.name, this.d, this.useFirst)
+fun OneAuditConfig.publishJson() = OneAuditConfigJson(this.strategy.name)
 fun OneAuditConfigJson.import() = OneAuditConfig(
-        enumValueOf(this.strategy, OneAuditStrategyType.entries) ?: OneAuditStrategyType.generalAdaptive,
-        this.d,
-        this.useFirst
+        enumValueOf(this.strategy, OneAuditStrategyType.entries) ?: OneAuditStrategyType.simulate,
     )
 
 /////////////////////////////////////////////////////////////////////////////////

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AuditRoundJson.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AuditRoundJson.kt
@@ -232,7 +232,7 @@ data class EstimationRoundResultJson(
     val startingErrorRates: Map<Double, Double>? = null, // error rates used for estimation
     val estimatedDistribution: List<Int>,
     val ntrials: Int,
-    val estNewMvrs: Int = 0,
+    val simNewMvrs: Int = 0,
 )
 
 fun EstimationRoundResult.publishJson() = EstimationRoundResultJson(
@@ -243,11 +243,10 @@ fun EstimationRoundResult.publishJson() = EstimationRoundResultJson(
     this.startingErrorRates,
     this.estimatedDistribution,
     this.ntrials,
-    this.estNewMvrs,
+    this.simNewMvrs,
 )
 
-fun EstimationRoundResultJson.import() : EstimationRoundResult {
-    val rr = EstimationRoundResult(
+fun EstimationRoundResultJson.import() = EstimationRoundResult(
         this.roundIdx,
         this.strategy,
         this.fuzzPct,
@@ -255,10 +254,8 @@ fun EstimationRoundResultJson.import() : EstimationRoundResult {
         this.startingErrorRates,
         this.estimatedDistribution,
         this.ntrials,
+        this.simNewMvrs,
     )
-    rr.estNewMvrs = this.estNewMvrs
-    return rr
-}
 
 // data class AuditRoundResult(
 //    val roundIdx: Int,
@@ -276,7 +273,7 @@ data class AuditRoundResultJson(
     val desc: String,
     val roundIdx: Int,
     val nmvrs: Int,   // estimated sample size
-    val maxSampleIndexUsed: Int,   // max index used
+    // val maxSampleIndexUsed: Int,   // max index used
     val plast: Double,       // last pvalue when testH0 terminates
     val pmin: Double,       // minimum pvalue reached
     val samplesUsed: Int,     // sample count when testH0 terminates, usually maxSamples
@@ -289,7 +286,7 @@ fun AuditRoundResult.publishJson() = AuditRoundResultJson(
     this.toString(),
     this.roundIdx,
     this.nmvrs,
-    this.countCvrsUsedInAudit,
+    // this.countCvrsUsedInAudit,
     this.plast,
     this.pmin,
     this.samplesUsed,
@@ -303,7 +300,7 @@ fun AuditRoundResultJson.import() : AuditRoundResult {
     return AuditRoundResult(
         this.roundIdx,
         this.nmvrs,
-        this.maxSampleIndexUsed,
+        // this.maxSampleIndexUsed,
         this.plast,
         this.pmin,
         this.samplesUsed,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaAssertionAuditor.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/ClcaAssertionAuditor.kt
@@ -147,7 +147,7 @@ class ClcaAssertionAuditor(val quiet: Boolean = true): ClcaAssertionAuditorIF {
         assertionRound.auditResult = AuditRoundResult(
             roundIdx,
             nmvrs = samplerTracker.maxSamples(),
-            countCvrsUsedInAudit = samplerTracker.countCvrsUsedInAudit(),
+            // countCvrsUsedInAudit = samplerTracker.countCvrsUsedInAudit(),
             plast = testH0Result.pvalueLast,
             pmin = testH0Result.pvalueMin,
             samplesUsed = testH0Result.sampleCount,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAuditAssertionAuditor.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/OneAuditAssertionAuditor.kt
@@ -51,7 +51,7 @@ class OneAuditAssertionAuditor(val pools: List<OneAuditPoolIF>, val quiet: Boole
         assertionRound.auditResult = AuditRoundResult(
             roundIdx,
             nmvrs = samplerTracker.maxSamples(),
-            countCvrsUsedInAudit = samplerTracker.countCvrsUsedInAudit(),
+            // countCvrsUsedInAudit = samplerTracker.countCvrsUsedInAudit(),
             plast = testH0Result.pvalueLast,
             pmin = testH0Result.pvalueMin,
             samplesUsed = testH0Result.sampleCount,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingAssertionAuditor.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PollingAssertionAuditor.kt
@@ -100,7 +100,7 @@ fun auditPollingAssertion(
 
     assertionRound.auditResult = AuditRoundResult(roundIdx,
         nmvrs = sampler.nmvrs(),
-        countCvrsUsedInAudit = sampler.countCvrsUsedInAudit(),
+        // countCvrsUsedInAudit = sampler.countCvrsUsedInAudit(),
         plast = testH0Result.pvalueLast,
         pmin = testH0Result.pvalueMin,
         samplesUsed = testH0Result.sampleCount,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditConfig.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditConfig.kt
@@ -39,16 +39,15 @@ class TestAuditConfig {
     fun testOneAudit() {
         val config = AuditConfig(
             AuditType.ONEAUDIT, nsimEst = 10, seed=-2417429242344992892,
-            oaConfig = OneAuditConfig(OneAuditStrategyType.eta0Eps)
         )
         val expected =
             """AuditConfig(auditType=ONEAUDIT, riskLimit=0.05, seed=-2417429242344992892 persistedWorkflowMode=testSimulated
   minRecountMargin=0.005 removeTooManyPhantoms=false contestSampleCutoff=30000 removeCutoffContests=false
   nsimEst=10, quantile=0.8, simFuzzPct=null, mvrFuzzPct=0.0,
-  OneAuditConfig(strategy=eta0Eps, d=100, useFirst=false)
+  OneAuditConfig(strategy=simulate)
 """
         assertEquals(expected, config.toString())
-        assertEquals("eta0Eps", config.strategy())
+        assertEquals("simulate", config.strategy())
     }
 
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRoundCli.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRoundCli.kt
@@ -8,7 +8,7 @@ class TestRunRoundCli {
 
     @Test
     fun testRunRoundCli() {
-        val topdir = "$testdataDir/cases/sf2024/oa"
+        val topdir = "$testdataDir/cases/sf2024/oacalc"
         val auditdir = "$topdir/audit"
 
         RunRlaRoundCli.main(

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditConfigJson.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditConfigJson.kt
@@ -34,8 +34,7 @@ class TestAuditConfigJson {
             AuditConfig(
                 AuditType.ONEAUDIT, hasStyle=false, seed = 12356667890L, riskLimit=.03, nsimEst=42, quantile=.50, simFuzzPct=.111,
                 contestSampleCutoff=10000,  version=2.0,
-            oaConfig= OneAuditConfig(OneAuditStrategyType.bet99, d = 99)
-        )
+            )
         )
     }
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditRoundJson.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditRoundJson.kt
@@ -399,7 +399,6 @@ fun check(a1: AuditRoundResult, a2: AuditRoundResult): Boolean {
     assertEquals(a1.toString(), a2.toString())
     assertEquals(a1.roundIdx, a2.roundIdx)
     assertEquals(a1.nmvrs, a2.nmvrs)
-    assertEquals(a1.countCvrsUsedInAudit, a2.countCvrsUsedInAudit)
     assertEquals(a1.plast, a2.plast)
     assertEquals(a1.pmin, a2.pmin)
     assertEquals(a1.samplesUsed, a2.samplesUsed)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestOneAudit.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestOneAudit.kt
@@ -69,10 +69,7 @@ class TestOneAudit {
         )
         println(contestOA)
 
-        val config = AuditConfig(
-            AuditType.ONEAUDIT, nsimEst=10,
-            oaConfig = OneAuditConfig(OneAuditStrategyType.bet99)
-        )
+        val config = AuditConfig(AuditType.ONEAUDIT, nsimEst=10)
 
         val workflow = WorkflowTesterOneAudit(config, listOf(contestOA), MvrManagerForTesting(testCvrs, testCvrs, config.seed, pools=pools))
         runTestAuditToCompletion("testOneAuditContestSmall", workflow)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestOneAuditTask.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestOneAuditTask.kt
@@ -92,11 +92,7 @@ class TestOneAuditTask {
         val phantomPct = 0.00
         val cvrPercent = 0.80
 
-        val auditConfigIn = AuditConfig(
-            AuditType.ONEAUDIT, true,
-            oaConfig = OneAuditConfig(strategy= OneAuditStrategyType.clca)
-        )
-
+        val auditConfigIn = AuditConfig(AuditType.ONEAUDIT, true)
         val taskGen = OneAuditSingleRoundAuditTaskGeneratorWithFlips(
             Nc,
             margin,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistedWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistedWorkflow.kt
@@ -117,7 +117,6 @@ class TestPersistedWorkflow {
 
         val config = AuditConfig(
             AuditType.ONEAUDIT, contestSampleCutoff = 20000, nsimEst = 10, simFuzzPct = .01,
-            oaConfig = OneAuditConfig(OneAuditStrategyType.generalAdaptive)
         )
 
         val N = 5000

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaCreateOneAudit.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaCreateOneAudit.kt
@@ -5,6 +5,7 @@ import kotlinx.cli.ArgType
 import kotlinx.cli.default
 import kotlinx.cli.required
 import org.cryptobiotic.rlauxe.audit.*
+import org.cryptobiotic.rlauxe.audit.OneAuditStrategyType
 import org.cryptobiotic.rlauxe.core.ContestWithAssertions
 import org.cryptobiotic.rlauxe.oneaudit.OneAuditPoolFromCvrs
 import org.cryptobiotic.rlauxe.oneaudit.OneAuditVunderFuzzer
@@ -74,11 +75,16 @@ object RunRlaCreateOneAudit {
             shortName = "extraPct",
             description = "add extra percent to simulate diluted margin"
         ).default(.01)
+        val calc by parser.option(
+            type = ArgType.Boolean,
+            shortName = "calc",
+            description = "calculate mvrs needed for first round"
+        ).default(false)
 
         parser.parse(args)
         println(
             "RunRlaCreateOneAudit on $inputDir minMargin=$minMargin fuzzMvrs=$fuzzMvrs, cvrFraction=$cvrFraction, ncards=$ncards hasStyle=$hasStyle" +
-                    " extra=$extra"
+                    " extra=$extra cals =$calc"
         )
         startTestElectionOneAudit(
             inputDir,
@@ -87,6 +93,7 @@ object RunRlaCreateOneAudit {
             cvrFraction=cvrFraction,
             ncards,
             extra,
+            calc,
         )
     }
 
@@ -97,6 +104,7 @@ object RunRlaCreateOneAudit {
         cvrFraction: Double,
         ncards: Int,
         extraPct: Double,
+        calc: Boolean,
     ) {
         val auditDir = "$topdir/audit"
         clearDirectory(Path(auditDir))
@@ -104,7 +112,7 @@ object RunRlaCreateOneAudit {
         val config = AuditConfig(
             AuditType.ONEAUDIT, contestSampleCutoff = 20000, nsimEst = 10, simFuzzPct = fuzzPct,
             persistedWorkflowMode = PersistedWorkflowMode.testPrivateMvrs,
-            oaConfig = OneAuditConfig(OneAuditStrategyType.clca)
+            oaConfig = if (calc) OneAuditConfig(strategy = OneAuditStrategyType.calcMvrsNeeded) else OneAuditConfig()
         )
 
         clearDirectory(Path(auditDir))

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/CardManifestAttack.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/CardManifestAttack.kt
@@ -244,7 +244,6 @@ class CardManifestAttack {
         val auditdir = "$topdir/audit"
         val config = AuditConfig(
             AuditType.ONEAUDIT, hasStyle = hasStyle, contestSampleCutoff = 20000, nsimEst = 10,
-            oaConfig = OneAuditConfig(OneAuditStrategyType.generalAdaptive)
         )
         CreateAudit("hideInOtherPoolAttack", config, election, auditDir = "$topdir/audit",)
 

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/OaMarginAttack.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/OaMarginAttack.kt
@@ -40,10 +40,10 @@ class OaMarginAttack {
 
             val oneauditGeneratorBet99 = OneAuditSingleRoundAuditTaskGeneratorWithFlips(
                 Nc=N, margin=margin, underVotePct=0.0, phantomPct=0.0, cvrPercent=cvrPercent, mvrsFuzzPct=fuzzPct,
-                parameters=mapOf("nruns" to nruns.toDouble(), "cat" to "bet99", "fuzzPct" to fuzzPct),
+                parameters=mapOf("nruns" to nruns.toDouble(), "cat" to "simulate", "fuzzPct" to fuzzPct),
                 auditConfigIn = AuditConfig(
                     AuditType.ONEAUDIT, true, nsimEst = nsimEst,
-                    oaConfig = OneAuditConfig(strategy= OneAuditStrategyType.bet99)
+                    oaConfig = OneAuditConfig(strategy= OneAuditStrategyType.simulate)
                 ),
                 p1flips=margin*extra,
             )
@@ -51,10 +51,10 @@ class OaMarginAttack {
 
             val oneauditGeneratorEta0Eps = OneAuditSingleRoundAuditTaskGeneratorWithFlips(
                 Nc=N, margin=margin, underVotePct=0.0, phantomPct=0.0, cvrPercent=cvrPercent, mvrsFuzzPct=fuzzPct,
-                parameters=mapOf("nruns" to nruns.toDouble(), "cat" to "eta0Eps", "fuzzPct" to fuzzPct),
+                parameters=mapOf("nruns" to nruns.toDouble(), "cat" to "calcMvrsNeeded", "fuzzPct" to fuzzPct),
                 auditConfigIn = AuditConfig(
                     AuditType.ONEAUDIT, true, nsimEst = nsimEst,
-                    oaConfig = OneAuditConfig(strategy= OneAuditStrategyType.eta0Eps)
+                    oaConfig = OneAuditConfig(strategy= OneAuditStrategyType.calcMvrsNeeded)
                 ),
                 p1flips=margin*extra,
             )

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/OaPhantomAttack.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/OaPhantomAttack.kt
@@ -37,20 +37,20 @@ class OaPhantomAttack {
 
             val oneauditGeneratorBet99 = OneAuditSingleRoundAuditTaskGeneratorWithFlips(
                 Nc=N, margin=margin, underVotePct=0.0, phantomPct=phantomPct, cvrPercent=cvrPercent, mvrsFuzzPct=fuzzPct,
-                parameters=mapOf("nruns" to nruns.toDouble(), "cat" to "bet99", "fuzzPct" to fuzzPct),
+                parameters=mapOf("nruns" to nruns.toDouble(), "cat" to "simulate", "fuzzPct" to fuzzPct),
                 auditConfigIn = AuditConfig(
                     AuditType.ONEAUDIT, true, nsimEst = nsimEst,
-                    oaConfig = OneAuditConfig(strategy= OneAuditStrategyType.bet99)
+                    oaConfig = OneAuditConfig(strategy= OneAuditStrategyType.simulate)
                 ),
             )
             tasks.add(RepeatedWorkflowRunner(nruns, oneauditGeneratorBet99))
 
             val oneauditGeneratorEta0Eps = OneAuditSingleRoundAuditTaskGeneratorWithFlips(
                 Nc=N, margin=margin, underVotePct=0.0, phantomPct=phantomPct, cvrPercent=cvrPercent, mvrsFuzzPct=fuzzPct,
-                parameters=mapOf("nruns" to nruns.toDouble(), "cat" to "eta0Eps", "fuzzPct" to fuzzPct),
+                parameters=mapOf("nruns" to nruns.toDouble(), "cat" to "calcMvrsNeeded", "fuzzPct" to fuzzPct),
                 auditConfigIn = AuditConfig(
                     AuditType.ONEAUDIT, true, nsimEst = nsimEst,
-                    oaConfig = OneAuditConfig(strategy= OneAuditStrategyType.eta0Eps)
+                    oaConfig = OneAuditConfig(strategy= OneAuditStrategyType.calcMvrsNeeded)
                 ),
             )
             tasks.add(RepeatedWorkflowRunner(nruns, oneauditGeneratorEta0Eps))

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/CobraAudit.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cobra/CobraAudit.kt
@@ -141,7 +141,7 @@ class AuditCobraAssertion(
         assertionRound.auditResult = AuditRoundResult(
             roundIdx,
             nmvrs = sampleTracker.nmvrs(),
-            countCvrsUsedInAudit = sampleTracker.countCvrsUsedInAudit(),
+            // countCvrsUsedInAudit = sampleTracker.countCvrsUsedInAudit(),
             plast = testH0Result.pvalueLast,
             pmin = testH0Result.pvalueMin,
             samplesUsed = samplesNeeded,

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaAudit.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/corla/CorlaAudit.kt
@@ -150,7 +150,7 @@ class AuditCorlaAssertion(val quiet: Boolean = true): ClcaAssertionAuditorIF {
         assertionRound.auditResult = AuditRoundResult(
             roundIdx,
             nmvrs = sampling.nmvrs(),
-            countCvrsUsedInAudit = sampling.countCvrsUsedInAudit(),
+            // countCvrsUsedInAudit = sampling.countCvrsUsedInAudit(),
             plast = testH0Result.pvalueLast,
             pmin = testH0Result.pvalueMin,
             samplesUsed = samplesNeeded,

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/AuditsNoErrors.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/AuditsNoErrors.kt
@@ -44,7 +44,6 @@ class AuditsNoErrors {
                     N, margin, 0.0, 0.0, cvrPercent, 0.0,
                     auditConfigIn = AuditConfig(
                         AuditType.ONEAUDIT, true,
-                        oaConfig = OneAuditConfig(strategy= OneAuditStrategyType.generalAdaptive)
                     ),
                     parameters=mapOf("nruns" to nruns, "cat" to "oneaudit-${(100 * cvrPercent).toInt()}%"),
                 )


### PR DESCRIPTION
OneAuditConfig.strategy = simulate, calcMvrsNeeded 
add calculateSampleSizes() vs simulateSampleSizes

getSubsetForEstimation skip previousSamples

cleanup AuditRound fields, esp for viewer
remove auditResult.countCvrsUsedInAudit
EstimationRoundResult.estNewMvrs -> simNewMvrs