### PR TITLE
Avoid confusing branding of "ranked choice"

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ The Rlauxe library is an independent implementation of the SHANGRLA framework, b
 
 The [SHANGRLA python library](https://github.com/pbstark/SHANGRLA) is the work of Philip Stark and collaborators, released under the AGPL-3.0 license.
 
-Rlauxe uses the [Raire Java library](https://github.com/DemocracyDevelopers/raire-java) for Ranked Choice contests, also called Instant runoff Voting (IRV).
+Rlauxe uses the [Raire Java library](https://github.com/DemocracyDevelopers/raire-java) for Instant runoff Voting (IRV) contests.
 Raire-Java is Copyright 2023-2025 Democracy Developers. It is based on software (c) Michelle Blom in C++
 https://github.com/michelleblom/audit-irv-cp/tree/raire-branch, and released under the GNU General Public License v3.0.
 

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/dominion/DominionCvrExportJson.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/dominion/DominionCvrExportJson.kt
@@ -168,7 +168,7 @@ data class Contest(
 // CandidateId: indicates the candidate the mark is for (if a write-in position is resolved to a
 //   qualified write-in the candidate id will point to a qualified write-in).
 // PartyId: indicates party affiliation. If not party affiliation then this will be 0.
-// Rank: indicates rank; will be 1 by default, will only contain values higher than 1 if ranked choice voting is used.
+// Rank: indicates rank; will be 1 by default, will only contain values higher than 1 if ranked voting is used.
 // WriteinIndex: if mark is for write-in position (or qualified write-in) this attribute indicates which
 //   write-in position in the contest (0 means first, 1 means second position, etc.)
 // MarkDensity: percentage that voting box was filled.

--- a/docs/Raire.md
+++ b/docs/Raire.md
@@ -1,7 +1,7 @@
 # Instant Runoff Voting (IRV)
 02/21/2026
 
-Also known as Ranked Choice Voting, this allows voters to rank their choices by preference.
+Instant Runoff Voting (IRV) allows voters to rank their choices by preference.
 In each round, the candidate with the fewest first-preferences (among the remaining candidates) is eliminated.
 This continues until only one candidate is left. Only 1 winner is allowed.
 


### PR DESCRIPTION
It is best to avoid using the confusing term "ranked choice voting", especially for technical work where
the distinctions are critical.
The RCV term is not consistently defined, but is commonly used for IRV, STV, and the other terribly *anti-proportional*
multi-winner method used in Utah. This code only applies to IRV, so using the RCV term isn't appropriate.
