### PR TITLE
SF OneAudit with precinct and style pools

### DIFF
--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/dominion/CvrExport.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/dominion/CvrExport.kt
@@ -6,7 +6,6 @@ import org.cryptobiotic.rlauxe.audit.unpooled
 
 // intermediate CVR representation for DominionCvrSummary
 data class CvrExport(val id: String, val group: Int, val ballotStyleId: Int, val precinctPortionId: Int, val votes: Map<Int, IntArray>) {
-    val poolCounts = mutableMapOf<String, Int>()
 
     // Calculate the pool name from the cvr id. Could pass in a function (CvrExport) -> pool name
     fun poolKey(): String {

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/MakeElectionPrecinctAndStyle.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/MakeElectionPrecinctAndStyle.kt
@@ -1,0 +1,241 @@
+package org.cryptobiotic.rlauxe.sf
+
+import org.cryptobiotic.rlauxe.testdataDir
+import org.cryptobiotic.rlauxe.dominion.cvrExportCsvFile
+import kotlin.test.Test
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.cryptobiotic.rlauxe.audit.*
+import org.cryptobiotic.rlauxe.core.ContestInfo
+import org.cryptobiotic.rlauxe.core.ContestWithAssertions
+import org.cryptobiotic.rlauxe.dominion.CvrExport
+import org.cryptobiotic.rlauxe.oneaudit.OneAuditPoolFromCvrs
+import org.cryptobiotic.rlauxe.dominion.cvrExportCsvIterator
+import org.cryptobiotic.rlauxe.audit.CardPool
+import org.cryptobiotic.rlauxe.dominion.CvrExportToCardAdapter
+import org.cryptobiotic.rlauxe.util.CloseableIterator
+import org.cryptobiotic.rlauxe.util.ContestTabulation
+import org.cryptobiotic.rlauxe.util.TransformingIterator
+import org.cryptobiotic.rlauxe.util.nfz
+import org.cryptobiotic.rlauxe.utils.tabulateCardsAndCount
+import kotlin.Boolean
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.forEach
+import kotlin.collections.toList
+
+class MakeElectionPrecinctAndStyle {
+    val sfDir = "$testdataDir/cases/sf2024"
+    val castVoteRecordZip = "$sfDir/CVR_Export_20241202143051.zip"
+    val cvrExportCsv = "$sfDir/$cvrExportCsvFile"
+    val auditdir = "$testdataDir/cases/sf2024/oaps/audit"
+    val contestManifestFilename = "ContestManifest.json"
+    val candidateManifestFile = "CandidateManifest.json"
+
+    val creation = AuditCreationConfig(AuditType.ONEAUDIT, riskLimit=.05,)
+    val round = AuditRoundConfig(
+        SimulationControl(nsimTrials = 22),
+        ContestSampleControl(minRecountMargin = .005, minMargin=0.0, contestSampleCutoff = 2500, auditSampleCutoff = 5000),
+        ClcaConfig(fuzzMvrs=.001), null)
+
+    val mvrSource: MvrSource = MvrSource.testPrivateMvrs
+
+    @Test
+    fun makeElectionPrecinctOA() {
+
+        val election = CreatePrecinctAndStyle(
+            castVoteRecordZip,
+            contestManifestFilename,
+            candidateManifestFile,
+            cvrExportCsv,
+            auditType = creation.auditType,
+            poolsHaveOneCardStyle=true,
+            mvrSource = mvrSource
+        )
+
+        createElectionRecord(election, auditDir = auditdir, validate = true)
+
+        val config = Config(election.electionInfo(), creation, round)
+        createAuditRecord(config, election, auditDir = auditdir, validate = true)
+
+        val result = startFirstRound(auditdir)
+        if (result.isErr) logger.error{ result.toString() }
+    }
+}
+
+
+private val logger = KotlinLogging.logger("CreateSfprecinctOA")
+
+// use precincts as the pools
+class CreatePrecinctAndStyle(
+    castVoteRecordZip: String,
+    contestManifestFilename: String,
+    candidateManifestFile: String,
+    val cvrExportCsv: String,
+    val auditType: AuditType,
+    val poolsHaveOneCardStyle: Boolean,
+    val mvrSource: MvrSource = MvrSource.testPrivateMvrs,
+): ElectionBuilder {
+
+    val cardPoolMapByName: Map<String, OneAuditPoolFromCvrs>
+    val cardPoolBuilders: List<OneAuditPoolFromCvrs>
+    val cardPools: List<CardPool>
+    val cardStyleMap: Map<Set<Int>, CardStyle>
+    //  val cardStyles: List<CardStyleIF>
+    val contestsUA: List<ContestWithAssertions>
+    val ncards: Int
+
+    val ballotStyles: Map<Int, IntArray> = // ballot style id -> contest Ids
+        readBallotTypeContestManifestUnwrapped("src/test/data/SF2024/manifests/BallotTypeContestManifest.json")!!
+            .ballotStyles
+
+    init {
+        val (contestNcs, contestInfos) = makeContestInfos(
+            castVoteRecordZip,
+            contestManifestFilename,
+            candidateManifestFile
+        )
+        val infos = contestInfos.associateBy { it.id }
+
+        val (precinctPools, allCvrTabs, styles, unpool) = createPrecinctPools(
+            infos,
+            cvrExportCsv,
+            poolsHaveOneCardStyle,
+        )
+
+        cardPoolMapByName = precinctPools
+        cardPoolBuilders = cardPoolMapByName.values.toList()
+        cardStyleMap = styles
+        //  cardStyles = styles.values.toList()
+
+        // the full and complete CardsWithStyleName, merged with the pools
+        val auditableCardIter: CloseableIterator<AuditableCard> = MergeBatchesIntoCardManifestIterator(createCards(auditType), cardPoolBuilders)
+
+        val (manifestTabs, count) = tabulateCardsAndCount( auditableCardIter, infos)
+        val contestNbs = manifestTabs.mapValues { it.value.ncardsTabulated }
+        // println("contestNbs= ${contestNbs}")
+        this.ncards = count
+
+        // make contests based on cvr tabulations
+        cardPools = cardPoolBuilders.map { it.toOneAuditPool() } // TODO not sure why need to convert
+        contestsUA = if (auditType.isClca()) {
+            makeClcaContestsSF(infos, allCvrTabs, contestNcs, contestNbs).sortedBy { it.id }
+        } else if (auditType.isOA()) {
+            makeOneAuditContestsSF(infos, allCvrTabs, contestNcs, contestNbs, unpool, cardPools).sortedBy { it.id } // TODO
+        } else {
+            makePollingContestsSF(infos, allCvrTabs, contestNcs, contestNbs).sortedBy { it.id }
+        }
+    }
+
+    fun createPrecinctPools(
+        contestInfos: Map<Int, ContestInfo>,
+        cvrExportCsv: String,
+        poolsHaveOneCardStyle: Boolean,
+    ): PrecinctData {
+
+        val cardStyles = mutableMapOf<Set<Int>, CardStyle>() // contests.hashCode -> contests
+        val precinctPools: MutableMap<String, OneAuditPoolFromCvrs> = mutableMapOf()
+        val unpool = OneAuditPoolFromCvrs("unpool", 0, true, contestInfos)
+
+        val allCvrTabs = mutableMapOf<Int, ContestTabulation>()
+        var cardCount = 0
+        cvrExportCsvIterator(cvrExportCsv).use { cvrIter ->
+            while (cvrIter.hasNext()) {
+                cardCount++
+                val cvrExport: CvrExport = cvrIter.next()
+                if (cvrExport.group == 1) {
+                    val cardStyle = cardStyles.getOrPut(cvrExport.votes.keys) { CardStyle.from(cardStyles.size + 1, cvrExport.votes.keys) }
+                    val poolName = poolName(cvrExport.precinctPortionId, cardStyle)
+                    val pool = precinctPools.getOrPut(poolName) {
+                        OneAuditPoolFromCvrs(poolName, precinctPools.size + 1, poolsHaveOneCardStyle, contestInfos)
+                    }
+                    pool.accumulateVotes(cvrExport.toCvr(null, cvrExport.id))
+                } else {
+                    unpool.accumulateVotes(cvrExport.toCvr(null, cvrExport.id))
+                }
+                cvrExport.votes.forEach { (id, cands) ->
+                    val contestTab = allCvrTabs.getOrPut(id) { ContestTabulation(contestInfos[id]!!) }
+                    contestTab.addVotes(cands, phantom=false)
+                }
+            }
+        }
+
+        return PrecinctData(precinctPools, allCvrTabs, cardStyles, unpool)
+    }
+
+    fun poolName(precinctPortionId: Int, cardStyle: CardStyle) = "precinct${nfz(precinctPortionId, 3)}-style${nfz(cardStyle.id(),2)}"
+
+    data class PrecinctAndStyle(val precinctId: Int, val cardStyle: Set<Int>)
+
+    data class PrecinctData(val pools: Map<String, OneAuditPoolFromCvrs>, val tabs: Map<Int, ContestTabulation>, val styles: Map<Set<Int>, CardStyle>,
+                            val unpool: OneAuditPoolFromCvrs)
+
+    override fun electionInfo() = ElectionInfo(
+        "SF24-PrecinctOA", auditType, ncards(), contestsUA.size, cvrsContainUndervotes = true,
+        mvrSource = mvrSource
+    )
+
+    override fun cardStyles() = null // cardStyles
+    override fun cardPools() = if (auditType.isOA()) cardPoolBuilders else null
+    override fun contestsUA() = contestsUA
+    override fun cards() = createCards(auditType)
+    override fun ncards() = ncards
+
+    fun createCards(auditType: AuditType): CloseableIterator<CardWithBatchName> {
+        val cvrExportIter = cvrExportCsvIterator(cvrExportCsv)
+        val poolMap = cardPools()?.associateBy { it.name() } ?: emptyMap()
+        val poolCounts = mutableMapOf<String, Int>() // to assign index within the poool
+        val convertPoolIds = auditType.isOA()
+        var countIndex = 0
+
+        // TODO compare to CreateSfElection.createCards(); replacing CvrExportToCardAdapter and merge
+        // converts CvrExport to CardWithBatchName, adds poolId, styleName, location
+        // val cardIter = CvrExportToCardAdapter(cvrExportIter, cardPools(), auditType.isOA())
+
+        val transformer = TransformingIterator<CvrExport, CardWithBatchName>(cvrExportIter) { cvrExport ->
+            val pool = if (cvrExport.group != 1) null else {
+                val cardStyle = cardStyleMap[cvrExport.votes.keys]!!
+                val poolName = poolName(cvrExport.precinctPortionId, cardStyle)
+                cardPoolMapByName[poolName]!!
+            }
+            val poolId = pool?.poolId
+
+            val hasCvr = auditType.isClca() || (auditType.isOA() && poolId == null)
+            val votes = if (hasCvr) cvrExport.votes else null  // removes votes for pooled data
+
+            // Add location as poolName + index
+            val location = if (!convertPoolIds || pool == null) null else {
+                val poolCount =  poolCounts.getOrPut(pool.name()) { 0 }
+                poolCounts[pool.name()] = poolCount + 1
+                "${pool.name()} position${poolCount+1}"
+            }
+
+            CardWithBatchName(
+                cvrExport.id,
+                location,
+                countIndex++,
+                0,
+                phantom = false,
+                votes =  votes,
+                poolId = poolId,
+                styleName = pool?.name() ?: CardStyle.fromCvr,
+            )
+        }
+
+        return transformer
+    }
+
+    // TODO add optional fuzz or some other error method?
+    // the cvrExports are the private mvrs; must be in same order as createCards
+    override fun createUnsortedMvrsExternal() = null
+    override fun createUnsortedMvrsInternal(): List<CardWithBatchName> {
+        val cvrExportIter = cvrExportCsvIterator(cvrExportCsv)
+        val cardIter = CvrExportToCardAdapter(cvrExportIter, cardPools(), auditType.isOA())
+
+        val unsortedMvrs = mutableListOf<CardWithBatchName>()
+        cardIter.use { iter ->
+            while( iter.hasNext()) { unsortedMvrs.add (iter.next()) }
+        }
+        return unsortedMvrs
+    }
+}

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/MakeElectionPrecinctOA.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/MakeElectionPrecinctOA.kt
@@ -41,7 +41,7 @@ class MakeElectionPrecinctOA {
 
     val creation = AuditCreationConfig(AuditType.ONEAUDIT, riskLimit=.05,)
     val round = AuditRoundConfig(
-        SimulationControl(nsimTrials = 22),
+        SimulationControl(nsimTrials = 2),
         ContestSampleControl(minRecountMargin = .005, minMargin=0.0, contestSampleCutoff = 2500, auditSampleCutoff = 5000),
         ClcaConfig(fuzzMvrs=.001), null)
 
@@ -203,16 +203,6 @@ class CreateSfprecinctOA(
             // val poolName = cvrExport.poolKey()  // TODO HEY poolKey()
             val pool = if (cvrExport.group != 1) null else poolMap[ precinctName ]
             val poolId = pool?.poolId
-
-            if (cvrExport.id == "26-143-00026_00143_000127") {
-                val wtf = cvrExport.votes.keys.toList().sum()
-                println("${cvrExport.votes.keys} sum = $wtf")
-                val hash = cvrExport.votes.keys.hashCode()
-                println(hash)
-                val pool = cardStyleMap[cvrExport.votes.keys]
-                println(pool)
-                print("")
-            }
 
             val style = if (cvrExport.group != 1) null else cardStyleMap[cvrExport.votes.keys]!!
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/EstimateAudit.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/EstimateAudit.kt
@@ -22,6 +22,8 @@ import org.cryptobiotic.rlauxe.util.dfn
 import org.cryptobiotic.rlauxe.util.margin2mean
 import org.cryptobiotic.rlauxe.util.roundUp
 import org.cryptobiotic.rlauxe.persist.CardManifest
+import org.cryptobiotic.rlauxe.persist.Publisher
+import org.cryptobiotic.rlauxe.persist.csv.writeCardCsvFile
 import kotlin.Double
 import kotlin.Int
 import kotlin.math.abs
@@ -43,6 +45,7 @@ private val showWork = false
 //   assertionRound.estimationResult = estimationResult
 
 class EstimateAudit(
+    val auditdir: String,
     val config: Config,
     val roundIdx: Int,
     val contests: List<ContestRound>,
@@ -67,7 +70,7 @@ class EstimateAudit(
         // each trial is running all the contests in the round (but only the minAssertion)
         val ntrials = if (auditType.isClca()) 1 else config.round.simulation.nsimTrials
         repeat(ntrials) { run ->
-            tasks.add(AuditTrialTask(roundIdx, run+1, config, contestsToAudit, pools, batches, cardManifest))
+            tasks.add(AuditTrialTask(auditdir, roundIdx, run+1, config, contestsToAudit, pools, batches, cardManifest))
         }
         val trialResults: List<List<AssertionTrialIF>> = ConcurrentTaskRunner<List<AssertionTrialIF>>().run(tasks, nthreads)
 
@@ -146,18 +149,21 @@ class EstimateAudit(
 
 // 1 trial, all contests
 class AuditTrialTask(
+    val auditdir: String,
     val roundIdx: Int,
     val run: Int,
     val config: Config,
     val contestsToAudit: List<ContestRound>,
     val pools: List<CardPool>?,
     val batches: List<CardStyleIF>?,
-    val cardManifest: CardManifest) : ConcurrentTask<List<AssertionTrialIF>> {
+    val cardManifest: CardManifest
+) : ConcurrentTask<List<AssertionTrialIF>> {
 
     override fun name() = "roundIdx $roundIdx Run $run"
 
     override fun run(): List<AssertionTrialIF> {
         val stopwatch = Stopwatch()
+        val simMvrs = mutableListOf<AuditableCard>()
 
         // TODO use VunderPoolsFuzzer when cvrsContainUndervotes = false
         // used for OA and Polling; different simulated pool data each run; TODO could use VunderPoolsFuzzer
@@ -177,7 +183,6 @@ class AuditTrialTask(
         }
 
         var cardSortedIndex = 1 // 1 based
-
         var countEstimatedCards = 0
         var countPoolCards = 0
         cardManifest.cards.iterator().use { sortedCardIter ->
@@ -191,7 +196,7 @@ class AuditTrialTask(
                     (card.poolId() != null && vunderPools != null) -> vunderPools.simulatePooledCard(card)
                     (vunderBatches != null) -> vunderBatches.simulatePooledCard(card)
                     (onePool != null) -> onePool.simulatePooledCard(card)
-                    else -> null
+                    else -> card // TODO was null; wtf ??
                 }
 
                 var include = false
@@ -207,15 +212,26 @@ class AuditTrialTask(
                     // sampledCards.add(card)
                     countEstimatedCards++
                     if (card.poolId() != null) countPoolCards++
+                    if (keepSimMvrs) simMvrs.add(mvr)
                 }
                 cardSortedIndex++
             }
         }
         logger.debug { "roundIdx $roundIdx $run countEstimatedCards=$countEstimatedCards took $stopwatch" }
 
+        if (keepSimMvrs) {
+            // hmm on subsequent rounds, wont you get diffferent simulation on previous cards ?
+            // yes but we skip cards already used using prevSamplesUsed ....
+            val publisher = Publisher(auditdir)
+            writeCardCsvFile(simMvrs , publisher.estMvrsFile(roundIdx, run))
+        }
+
         return contestTrials
     }
 }
+
+private val keepSimMvrs = false
+
 
 // 1 trial, 1 Clca contest
 class ContestClcaTrial(val run: Int,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/Vunder.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/Vunder.kt
@@ -36,7 +36,7 @@ data class Vunder(val contestId: Int, val poolId: Int?, val voteCounts: List<Pai
     }
 
     override fun toString() = buildString {
-        append("id=$contestId, voteForN=$voteForN, votes=${cands()}, nvotes=$nvotes ncards=$ncards, undervotes=$undervotes, missing=$missing")
+        append("Vunder contestId=$contestId, voteForN=$voteForN, votes=${cands()}, nvotes=$nvotes ncards=$ncards, undervotes=$undervotes, missing=$missing")
     }
 
     companion object {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/VunderPools.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/VunderPools.kt
@@ -4,6 +4,7 @@ import org.cryptobiotic.rlauxe.audit.AuditableCard
 import org.cryptobiotic.rlauxe.audit.CardStyleIF
 import org.cryptobiotic.rlauxe.audit.CardPool
 import org.cryptobiotic.rlauxe.core.ContestWithAssertions
+import org.cryptobiotic.rlauxe.core.Cvr
 import org.cryptobiotic.rlauxe.util.AuditableCardBuilder
 import org.cryptobiotic.rlauxe.util.CvrBuilder2
 import kotlin.collections.get
@@ -75,6 +76,22 @@ class VunderPool(vunders: Map<Int, Vunder>, val poolName: String, val poolId: In
             return VunderPool(vunders, "all", poolId, true)
         }
     }
+}
+
+// for viewer
+fun makeCvrsForVunderPool(pool: CardPool, vunderpool: VunderPool): List<Cvr> {
+    val rcvrs = mutableListOf<Cvr>()
+    var count = 1
+    while (!vunderpool.done()) {
+        val cvrId = "${pool.name()}-${count}"
+        val cvb2 = CvrBuilder2(cvrId, phantom = false, poolId = pool.poolId)
+        vunderpool.simulatePooledCvr(cvb2)
+        rcvrs.add(cvb2.build())
+        count++
+    }
+
+    rcvrs.shuffle()
+    return rcvrs
 }
 
 // for multiple batches, multiple contests and one "pool" of subtotaled votes

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/Publisher.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/Publisher.kt
@@ -96,6 +96,12 @@ class Publisher(val auditDir: String) {
         return "$dir/sampleMvrs$round.csv"
     }
 
+    fun estMvrsFile(round: Int, trial: Int): String {
+        val dir = "$auditDir/round$round"
+        validateOutputDir(Path.of(dir), ErrorMessages("sampleMvrsFile"))
+        return "$dir/estMvrs$trial.csv"
+    }
+
     // what round are we on?
     fun currentRound(): Int {
         var roundIdx = 1

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Utils.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/util/Utils.kt
@@ -44,6 +44,7 @@ fun df(d: Double?) = if (d==null) "N/A" else "%6.4f".format(d)
 fun dfn(d: Double?, n: Int) = if (d==null) "N/A" else "%${n+2}.${n}f".format(d)
 fun pfn(d: Double?, n: Int=4) = if (d==null) "N/A" else "%${n+2}.${n}f%%".format(100*d)
 fun nfn(i: Int, n: Int) = "%${n}d".format(i)
+fun nfz(i: Int, n: Int) = i.toString().padStart(n, '0')
 fun sfn(s: String, n: Int) = "%${n}s".format(s)  // right justify in width n
 fun trunc(s: String, n:Int) : String {
     if (s.length > n) return s.substring(0,n)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditWorkflow.kt
@@ -43,6 +43,7 @@ import org.cryptobiotic.rlauxe.util.Stopwatch
 
         // estimate how many samples are needed for each contest, to satisfy the risk function,
         val estimate = EstimateAudit(
+            auditdir = mvrManager.auditdir(),
             config,
             auditRound.roundIdx,
             auditRound.contestRounds,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManager.kt
@@ -14,6 +14,7 @@ interface MvrManager {
     fun batches(): List<CardStyleIF>?
     fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCard>>  // Pair(mvr, cvr)
     fun writeMvrsForRound(round: Int): Int
+    fun auditdir() = "none"
 }
 
 // when the MvrManager supplies the audited mvrs, its a test

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManager.kt
@@ -30,6 +30,7 @@ open class PersistedMvrManager(val auditRecord: AuditRecord, val mvrWrite: Boole
     override fun sortedManifest() = sortedManifest
     override fun batches() = auditRecord.readCardStyles()
     override fun pools() = auditRecord.readCardPools() // could test if batches are cardPools
+    override fun auditdir() = auditRecord.location
 
     override fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCard>>  {
         val mvrsForRound = readMvrsForRound(round)
@@ -113,8 +114,6 @@ open class PersistedMvrManager(val auditRecord: AuditRecord, val mvrWrite: Boole
         writeCardCsvFile(sampledMvrs , publisher.sampleMvrsFile(round))
         logger.info{"enterMvrs write sampledMvrs to '${publisher.sampleMvrsFile(round)}' for round $round"}
 
-        // TODO AuditRecord.previousMvrs do we really need to do this ??
-        // sampledMvrs.forEach { auditRecord.previousMvrs[it.prn] = it } // cumulative
         return true
     }
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
@@ -128,6 +128,7 @@ class TestConsistentSampling {
             //   useAssertionRound.estNewMvrs = newMvrs
             //   assertionRound.estimationResult = estimationResult
             val estimate = EstimateAudit(
+                mvrManager.auditdir(),
                 Config.from(AuditType.CLCA),
                 auditRound.roundIdx,
                 auditRound.contestRounds,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestOneShot.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestOneShot.kt
@@ -9,7 +9,7 @@ class TestOneShot {
 
     @Test
     fun testOneShot() {
-        val auditdir = "$testdataDir/cases/sf2024/oap/audit"
+        val auditdir = "$testdataDir/cases/sf2024/oa/audit"
         val record = AuditRecord.readFrom(auditdir)
         if (record == null) throw RuntimeException("record is null")
         require (record is AuditRecord)
@@ -32,6 +32,7 @@ class TestOneShot {
         val roundIdx = 4
         val auditRound = record.rounds[roundIdx-1]
         val estaudit = EstimateAudit(
+            auditdir,
             record.config,
             roundIdx,
             auditRound.contestRounds,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestVunder.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestVunder.kt
@@ -44,10 +44,10 @@ class TestVunder {
             println("  vunders= ${vunders.cands()}")
         }
 
-        assertEquals("id=0, voteForN=1, votes={0=200, 1=123, 2=17}, nvotes=340 ncards=391, undervotes=51, missing=0", contestVotes[0].toString())
+        assertEquals("Vunder contestId=0, voteForN=1, votes={0=200, 1=123, 2=17}, nvotes=340 ncards=391, undervotes=51, missing=0", contestVotes[0].toString())
         assertTrue(checkEquivilentVotes(mapOf(0 to 200, 1 to 123, 2 to 17), contestVotes[0]!!.cands()))
 
-        assertEquals("id=1, voteForN=1, votes={0=71, 1=123, 2=3}, nvotes=197 ncards=248, undervotes=51, missing=0", contestVotes[1].toString())
+        assertEquals("Vunder contestId=1, voteForN=1, votes={0=71, 1=123, 2=3}, nvotes=197 ncards=248, undervotes=51, missing=0", contestVotes[1].toString())
         assertTrue(checkEquivilentVotes(mapOf(0 to 71, 1 to 123, 2 to 3), contestVotes[1]!!.cands()))
     }
 
@@ -74,7 +74,7 @@ class TestVunder {
         }
 
         assertTrue(checkEquivilentVotes(mapOf(0 to 200, 1 to 123, 2 to 17), vunders[0]!!.cands()))
-        assertEquals("id=0, voteForN=2, votes={0=200, 1=123, 2=17}, nvotes=340 ncards=391, undervotes=51, missing=196", vunders[0]!!.toString())
+        assertEquals("Vunder contestId=0, voteForN=2, votes={0=200, 1=123, 2=17}, nvotes=340 ncards=391, undervotes=51, missing=196", vunders[0]!!.toString())
     }
 
     // checkEquivilentVotes(vunder.candVotes, contestTab.votes)

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/ClcaDistributions.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/ClcaDistributions.kt
@@ -83,7 +83,7 @@ class ClcaDistributions {
         val auditRound = AuditRound(1, contestRounds = contestRounds, samplePrns = emptyList())
 
         // just want the sample estimation stuff
-        val optimistic = EstimateAudit(config,  auditRound.roundIdx, auditRound.contestRounds, mvrManager.pools(), mvrManager.batches(), mvrManager.sortedManifest())
+        val optimistic = EstimateAudit("none", config,  auditRound.roundIdx, auditRound.contestRounds, mvrManager.pools(), mvrManager.batches(), mvrManager.sortedManifest())
         return optimistic.run()
 
         /* was


### PR DESCRIPTION
EstimateAudit bug with mvr set to  null (!)
EstimateAudit can write out mvrs used, for debugging

fun nfz() for leading zeros