### PR TITLE
optimize consistentSampling time (2)

### DIFF
--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSf2024OneAuditIrv.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSf2024OneAuditIrv.kt
@@ -23,6 +23,7 @@ import org.cryptobiotic.rlauxe.util.mean2margin
 import org.cryptobiotic.rlauxe.util.pfn
 import org.cryptobiotic.rlauxe.util.tabulateAuditableCards
 import org.cryptobiotic.rlauxe.verify.AssortAvg
+import org.cryptobiotic.rlauxe.workflow.PersistedMvrManager
 import org.cryptobiotic.rlauxe.workflow.readSortedManifest
 import org.junit.jupiter.api.Assertions.assertEquals
 import kotlin.math.roundToInt
@@ -40,7 +41,8 @@ class TestSf2024OneAuditIrv() {
     init {
         val auditdir = "$testdataDir/cases/sf2024/oa/audit"
         val auditRecord = AuditRecord.read(auditdir) as AuditRecord
-        cardManifest = auditRecord.readSortedManifest()
+        val mvrManager = PersistedMvrManager(auditRecord)
+        cardManifest = mvrManager.sortedManifest()
         config = auditRecord.config
         contests = auditRecord.contests
         infos = contests.map{ it.contest.info() }.associateBy { it.id }

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfElectionVunderFuzz.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfElectionVunderFuzz.kt
@@ -33,7 +33,8 @@ class TestSfElectionVunderFuzz {
     init {
         val auditRecord = AuditRecord.read(auditdir) as AuditRecord
         mvrManager = PersistedMvrManager(auditRecord)
-        cardManifest = auditRecord.readSortedManifest()
+        val mvrManager = PersistedMvrManager(auditRecord)
+        cardManifest = mvrManager.sortedManifest()
         config = auditRecord.config
         contests = auditRecord.contests
         infos = contests.map { it.contest.info() }.associateBy { it.id }

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -1,7 +1,8 @@
 plugins {
     kotlin("jvm")
-    // alias(libs.plugins.kotlin.jvm)
     alias(libs.plugins.kotlinx.serialization)
+    id("com.google.protobuf") version "0.10.0"
+
     id ("java-test-fixtures")
     `java-test-fixtures`
 }
@@ -19,6 +20,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
     implementation(libs.kotlinx.serialization.protobuf)
     implementation(libs.bundles.logging)
+    implementation(libs.google.protobuf)
 
     testImplementation(platform("org.junit:junit-bom:5.13.4"))
     testImplementation("org.junit.jupiter:junit-jupiter")
@@ -38,6 +40,21 @@ dependencies {
     testImplementation(libs.kotest.property)
     testImplementation(libs.kotlinx.coroutines.test)
     testImplementation(libs.logback.classic)
+}
+
+protobuf {
+    protoc {
+        path = "/home/stormy/install/protoc/bin/protoc"
+    }
+
+    generateProtoTasks {
+        all().forEach { task ->
+            task.builtins {
+                // Generates idiomatic Kotlin DSLs
+                create("kotlin")
+            }
+        }
+    }
 }
 
 tasks.test {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCard.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCard.kt
@@ -31,7 +31,7 @@ import kotlin.ranges.until
 //                                      // hasContest: maybe a bitMap? and factor out into a StyleIF?
 
 
-interface AuditableCardIF: CardIF, CvrIF {
+interface AuditableCardIF: CardIF, CvrIF, SamplingCardIF {
     fun style(): StyleIF            // "fromCvr" if no cardStyle and its from a CVR (then votes is non null)
     fun possibleContests() : IntArray
     // TODO is hasStyle really card specific? contest? audit?
@@ -42,145 +42,10 @@ interface AuditableCardIF: CardIF, CvrIF {
     fun toCvr(): Cvr  // TODO can we get rid of?
 }
 
-class AuditableCardProto(
-    val id: String, // enough info to find the card for a manual audit.
-    val location: String?, // enough info to find the card for a manual audit.
-    val index: Int,  // index into the original, canonical list of cards
-    val prn: Long,   // psuedo random number
-    val phantom: Boolean,
-    val poolId: Int?, // must be set if its from a CardPool
-    val contestIds: IntArray,
-    val contestStarts: IntArray,
-    val candidates: IntArray,
-    val style: StyleIF
-): AuditableCardIF {
-    val useCvr = CardStyle.useVotes(style.name())
-
-    val votes: Map<Int, IntArray>? by lazy {
-        if (contestIds.isEmpty()) null else {
-            val lastIndex = contestIds.size - 1
-            val makeVotes = mutableMapOf<Int, IntArray>()
-            contestIds.forEachIndexed { index, contestId ->
-                val start = contestStarts[index]
-                val end = if (index < lastIndex) contestStarts[index + 1] else candidates.size
-                if (start > end || end > candidates.size)
-                makeVotes[contestId] = candidates.sliceArray(start until end)
-            }
-            makeVotes.toMap()
-        }
-    }
-
-    // constructor(card: CardWithBatchName, cardStyle: StyleIF): this(card.id, card.location, card.index, card.prn, card.phantom, card.poolId, card.votes, cardStyle)
-    // constructor(cvr: Cvr, index: Int, prn: Long): this(cvr.id, null, index, prn, cvr.phantom, cvr.poolId, cvr.votes, style = CardStyle.fromCvrBatch)
-
-    override fun hasContest(contestId: Int): Boolean {
-        return if (!useCvr) style.hasContest(contestId)
-        else contestIds.contains(contestId)
-    }
-
-    override fun possibleContests() : IntArray {
-        return when {
-            CardStyle.useVotes(style.name()) -> votes!!.keys.toList().sorted().toIntArray() // assumes cvrsContainUndervotes, use cardStyle if not.
-            else -> style.possibleContests().toList().sorted().toIntArray()
-        }
-    }
-
-    override fun id() = id
-    override fun location() = location ?: id()
-    override fun index() = index
-    override fun prn() = prn
-    override fun phantom() = phantom
-    override fun votes() = votes
-    override fun votes(contestId: Int): IntArray? = votes?.get(contestId)
-    override fun poolId(): Int? = poolId
-    override fun styleName() = style.name()
-    override fun style() = style
-    override fun hasStyle() = style.hasExactContests()
-
-    override fun toCvr(): Cvr {
-        TODO("Not yet implemented")
-    }
-
-    override fun hasMarkFor(contestId: Int, candidateId: Int): Int {
-        val contestVotes = votes(contestId)
-        return if (contestVotes == null) 0
-        else if (contestVotes.contains(candidateId)) 1 else 0
-    }
-
-    /*
-    override fun votes(contestId: Int): IntArray? {
-        // or turn back into a map lazily ??
-        // HEY consistent sampling only wants hasContest, optimize for that...
-        val contestIdx = contestIds.indexOf(contestId)
-        val start = contestStarts[contestIdx]
-        val end = contestStarts[contestIdx+1]
-        return candidates // .subarray(start, end)
-    } */
-
-    override fun equals(other: Any?): Boolean {
-        if (this === other) return true
-        if (other !is AuditableCardProto) return false
-
-        if (index != other.index) return false
-        if (prn != other.prn) return false
-        if (phantom != other.phantom) return false
-        if (poolId != other.poolId) return false
-        if (id != other.id) return false
-        if (location != other.location) return false
-        if (!contestIds.contentEquals(other.contestIds)) return false
-        if (!contestStarts.contentEquals(other.contestStarts)) return false
-        if (!candidates.contentEquals(other.candidates)) return false
-        if (style != other.style) return false
-        if ((votes == null) != (other.votes == null)) return false
-        if (votes != null) {
-            for ((contestId, candidates) in votes) {
-                val otherCands = other.votes!![contestId]
-                if (!candidates.contentEquals(otherCands)) return false
-            }
-        }
-
-        return true
-    }
-
-    override fun hashCode(): Int {
-        var result = index
-        result = 31 * result + prn.hashCode()
-        result = 31 * result + phantom.hashCode()
-        result = 31 * result + (poolId ?: 0)
-        result = 31 * result + id.hashCode()
-        result = 31 * result + (location?.hashCode() ?: 0)
-        result = 31 * result + contestIds.contentHashCode()
-        result = 31 * result + contestStarts.contentHashCode()
-        result = 31 * result + candidates.contentHashCode()
-        result = 31 * result + style.hashCode()
-        result = 31 * result + votes.hashCode()
-        return result
-    }
-
-    override fun toString()= buildString {
-        appendLine("id='$id', location=$location, index=$index, prn=$prn, phantom=$phantom, poolId=$poolId, ")
-        appendLine("   contestIds=${contestIds.contentToString()}, contestStarts=${contestStarts.contentToString()}, ")
-        appendLine("   candidates=${candidates.contentToString()}, style=$style, votes=$votes")
-    }
-
-    companion object {
-        // how much does a copy cost?
-        fun from(pcard: ProtoCard, styles: Map<String, StyleIF>) =
-            AuditableCardProto(
-                pcard.id,
-                if (pcard.location == pcard.id) null else pcard.location,
-                pcard.index,
-                pcard.prn,
-                pcard.phantom,
-                pcard.poolId,
-                pcard.contestIds,  // not making copies
-                pcard.contestStarts,
-                pcard.candidates,
-                styles[pcard.styleName] ?: CardStyle.fromCvrBatch,
-            )
-    }
+interface SamplingCardIF {
+    fun hasContest(contestId: Int): Boolean
+    fun prn(): Long
 }
-
 
 // The information we have on each physical card in the audit; the complete set is the CardManifest.
 
@@ -243,7 +108,6 @@ data class AuditableCard (
             else -> style.possibleContests().toList().sorted().toIntArray()
         }
     }
-
 
     //// Kotlin data class doesnt handle IntArray correctly
     override fun equals(other: Any?): Boolean {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAuditRound.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAuditRound.kt
@@ -16,6 +16,7 @@ import org.cryptobiotic.rlauxe.util.Stopwatch
 import org.cryptobiotic.rlauxe.verify.VerifyAuditRoundCommitment
 import org.cryptobiotic.rlauxe.verify.VerifyResults
 import org.cryptobiotic.rlauxe.verify.preAuditContestCheck
+import org.cryptobiotic.rlauxe.workflow.PersistedMvrManager
 import org.cryptobiotic.rlauxe.workflow.PersistedWorkflow
 import java.nio.file.Files.notExists
 import java.nio.file.Path
@@ -149,24 +150,21 @@ fun runAllRoundsAndVerify(auditdir: String, maxRounds:Int=7, verify:Boolean = tr
 
 // for testing
 fun resampleAndSaveResults(auditdir: String): Boolean {
-    val auditRecord = AuditRecord.read(auditdir)!!
-    return resampleAndSaveResults(auditdir, auditRecord.rounds.last() as AuditRound)
+    val auditRecord = AuditRecord.read(auditdir)!! as AuditRecord
+    return resampleAndSaveResults(auditRecord, auditRecord.rounds.last())
 }
 
 // for viewer
-fun resampleAndSaveResults(auditdir: String, lastRound: AuditRound): Boolean {
+fun resampleAndSaveResults(auditRecord: AuditRecord, lastRound: AuditRound): Boolean {
     try {
-        val auditRecord = AuditRecord.read(auditdir)!!
+        val mvrManager = PersistedMvrManager(auditRecord)
 
         // resample
         val previousSamples = auditRecord.rounds.previousSamplePrns(lastRound.roundIdx)
-        // TODO removeContestsAndSample or consistentSampling??
-        // removeContestsAndSample(auditRecord.config.round.sampling, auditRecord.readSortedManifest(), lastRound, previousSamples)
-        val sortedManifest = auditRecord.readSortedManifest(auditRecord.readCardStyles())
-        chooseSamples(auditRecord.config.sampling, lastRound, sortedManifest, previousSamples)
+        chooseSamples(auditRecord.config.sampling, lastRound, mvrManager.samplingCards(), previousSamples)
 
         // writeAuditState
-        val publisher = Publisher(auditdir)
+        val publisher = Publisher(auditRecord.location)
         writeAuditRoundJsonFile(lastRound, publisher.auditEstFile(lastRound.roundIdx))
         logger.info {"resampleAndRun writeAuditEstimation to ${publisher.auditEstFile(lastRound.roundIdx)}"}
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ContestWithAssertions.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ContestWithAssertions.kt
@@ -2,6 +2,7 @@ package org.cryptobiotic.rlauxe.core
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.audit.AuditableCard
+import org.cryptobiotic.rlauxe.audit.AuditableCardIF
 import org.cryptobiotic.rlauxe.betting.TestH0Status
 import org.cryptobiotic.rlauxe.dhondt.DHondtContest
 import org.cryptobiotic.rlauxe.util.CloseableIterator
@@ -212,7 +213,7 @@ open class ContestWithAssertions(
         private val logger = KotlinLogging.logger("ContestUnderAudit")
 
         // make contestUA from contests, generate Npop by reading cards
-        fun make(contests: List<ContestIF>, cards: CloseableIterator<AuditableCard>, isClca: Boolean, hasStyle: Boolean): List<ContestWithAssertions> {
+        fun make(contests: List<ContestIF>, cards: CloseableIterator<AuditableCardIF>, isClca: Boolean, hasStyle: Boolean): List<ContestWithAssertions> {
             val infos = contests.map { it.info() }.associateBy { it.id }
             val contestTabs = tabulateAuditableCards(cards, infos)
             val npopMap = contestTabs.mapValues { it.value.ncardsTabulated }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ConsistentSampling.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ConsistentSampling.kt
@@ -4,8 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.audit.*
 import org.cryptobiotic.rlauxe.betting.TestH0Status
 import org.cryptobiotic.rlauxe.util.Stopwatch
-import org.cryptobiotic.rlauxe.persist.CardManifest
-import kotlin.collections.set
+import org.cryptobiotic.rlauxe.util.CloseableIterable
 
 private val verifyMaxIndex = false
 private val logger = KotlinLogging.logger("ConsistentSampling")
@@ -14,7 +13,7 @@ private val logger = KotlinLogging.logger("ConsistentSampling")
 // also called by rlauxe-viewer
 fun removeContestsAndSample(
     sampling: ContestSampleControl,
-    sortedManifest: CardManifest,
+    samplingCards: CloseableIterable<SamplingCardIF>,
     auditRound: AuditRoundIF,
     previousSamples: Set<Long>, // all previous prns ever sampled
 ) {
@@ -33,11 +32,11 @@ fun removeContestsAndSample(
         }
     }
 
-    var lastCardsUsed : List<AuditableCardIF> = emptyList()
+    // var lastCardsUsed : List<AuditableCardIF> = emptyList()
     val contestsNotDone = auditRound.contestRounds.filter { !it.done }.toMutableList()
     while (contestsNotDone.isNotEmpty()) {
         // create a strawman sample
-        lastCardsUsed = chooseSamples(sampling, auditRound, sortedManifest, previousSamples)
+        chooseSamples(sampling, auditRound, samplingCards, previousSamples)
 
         // enforce sample limits
         val removeContests = checkSampleLimits(sampling, auditRound, contestsNotDone)
@@ -46,7 +45,7 @@ fun removeContestsAndSample(
         // do it again
     }
 
-    // debug
+    /* debug
     // lastCardsUsed = consistentSampling( auditRound, sortedManifest, previousSamples)
 
     if (verifyMaxIndex) { // debugging, probably dont need this anymore
@@ -64,7 +63,7 @@ fun removeContestsAndSample(
             println("contest ${it.id} countInSample=${countSamples[it.id]} maxSampleAllowed=${it.maxSampleAllowed} est=${it.estMvrs} estNew=${it.estNewMvrs}")
             require (countSamples[it.id]!! >= it.estMvrs )
         }
-    }
+    } */
 
     logger.debug{"sampleAndRemoveContests success on ${auditRound.contestRounds.count { !it.done }} contests: round ${auditRound.roundIdx} took ${stopwatch}"}
 }
@@ -145,13 +144,13 @@ private fun checkSampleLimits(
 fun chooseSamples(
     sampling: ContestSampleControl,
     auditRound: AuditRoundIF,
-    sortedManifest: CardManifest,
+    samplingCards: CloseableIterable<SamplingCardIF>,
     previousSamples: Set<Long> = emptySet(), // all previous prns ever sampled
-): List<AuditableCardIF> {
+): List<Long> {
     if (sampling.sampling == Sampling.consistent || (auditRound.roundIdx == 1 && !auditRound.auditWasDone))
-        return consistentSampling(auditRound, sortedManifest, previousSamples)
+        return consistentSampling(auditRound, samplingCards, previousSamples)
     else
-        return uniformSampling(auditRound, sortedManifest, previousSamples)
+        return uniformSampling(auditRound, samplingCards, previousSamples)
 }
 
 // From Consistent Sampling with Replacement, Ronald Rivest, August 31, 2018
@@ -165,9 +164,9 @@ fun chooseSamples(
 
 fun consistentSampling(
     auditRound: AuditRoundIF,
-    sortedManifest: CardManifest,
+    samplingCards: CloseableIterable<SamplingCardIF>,
     previousSamples: Set<Long> = emptySet(), // all previous prns ever sampled
-): List<AuditableCardIF>  // debugging
+): List<Long>  // debugging
 {
     val stopwatch = Stopwatch()
     val skippedContests = mutableListOf<ContestRound>()
@@ -189,20 +188,20 @@ fun consistentSampling(
         it.haveNewSampleSize = 0
     }
 
-    val sampledCards = mutableListOf<AuditableCardIF>()
+    val sampledPrns = mutableListOf<Long>()
     var cardIndex = 0  // track maximum index (not done yet)
 
     var maxNewSamples = auditRound.auditorWantNewMvrs
     if (maxNewSamples == null || maxNewSamples < 0) maxNewSamples = Int.MAX_VALUE
 
-    val sortedCardIter = sortedManifest.cards.iterator()
+    val samplingCardIter = samplingCards.iterator()
     while (
-        sortedCardIter.hasNext() &&
-        sampledCards.size < maxNewSamples &&
+        samplingCardIter.hasNext() &&
+        sampledPrns.size < maxNewSamples &&
         contestsIncluded.any { it.haveSampleSize < it.estMvrs }
     ) {
         // get the next card in sorted order
-        val card = sortedCardIter.next()
+        val card = samplingCardIter.next()
 
         // do we want it ?
         var include = false
@@ -214,7 +213,7 @@ fun consistentSampling(
         }
 
         if (include) {
-            sampledCards.add(card) // TODO just save the prns?
+            sampledPrns.add(card.prn())
             //   If you assume that previousSamples had all contests audited, then previousSamples reflects ballots already audited,
             //   (even if not used for this contest), so you dont need to sample them again, so theyre not new.
             // TODO do all at once at the end for speed ??
@@ -232,7 +231,7 @@ fun consistentSampling(
                         contestRound.haveNewSampleSize++
                     }
                     // ok to use if we havent skipped any cards for this contest in its sequence
-                    contestRound.maxSampleAllowed = sampledCards.size
+                    contestRound.maxSampleAllowed = sampledPrns.size
                 } else {
                     // if card has contest but its not included in the sample, then continuity has been broken
                     skippedContests.add(contestRound)
@@ -270,19 +269,19 @@ fun consistentSampling(
     // if (debugConsistent) logger.info{"**consistentSampling haveSampleSize = $haveSampleSize, haveNewSamples = $haveNewSamples, newMvrs=$newMvrs"}
 
     // set the results into the auditRound direclty
-    auditRound.nmvrs = sampledCards.size
+    auditRound.nmvrs = sampledPrns.size
     auditRound.newmvrs = newMvrs
-    auditRound.samplePrns = sampledCards.map { it.prn() }
+    auditRound.samplePrns = sampledPrns
 
-    logger.info{" consistentSampling read $cardIndex and chose ${sampledCards.size} cards; took $stopwatch"}
-    return sampledCards
+    logger.info{" consistentSampling read $cardIndex and chose ${sampledPrns.size} cards; took $stopwatch"}
+    return sampledPrns
 }
 
 fun uniformSampling(
     auditRound: AuditRoundIF,
-    sortedManifest: CardManifest,
+    samplingCards: CloseableIterable<SamplingCardIF>,
     previousSamples: Set<Long> = emptySet(), // all previous prns ever sampled
-): List<AuditableCardIF> {
+): List<Long> {
 
     // ignore included flag, eliminate done
     val contestsIncluded = auditRound.contestRounds.filter { !it.done }
@@ -297,7 +296,7 @@ fun uniformSampling(
         it.haveNewSampleSize = 0
     }
 
-    val sampledCards = mutableListOf<AuditableCardIF>()
+    val sampledPrns = mutableListOf<Long>()
     var cardIndex = 0  // track maximum index (not done yet)
 
     val maxNewSamples = auditRound.auditorWantNewMvrs
@@ -307,14 +306,14 @@ fun uniformSampling(
     }
 
     // TODO on subsequent rounds, start from where you left off ??
-    val sortedCardIter = sortedManifest.cards.iterator()
+    val sortedCardIter = samplingCards.iterator()
     while (
         sortedCardIter.hasNext() &&
-        sampledCards.size < maxNewSamples
+        sampledPrns.size < maxNewSamples
     ) {
         // get the next card in sorted order
         val card = sortedCardIter.next()
-        sampledCards.add(card)
+        sampledPrns.add(card.prn())
 
         //   If you assume that previousSamples had all contests audited, then previousSamples reflects ballots already audited,
         //   (even if not used for this contest), so you dont need to sample them again, so theyre not new.
@@ -328,7 +327,7 @@ fun uniformSampling(
                 if (!previousSamples.contains(card.prn())) {
                     contest.haveNewSampleSize++
                 }
-                contest.maxSampleAllowed = sampledCards.size // probably not needed ??
+                contest.maxSampleAllowed = sampledPrns.size // probably not needed ??
             }
         }
 
@@ -336,11 +335,11 @@ fun uniformSampling(
     }
 
     // set the results into the auditRound direclty
-    auditRound.nmvrs = sampledCards.size
+    auditRound.nmvrs = sampledPrns.size
     auditRound.newmvrs = newMvrs
-    auditRound.samplePrns = sampledCards.map { it.prn() }
+    auditRound.samplePrns = sampledPrns
 
-    logger.info{" consistentSampling chose ${sampledCards.size} cards"}
-    return sampledCards
+    logger.info{" consistentSampling chose ${sampledPrns.size} cards"}
+    return sampledPrns
 }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/EstimateAudit.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/EstimateAudit.kt
@@ -51,7 +51,7 @@ class EstimateAudit(
     val roundIdx: Int,
     val contests: List<ContestRound>,
     val pools: List<CardPool>?,
-    val batches: List<StyleIF>?,
+    val styles: List<StyleIF>?,
     val cardManifest: CardManifest,
 ) {
     val auditType = config.auditType
@@ -71,7 +71,7 @@ class EstimateAudit(
         // each trial is running all the contests in the round (but only the minAssertion)
         val ntrials = if (auditType.isClca()) 1 else config.round.simulation.nsimTrials
         repeat(ntrials) { run ->
-            tasks.add(AuditTrialTask(auditdir, roundIdx, run+1, config, contestsToAudit, pools, batches, cardManifest))
+            tasks.add(AuditTrialTask(auditdir, roundIdx, run+1, config, contestsToAudit, pools, styles, cardManifest))
         }
         val trialResults: List<List<AssertionTrialIF>> = ConcurrentTaskRunner<List<AssertionTrialIF>>().run(tasks, nthreads)
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/AuditRecord.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/AuditRecord.kt
@@ -15,6 +15,7 @@ import org.cryptobiotic.rlauxe.audit.MergeBatchesIntoCardManifestIterable
 import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.audit.CardPool
 import org.cryptobiotic.rlauxe.audit.Config
+import org.cryptobiotic.rlauxe.audit.SamplingCardIF
 import org.cryptobiotic.rlauxe.persist.csv.readCardPoolCsvFile
 import org.cryptobiotic.rlauxe.persist.csv.readCardsCsvIterator
 import org.cryptobiotic.rlauxe.persist.json.*
@@ -31,8 +32,10 @@ interface AuditRecordIF {
     val contests: List<ContestWithAssertions>
     val rounds: List<AuditRoundIF>
 
-    fun readSortedManifest(): CardManifest
-    fun readSortedManifest(batches: List<StyleIF>?): CardManifest
+    // fun readSortedManifest(): CardManifest
+    fun readSortedManifest(styles: List<StyleIF>?): CardManifest
+    fun readSamplingCards(): CloseableIterable<SamplingCardIF>?
+
     fun readOneShotMvrs(): Map<Int, Int>
     fun readCardStyles(): List<StyleIF>?
     fun name(): String
@@ -52,20 +55,21 @@ open class AuditRecord(
     override fun auditdir() = location // it.location.substring(stateRecord.location.length)
     override fun name() = electionInfo.electionName // it.location.substring(stateRecord.location.length)
 
-    // for efficiency, batches can be read once and stored by the caller
-    override fun readSortedManifest(batches: List<StyleIF>?): CardManifest {
-        // merge batch references into the Card
+    override fun readSamplingCards(): CloseableIterable<SamplingCardIF>? = null
+
+    override fun readSortedManifest(styles: List<StyleIF>?): CardManifest {
+        // merge style references into the Card
         val mergedCards: CloseableIterable<AuditableCard> =
             MergeBatchesIntoCardManifestIterable(
                 CloseableIterable { readCardsCsvIterator(publisher.sortedCardsFile()) },
-                batches ?: emptyList(),
+                styles ?: emptyList(),
             )
         return CardManifest(mergedCards, electionInfo.totalCardCount)
     }
 
+    /*
     override fun readSortedManifest(): CardManifest {
         val batches = readCardPools() ?: readCardStyles() ?: emptyList() // pools are preferred
-        // merge batch references into the Card
         val mergedCards =
             MergeBatchesIntoCardManifestIterable(
                 CloseableIterable { readCardsCsvIterator(publisher.sortedCardsFile()) },
@@ -73,7 +77,7 @@ open class AuditRecord(
             )
 
         return CardManifest(mergedCards, electionInfo.totalCardCount)
-    }
+    } */
 
     override fun readCardStyles(): List<StyleIF>? {
         return if (!Files.exists(Path(publisher.cardStylesFile()))) null else {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CardManifest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CardManifest.kt
@@ -7,7 +7,8 @@ import org.cryptobiotic.rlauxe.audit.CardWithBatchName
 import org.cryptobiotic.rlauxe.audit.MergeBatchesIntoCardManifestIterable
 import org.cryptobiotic.rlauxe.util.CloseableIterable
 
-// TODO could this return
+// TODO why in persist ??
+// TODO why is ncards here ??
 class CardManifest(val cards: CloseableIterable<AuditableCardIF>, val ncards: Int) {
 
     companion object {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CompositeRecord.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CompositeRecord.kt
@@ -8,7 +8,9 @@ import org.cryptobiotic.rlauxe.audit.AuditRoundIF
 import org.cryptobiotic.rlauxe.audit.StyleIF
 import org.cryptobiotic.rlauxe.audit.Config
 import org.cryptobiotic.rlauxe.audit.ContestRound
+import org.cryptobiotic.rlauxe.audit.SamplingCardIF
 import org.cryptobiotic.rlauxe.core.*
+import org.cryptobiotic.rlauxe.util.CloseableIterable
 import org.cryptobiotic.rlauxe.util.ErrorMessages
 import kotlin.io.path.Path
 import kotlin.io.path.exists
@@ -52,12 +54,11 @@ data class CompositeRecord(
 
     override fun auditdir() = "$location/audit"
 
-    override fun readSortedManifest(batches: List<StyleIF>?): CardManifest {
-        return componentRecords.first().readSortedManifest(batches)
+    override fun readSortedManifest(styles: List<StyleIF>?): CardManifest {
+        return componentRecords.first().readSortedManifest(styles)
     }
-    override fun readSortedManifest(): CardManifest {
-        return componentRecords.first().readSortedManifest() // barf
-    }
+
+    override fun readSamplingCards(): CloseableIterable<SamplingCardIF>? = null
 
     override fun readOneShotMvrs() = emptyMap<Int, Int>()
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CountyAudit.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CountyAudit.kt
@@ -4,16 +4,15 @@ import com.github.michaelbull.result.unwrap
 import com.github.michaelbull.result.unwrapError
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.audit.AuditRound
-import org.cryptobiotic.rlauxe.audit.AuditableCard
-import org.cryptobiotic.rlauxe.audit.AuditableCardProto
 import org.cryptobiotic.rlauxe.audit.Config
-import org.cryptobiotic.rlauxe.audit.MergeBatchesIntoCardManifestIterable
+import org.cryptobiotic.rlauxe.audit.SamplingCardIF
 import org.cryptobiotic.rlauxe.audit.StyleIF
 import org.cryptobiotic.rlauxe.core.ContestWithAssertions
+import org.cryptobiotic.rlauxe.persist.csv.SamplingCard
+import org.cryptobiotic.rlauxe.persist.csv.SamplingCardIterator
 import org.cryptobiotic.rlauxe.persist.csv.readCardsCsvIterator
-import org.cryptobiotic.rlauxe.persist.protobuf.AuditableCardProtoIterator
+import org.cryptobiotic.rlauxe.persist.protobuf.ProtobufCardIterator
 import org.cryptobiotic.rlauxe.util.CloseableIterable
-import org.cryptobiotic.rlauxe.util.CloseableIterator
 import java.io.BufferedReader
 import java.io.File
 import kotlin.collections.forEach
@@ -31,6 +30,38 @@ class CountyAudit(
 
     override fun auditdir() = "$location/audit"
 
+    //// problem is you lose the cache is you close and open the AuditRecord between samplings
+    // caching takes about 10 secs
+
+    val styles by lazy { this.readCardStyles() ?: this.readCardPools() } // styles are preferred
+
+    val samplingCards : List<SamplingCardIF> by lazy {
+        val bufferSize = 100_000
+        val cardIter = SamplingCardIterator(publisher.cardsSamplingFile(), styles!!, bufferSize)
+        val cards = mutableListOf<SamplingCard>()
+        while (cardIter.hasNext()) {
+            cards.add(cardIter.next())
+        }
+        cards.toList()
+    }
+
+    override fun readSamplingCards(): CloseableIterable<SamplingCardIF> {
+        return CloseableIterable { samplingCards.iterator() }
+    }
+
+    // use proto cards
+    override fun readSortedManifest(styles: List<StyleIF>?): CardManifest {
+        val bufferSize = 100_000
+        val protoFilename = publisher.cardsProtoFile()
+
+        val protoManifest = CloseableIterable { ProtobufCardIterator(protoFilename, bufferSize, styles) }
+        // val protoManifest: CloseableIterable<AuditableCardProto> = CloseableIterable { AuditableCardProtoIterator(protoFilename, bufferSize, styles) }
+        logger.info{"using cardsProtoFile at ${protoFilename}"}
+        return CardManifest(protoManifest, electionInfo.totalCardCount)
+    }
+
+
+    // for viewer
     fun countMvrsByCounty(): Map<String, CountyData> {
         if (rounds.isEmpty()) return emptyMap()
         val lastRound = rounds.last() // TODO last round that has results
@@ -52,15 +83,6 @@ class CountyAudit(
         logger.info{ "countMvrsByCounty mvrs=$count sumCounties = ${ countyData.values.sumOf { it.nmvrs } }"}
 
         return countyData.toSortedMap()
-    }
-
-    // use proto cards
-    override fun readSortedManifest(batches: List<StyleIF>?): CardManifest {
-        val bufferSize = 100_000
-        val protoFilename = publisher.cardsProtoFile()
-        val protoManifest: CloseableIterable<AuditableCardProto> = CloseableIterable { AuditableCardProtoIterator(protoFilename, bufferSize, batches) }
-        logger.info{"using cardsProtoFile at ${protoFilename}"}
-        return CardManifest(protoManifest, electionInfo.totalCardCount)
     }
 
     companion object {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/Publisher.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/Publisher.kt
@@ -49,7 +49,8 @@ class Publisher(val auditDir: String) {
     fun auditRoundProtoFile() = "$auditDir/auditRoundConfig.json"
     // fun auditSeedFile() = "$auditDir/auditSeed.json"
     fun cardManifestFile() = "$auditDir/cardManifest.csv" // cardManifest
-    fun cardsProtoFile() = "$auditDir/cards.proto" // cardManifest
+    fun cardsSamplingFile() = "$auditDir/cardsSampling.bin" // just use for sampling
+    fun cardsProtoFile() = "$auditDir/cards.protobuf" // cardManifest
     fun cardPoolsFile() = "$auditDir/cardPools.csv"
     fun cardStylesFile() = "$auditDir/cardStyles.json"
     fun contestsFile() = "$auditDir/contests.json"

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/csv/CardCsv.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/csv/CardCsv.kt
@@ -2,9 +2,9 @@ package org.cryptobiotic.rlauxe.persist.csv
 
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.audit.CardIF
-import org.cryptobiotic.rlauxe.audit.CardStyle
-import org.cryptobiotic.rlauxe.audit.AuditableCardProto
 import org.cryptobiotic.rlauxe.audit.CardWithBatchName
+import org.cryptobiotic.rlauxe.audit.SamplingCardIF
+import org.cryptobiotic.rlauxe.audit.StyleIF
 import org.cryptobiotic.rlauxe.util.CloseableIterable
 import org.cryptobiotic.rlauxe.util.CloseableIterator
 import org.cryptobiotic.rlauxe.util.ZipReader
@@ -204,106 +204,62 @@ class IteratorCardsCsvStream(input: InputStream, bufferSize: Int): CloseableIter
     }
 }
 
-class CsvCardUsingArrays(input: InputStream, bufferSize: Int): CloseableIterator<AuditableCardProto> {
-    // was val reader = BufferedReader(InputStreamReader(input, "ISO-8859-1")) for some reason
-    val reader = BufferedReader(InputStreamReader(input),bufferSize)
-    var nextLine: String? = null
-    var countLines  = 0
+///////////////////////////////////////////////////////////////////////////////////////
 
-    init {
-        reader.readLine() // get rid of header line
-    }
+fun writeSamplingCards(cards: CloseableIterator<CardIF>, outputStream: OutputStream, styles: List<StyleIF>, limit: Int? = null): Int {
+    val styleMap = styles.associate { it.name() to it.id() }
+    var count = 0
 
-    override fun hasNext() : Boolean {
-        if (nextLine == null) {
-            countLines++
-            nextLine = reader.readLine()
+    DataOutputStream(outputStream).use { dos ->
+        while (cards.hasNext() && (limit == null || count < limit)) {
+            val card: CardIF = cards.next()
+            dos.writeLong(card.prn())
+            val styleId = styleMap[card.styleName()]
+            if (styleId == null)
+                throw RuntimeException()
+            dos.writeInt(styleId)
+            count++
         }
-        return nextLine != null
+        // EOF
+        dos.writeLong(0L)
+        dos.writeInt(-1)
     }
+    return count
+}
 
-    override fun next(): AuditableCardProto {
-        if (!hasNext()) throw NoSuchElementException()
-        val result =  readCardWithArrays(nextLine!!)
-        nextLine = null
-        return result
+class SamplingCardIterator(inputFile: String, styles: List<StyleIF>, bufferSize: Int): CloseableIterator<SamplingCardIF> {
+    val styleMap = styles.associate { it.id() to it }
+    val inputStream = FileInputStream(inputFile)
+    val dos = DataInputStream(inputStream)
+
+    var nextCard: SamplingCard? = null
+    var count = 0
+
+    override fun next() = nextCard!!
+
+    override fun hasNext(): Boolean {
+        val prn = dos.readLong()
+        val styleId = dos.readInt()
+        if (styleId == -1) {
+            nextCard = null
+            return false
+        }
+        val style = styleMap[styleId]
+        if (style == null)
+            throw RuntimeException()
+        nextCard = SamplingCard(prn, style)
+        return true
     }
 
     override fun close() {
-        reader.close()
+        dos.close()
+        inputStream.close()
     }
 }
 
-
-fun readCardWithArrays(line: String): AuditableCardProto {
-    val tokens = line.split(",")
-    val ttokens = tokens.map { it.trim() }
-
-    var idx = 0
-    val id = ttokens[idx++]
-    val locationToken = ttokens[idx++]
-    val location = locationToken.ifEmpty { null }
-    val index = ttokens[idx++].toInt()
-    val sampleNum = ttokens[idx++].toLong(radix=16)
-    val phantom = ttokens[idx++] == "yes"
-    val poolIdToken = ttokens[idx++]
-    val poolId = if (poolIdToken.isEmpty()) null else poolIdToken.toInt()
-    val styleName = ttokens[idx++].trim()
-
-    // if clca, list of actual contests and their votes
-    // if (idx < ttokens.size-1) {
-        val contestsStr = ttokens[idx++].trim()
-        val contestsTokenTrimmed = contestsStr.split(" ").map { it.trim() }
-
-        val contestIds = mutableListOf<Int>()
-
-        contestsTokenTrimmed.forEach { tok ->
-            if (tok.isNotEmpty()) contestIds.add(tok.toInt())
-        }
-
-    val contestStarts = mutableListOf<Int>()
-    val candidates = mutableListOf<Int>()
-
-        val hasVotes = (idx + contestIds.size) < ttokens.size
-
-        val votes = if (!hasVotes) null else {
-            val work = mutableListOf<IntArray>()
-            while (idx < ttokens.size && (work.size < contestIds.size)) {
-                val vtokens = ttokens[idx]
-                val candArray =
-                    if (vtokens.isEmpty()) intArrayOf()
-                    else vtokens.split(" ").map { it.trim().toInt() }.toIntArray()
-                work.add(candArray)
-                idx++
-            }
-            require(contestIds.size == work.size) { "contests.size (${contestIds.size}) != votes.size (${work.size})" }
-            contestIds.zip(work).toMap()
-        }
-
-    if (votes != null) {
-        var start = 0
-        contestIds.forEach {
-            val cands = votes[it]!!
-            candidates.addAll(cands.toList())
-            contestStarts.add(start)
-            start += cands.size
-        }
-    }
-
-        return AuditableCardProto(
-            id,
-            if (location == id) null else location,
-            index, sampleNum, phantom, poolId,
-            contestIds.toIntArray(),
-            contestStarts.toIntArray(),
-            candidates.toIntArray(),
-            CardStyle.fromCvrBatch,
-            // styleName=styleName
-        )
-    //}
-    //return CardUsingArrays(id, location, index, sampleNum, phantom, poolId,null, , styleName=styleName)
+data class SamplingCard(val prn : Long, val style: StyleIF) : SamplingCardIF {
+    override fun prn() = prn
+    override fun hasContest(contestId: Int) = style.hasContest( contestId)
 }
-
-
 
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/ProtoCard.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/ProtoCard.kt
@@ -6,10 +6,12 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.encodeToByteArray
 import kotlinx.serialization.protobuf.ProtoBuf
+import org.cryptobiotic.rlauxe.audit.AuditableCardIF
 import org.cryptobiotic.rlauxe.audit.CardIF
-import org.cryptobiotic.rlauxe.audit.AuditableCardProto
+import org.cryptobiotic.rlauxe.audit.CardStyle
 import org.cryptobiotic.rlauxe.audit.CardWithBatchName
 import org.cryptobiotic.rlauxe.audit.StyleIF
+import org.cryptobiotic.rlauxe.core.Cvr
 import org.cryptobiotic.rlauxe.util.CloseableIterator
 import org.cryptobiotic.rlauxe.util.ErrorMessages
 import java.io.BufferedInputStream
@@ -220,3 +222,146 @@ fun readVlen(input: InputStream): Int {
     return result
 }
 
+//////////////////////////////////////////////////////
+
+
+class AuditableCardProto(
+    val id: String, // enough info to find the card for a manual audit.
+    val location: String?, // enough info to find the card for a manual audit.
+    val index: Int,  // index into the original, canonical list of cards
+    val prn: Long,   // psuedo random number
+    val phantom: Boolean,
+    val poolId: Int?, // must be set if its from a CardPool
+    val contestIds: IntArray,
+    val contestStarts: IntArray,
+    val candidates: IntArray,
+    val style: StyleIF
+): AuditableCardIF {
+    val useCvr = CardStyle.useVotes(style.name())
+
+    val votes: Map<Int, IntArray>? by lazy {
+        if (contestIds.isEmpty()) null else {
+            val lastIndex = contestIds.size - 1
+            val makeVotes = mutableMapOf<Int, IntArray>()
+            contestIds.forEachIndexed { index, contestId ->
+                val start = contestStarts[index]
+                val end = if (index < lastIndex) contestStarts[index + 1] else candidates.size
+                if (start > end || end > candidates.size)
+                    makeVotes[contestId] = candidates.sliceArray(start until end)
+            }
+            makeVotes.toMap()
+        }
+    }
+
+    // TODO test that StyleIF.contests agrees with votes when they are both present
+
+    // constructor(card: CardWithBatchName, cardStyle: StyleIF): this(card.id, card.location, card.index, card.prn, card.phantom, card.poolId, card.votes, cardStyle)
+    // constructor(cvr: Cvr, index: Int, prn: Long): this(cvr.id, null, index, prn, cvr.phantom, cvr.poolId, cvr.votes, style = CardStyle.fromCvrBatch)
+
+    override fun hasContest(contestId: Int): Boolean {
+        return if (!useCvr) style.hasContest(contestId)
+        else contestIds.contains(contestId)
+    }
+
+    override fun possibleContests() : IntArray {
+        return when {
+            CardStyle.useVotes(style.name()) -> votes!!.keys.toList().sorted().toIntArray() // assumes cvrsContainUndervotes, use cardStyle if not.
+            else -> style.possibleContests().toList().sorted().toIntArray()
+        }
+    }
+
+    override fun id() = id
+    override fun location() = location ?: id()
+    override fun index() = index
+    override fun prn() = prn
+    override fun phantom() = phantom
+    override fun votes() = votes
+    override fun votes(contestId: Int): IntArray? = votes?.get(contestId)
+    override fun poolId(): Int? = poolId
+    override fun styleName() = style.name()
+    override fun style() = style
+    override fun hasStyle() = style.hasExactContests()
+
+    override fun toCvr(): Cvr {
+        TODO("Not yet implemented")
+    }
+
+    override fun hasMarkFor(contestId: Int, candidateId: Int): Int {
+        val contestVotes = votes(contestId)
+        return if (contestVotes == null) 0
+        else if (contestVotes.contains(candidateId)) 1 else 0
+    }
+
+    /*
+    override fun votes(contestId: Int): IntArray? {
+        // or turn back into a map lazily ??
+        // HEY consistent sampling only wants hasContest, optimize for that...
+        val contestIdx = contestIds.indexOf(contestId)
+        val start = contestStarts[contestIdx]
+        val end = contestStarts[contestIdx+1]
+        return candidates // .subarray(start, end)
+    } */
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AuditableCardProto) return false
+
+        if (index != other.index) return false
+        if (prn != other.prn) return false
+        if (phantom != other.phantom) return false
+        if (poolId != other.poolId) return false
+        if (id != other.id) return false
+        if (location != other.location) return false
+        if (!contestIds.contentEquals(other.contestIds)) return false
+        if (!contestStarts.contentEquals(other.contestStarts)) return false
+        if (!candidates.contentEquals(other.candidates)) return false
+        if (style != other.style) return false
+        if ((votes == null) != (other.votes == null)) return false
+        if (votes != null) {
+            for ((contestId, candidates) in votes) {
+                val otherCands = other.votes!![contestId]
+                if (!candidates.contentEquals(otherCands)) return false
+            }
+        }
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = index
+        result = 31 * result + prn.hashCode()
+        result = 31 * result + phantom.hashCode()
+        result = 31 * result + (poolId ?: 0)
+        result = 31 * result + id.hashCode()
+        result = 31 * result + (location?.hashCode() ?: 0)
+        result = 31 * result + contestIds.contentHashCode()
+        result = 31 * result + contestStarts.contentHashCode()
+        result = 31 * result + candidates.contentHashCode()
+        result = 31 * result + style.hashCode()
+        result = 31 * result + votes.hashCode()
+        return result
+    }
+
+    override fun toString()= buildString {
+        appendLine("id='$id', location=$location, index=$index, prn=$prn, phantom=$phantom, poolId=$poolId, ")
+        appendLine("   contestIds=${contestIds.contentToString()}, contestStarts=${contestStarts.contentToString()}, ")
+        appendLine("   candidates=${candidates.contentToString()}, style=$style, votes=$votes")
+    }
+
+    companion object {
+        // how much does a copy cost?
+        fun from(pcard: ProtoCard, styles: Map<String, StyleIF>) =
+            AuditableCardProto(
+                pcard.id,
+                if (pcard.location == pcard.id) null else pcard.location,
+                pcard.index,
+                pcard.prn,
+                pcard.phantom,
+                pcard.poolId,
+                pcard.contestIds,  // not making copies
+                pcard.contestStarts,
+                pcard.candidates,
+                styles[pcard.styleName] ?: CardStyle.fromCvrBatch,
+            )
+    }
+}

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/ProtoCardBunch.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/ProtoCardBunch.kt
@@ -8,7 +8,6 @@ import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.encodeToByteArray
 import kotlinx.serialization.protobuf.ProtoBuf
 import org.cryptobiotic.rlauxe.audit.CardIF
-import org.cryptobiotic.rlauxe.audit.AuditableCardProto
 import org.cryptobiotic.rlauxe.audit.CardWithBatchName
 import org.cryptobiotic.rlauxe.audit.StyleIF
 import org.cryptobiotic.rlauxe.util.CloseableIterator

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/ProtobufCards.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/ProtobufCards.kt
@@ -1,0 +1,232 @@
+package org.cryptobiotic.rlauxe.persist.protobuf
+
+import org.cryptobiotic.rlauxe.audit.AuditableCardIF
+import org.cryptobiotic.rlauxe.audit.CardIF
+import org.cryptobiotic.rlauxe.audit.CardStyle
+import org.cryptobiotic.rlauxe.audit.StyleIF
+import org.cryptobiotic.rlauxe.core.Cvr
+import org.cryptobiotic.rlauxe.persist.protobuf.Protobuf.Card.parseFrom
+import org.cryptobiotic.rlauxe.util.CloseableIterator
+import org.cryptobiotic.rlauxe.util.ErrorMessages
+import java.io.BufferedInputStream
+import java.io.InputStream
+import java.io.OutputStream
+import java.nio.ByteBuffer
+import java.nio.file.Files
+import java.nio.file.StandardOpenOption
+import kotlin.io.path.Path
+
+// message Card {
+//    string id = 1;        // enough info to find the card for a manual audit.
+//    string location = 2;  // enough info to find the card for a manual audit.
+//    uint32 index = 3;     // index into the original, canonical list of cards
+//    fixed64 prn = 4;      // psuedo random number
+//    bool phantom = 5;
+//    uint32 poolId = 6;    // must be set if its from a CardPool
+//    //repeated uint32 contestIds = 7;     // these define the votes: Map<Int, IntArray>
+//    //repeated uint32 contestStarts = 8;
+//    //repeated uint32 candidates = 9;
+//    string styleName = 10;
+//    repeated VotesEntry votes = 11; // these define the votes: Map<Int, IntArray>
+//}
+//
+//message VotesEntry {
+//    uint32 contest = 1;
+//    uint32 cands = 2;
+//}
+
+fun writeProtobufCards(cards: CloseableIterator<CardIF>, output: OutputStream, limit: Int? = null): Int {
+    // kotlinx.serialization's Protobuf implementation does not natively support writeDelimitedTo
+    var count = 0
+    while (cards.hasNext() && (limit == null || count < limit)) {
+        val card: CardIF = cards.next()
+        val protoCard: Protobuf.Card = encodeToProtobuf(card)
+        val bytes = protoCard.toByteArray()
+        writeDelimitedTo(bytes, output)
+        count++
+        if (count % 10000 == 0) { print("$count, ")}
+        if (count % 100000 == 0) { println("$count, ")}
+    }
+    return count
+}
+
+fun encodeToProtobuf(cardf : CardIF): Protobuf.Card  {
+
+    val voteEntries: List<Protobuf.VotesEntry> = if (cardf.votes() == null) emptyList() else {
+        cardf.votes()!!.map { (contestId, candidates) ->
+            votesEntry {
+                contest = contestId
+                cands.addAll(candidates.toList())
+            }
+        }
+    }
+
+    val wtf: Protobuf.Card = card {
+        id = cardf.id()
+        location = cardf.location()
+        index = cardf.index()
+        prn = cardf.prn()
+        phantom = cardf.phantom()
+        if (cardf.poolId() != null) poolId = cardf.poolId()!!
+        styleName = cardf.styleName()
+
+        votes.addAll(voteEntries)
+    }
+
+    return wtf
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////
+
+class ProtobufCardIterator(filename: String, bufferSize: Int, val styles: List<StyleIF>? = null): CloseableIterator<AuditableCardProtobuf> {
+    val styleMap: Map<String, StyleIF> = styles?.associateBy{ it.name() } ?: emptyMap()
+
+    val errs = ErrorMessages("readProtoCardsFile '${filename}'")
+    val inputStream: InputStream
+    var nextMessageSize = -1
+
+    init {
+        val filepath = Path(filename)
+        if (!Files.exists(filepath)) {
+            throw RuntimeException("file does not exist")
+        }
+        val input = Files.newInputStream(filepath, StandardOpenOption.READ)
+        inputStream = BufferedInputStream(input, bufferSize)
+    }
+
+    override fun hasNext(): Boolean {
+        nextMessageSize = readVlen(inputStream)
+        return (nextMessageSize > 0)
+    }
+
+    override fun next(): AuditableCardProtobuf {
+        val bytes = ByteArray(nextMessageSize)
+        val bytesRead = inputStream.read(bytes)
+        val pcard: Protobuf.Card = parseFrom(ByteBuffer.wrap(bytes))
+        return from(pcard, styleMap)
+    }
+
+    override fun close() {
+        inputStream.close()
+    }
+}
+
+fun from(pcard: Protobuf.Card, styles: Map<String, StyleIF>): AuditableCardProtobuf {
+    val votePairs: List<Pair<Int, IntArray>> = pcard.votesList.map {
+        Pair(it.contest, it.getCandsList().toIntArray())
+    }
+
+    return AuditableCardProtobuf(
+        pcard.id,
+        if (pcard.location == pcard.id) null else pcard.location,
+        pcard.index,
+        pcard.prn,
+        pcard.phantom,
+        if (pcard.hasPoolId()) pcard.poolId else null,
+        votePairs = votePairs,
+        styles[pcard.styleName] ?: CardStyle.fromCvrBatch,
+    )
+}
+
+////////////////////////////////////////////////////////////////////////////
+
+class AuditableCardProtobuf(
+    val id: String, // enough info to find the card for a manual audit.
+    val location: String?, // enough info to find the card for a manual audit.
+    val index: Int,  // index into the original, canonical list of cards
+    val prn: Long,   // psuedo random number
+    val phantom: Boolean,
+    val poolId: Int?, // must be set if its from a CardPool
+    val votePairs: List<Pair<Int, IntArray>>,  // contest -> candidates
+    val style: StyleIF
+): AuditableCardIF {
+    val useCvr = CardStyle.useVotes(style.name())
+
+    val contestIds: IntArray by lazy { votePairs.map{ it.first }.toIntArray() }
+    val votes: Map<Int, IntArray>? by lazy { if (votePairs.isEmpty()) null else votePairs.toMap() }
+
+    // TODO test that StyleIF.contests agrees with votes when they are both present
+
+    override fun hasContest(contestId: Int): Boolean {
+        return if (!useCvr) style.hasContest(contestId)
+        else contestIds.contains(contestId)
+    }
+
+    override fun possibleContests() : IntArray {
+        return when {
+            CardStyle.useVotes(style.name()) -> votes!!.keys.toList().sorted().toIntArray() // assumes cvrsContainUndervotes, use cardStyle if not.
+            else -> style.possibleContests().toList().sorted().toIntArray()
+        }
+    }
+
+    override fun id() = id
+    override fun location() = location ?: id()
+    override fun index() = index
+    override fun prn() = prn
+    override fun phantom() = phantom
+    override fun votes() = votes
+    override fun votes(contestId: Int): IntArray? = votes?.get(contestId)
+    override fun poolId(): Int? = poolId
+    override fun styleName() = style.name()
+    override fun style() = style
+    override fun hasStyle() = style.hasExactContests()
+
+    override fun toCvr(): Cvr {
+        TODO("Not yet implemented")
+    }
+
+    override fun hasMarkFor(contestId: Int, candidateId: Int): Int {
+        val contestVotes = votes(contestId)
+        return if (contestVotes == null) 0
+        else if (contestVotes.contains(candidateId)) 1 else 0
+    }
+
+    /*
+    override fun votes(contestId: Int): IntArray? {
+        // or turn back into a map lazily ??
+        // HEY consistent sampling only wants hasContest, optimize for that...
+        val contestIdx = contestIds.indexOf(contestId)
+        val start = contestStarts[contestIdx]
+        val end = contestStarts[contestIdx+1]
+        return candidates // .subarray(start, end)
+    } */
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (other !is AuditableCardProtobuf) return false
+
+        if (index != other.index) return false
+        if (prn != other.prn) return false
+        if (phantom != other.phantom) return false
+        if (poolId != other.poolId) return false
+        if (id != other.id) return false
+        if (location != other.location) return false
+        if (style != other.style) return false
+
+        if (votePairs.size != other.votePairs.size) return false
+        votePairs.forEachIndexed { idx, (contest, candidates) ->
+            val otherPair = other.votePairs[idx]
+            if (contest != otherPair.first) return false
+            if (!candidates.contentEquals(otherPair.second)) return false
+        }
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = index
+        result = 31 * result + prn.hashCode()
+        result = 31 * result + phantom.hashCode()
+        result = 31 * result + (poolId ?: 0)
+        result = 31 * result + id.hashCode()
+        result = 31 * result + (location?.hashCode() ?: 0)
+        result = 31 * result + style.hashCode()
+        result = 31 * result + votePairs.hashCode()
+        return result
+    }
+
+    override fun toString()= buildString {
+        appendLine("id='$id', location=$location, index=$index, prn=$prn, phantom=$phantom, poolId=$poolId, ")
+        appendLine("   style=$style, votes=$votes")
+    }
+}

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyContests.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyContests.kt
@@ -7,7 +7,6 @@ import org.cryptobiotic.rlauxe.core.ContestInfo
 import org.cryptobiotic.rlauxe.core.ContestWithAssertions
 import org.cryptobiotic.rlauxe.betting.TestH0Status
 import org.cryptobiotic.rlauxe.oneaudit.OneAuditClcaAssorter
-import org.cryptobiotic.rlauxe.audit.CardPool
 import org.cryptobiotic.rlauxe.persist.AuditRecord
 import org.cryptobiotic.rlauxe.irv.RaireAssorter
 import org.cryptobiotic.rlauxe.util.CloseableIterable
@@ -21,6 +20,7 @@ import org.cryptobiotic.rlauxe.util.pfn
 import org.cryptobiotic.rlauxe.util.sumContestTabulations
 import org.cryptobiotic.rlauxe.util.tabulateOneAuditPools
 import org.cryptobiotic.rlauxe.persist.CardManifest
+import org.cryptobiotic.rlauxe.workflow.PersistedMvrManager
 import kotlin.collections.component1
 import kotlin.collections.component2
 import kotlin.collections.forEach
@@ -32,22 +32,27 @@ import kotlin.use
 // for all audit types. Cards and CardPools must already be published, contests might not,
 // but only if you call cerify with the contests' note only then do you get contestUA.preAuditStatus saved
 class VerifyContests(val auditRecordLocation: String, val show: Boolean = false) {
-    val auditRecord: AuditRecord
+    // val auditRecord: AuditRecord
     val config: Config
     val allContests: List<ContestWithAssertions>?
     val allInfos: Map<Int, ContestInfo>?
     val cardManifest: CardManifest
+    val cardPools: List<CardPoolIF>?
 
     init {
         val result = AuditRecord.readWithResult(auditRecordLocation)
-        auditRecord = if (result.isOk) result.unwrap() else {
+        val auditRecord = if (result.isOk) result.unwrap() else {
             println(result.unwrapError())
             throw RuntimeException(result.unwrapError().toString())
         }
         config = auditRecord.config
         allContests = auditRecord.contests.sortedBy { it.id }
         allInfos = allContests.map{ it.contest.info() }.associateBy { it.id }
-        cardManifest = auditRecord.readSortedManifest()
+
+        val mvrManager = PersistedMvrManager(auditRecord)
+
+        cardManifest = mvrManager.sortedManifest()
+        cardPools = mvrManager.pools()
     }
 
     fun verify() = verify( allContests!!, show = show)
@@ -66,7 +71,6 @@ class VerifyContests(val auditRecordLocation: String, val show: Boolean = false)
 
         // OA
         if (config.isOA) {
-            val cardPools = auditRecord.readCardPools()
             if (cardPools != null) {
                 verifyOAagainstCards(contests, contestSummary, cardPools, infos, results, show = show)
                 verifyOAassortAvg(contests, cardManifest.cards.iterator(), results, show = show)
@@ -236,7 +240,7 @@ fun verifyManifest(
 fun verifyOAagainstCards(
     contests: List<ContestWithAssertions>,
     contestSummary: ContestSummary,
-    cardPools: List<CardPool>,
+    cardPools: List<CardPoolIF>,
     infos: Map<Int, ContestInfo>,
     result: VerifyResults,
     show: Boolean = false
@@ -439,7 +443,7 @@ fun verifyOAassortAvg(
 fun verifyOApools(
     contestsUA: List<ContestWithAssertions>,
     contestSummary: ContestSummary,
-    cardPools: List<CardPool>,
+    cardPools: List<CardPoolIF>,
     result: VerifyResults,
     show: Boolean = false
 ): VerifyResults {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditWorkflow.kt
@@ -39,7 +39,6 @@ import org.cryptobiotic.rlauxe.util.Stopwatch
         val stopwatch = Stopwatch()
 
         val mvrManager = mvrManager()
-        val sortedManifest = mvrManager.sortedManifest()
 
         // estimate how many samples are needed for each contest, to satisfy the risk function,
         val estimate = EstimateAudit(
@@ -48,8 +47,8 @@ import org.cryptobiotic.rlauxe.util.Stopwatch
             auditRound.roundIdx,
             auditRound.contestRounds,
             mvrManager().pools(),
-            mvrManager().batches(),
-            sortedManifest
+            mvrManager().styles(),
+            mvrManager.sortedManifest()
         )
         estimate.run(nthreads=null, contestOnly=null)
 
@@ -66,7 +65,7 @@ import org.cryptobiotic.rlauxe.util.Stopwatch
         //    contestRound.maxSampleAllowed = sampledCards.size
         removeContestsAndSample(
             config.round.sampling,
-            sortedManifest,
+            mvrManager.samplingCards(),
             auditRound,
             previousSamples = previousSamples,
         )

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/CompositeMvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/CompositeMvrManager.kt
@@ -5,6 +5,7 @@ import org.cryptobiotic.rlauxe.audit.*
 import org.cryptobiotic.rlauxe.core.ContestWithAssertions
 import org.cryptobiotic.rlauxe.core.CvrIF
 import org.cryptobiotic.rlauxe.audit.CardPool
+import org.cryptobiotic.rlauxe.persist.CardManifest
 import org.cryptobiotic.rlauxe.persist.CompositeRecordIF
 import org.cryptobiotic.rlauxe.persist.Publisher
 import org.cryptobiotic.rlauxe.persist.csv.readCardPoolCsvFile
@@ -21,10 +22,7 @@ open class CompositeMvrManager(
 
     val publisher = Publisher(auditRecord.componentRecords.first().location)
 
-    // override fun sortedManifest() = readCardManifestComposite(publisher)
-    override fun sortedManifest() = auditRecord.readSortedManifest()
-
-    override fun batches(): List<StyleIF>? {
+    override fun styles(): List<StyleIF>? {
         return readBatchesComposite(publisher)
     }
 
@@ -34,6 +32,10 @@ open class CompositeMvrManager(
 
     override fun writeMvrsForRound(round: Int): Int {
         TODO("Not yet implemented")
+    }
+
+    override fun sortedManifest(): CardManifest {
+        return auditRecord.readSortedManifest(styles())
     }
 
     override fun pools(): List<CardPool>? {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManager.kt
@@ -4,7 +4,9 @@ import org.cryptobiotic.rlauxe.audit.AuditableCardIF
 import org.cryptobiotic.rlauxe.audit.StyleIF
 import org.cryptobiotic.rlauxe.core.CvrIF
 import org.cryptobiotic.rlauxe.audit.CardPool
+import org.cryptobiotic.rlauxe.audit.SamplingCardIF
 import org.cryptobiotic.rlauxe.persist.CardManifest
+import org.cryptobiotic.rlauxe.util.CloseableIterable
 import org.cryptobiotic.rlauxe.util.CloseableIterator
 
 // use MvrManager for auditing, not creating an audit
@@ -12,11 +14,13 @@ interface MvrManager {
     // TODO why does mvrManager manage these ?? maybe let AuditWorkflow ??
     fun sortedManifest(): CardManifest
     fun pools(): List<CardPool>?
-    fun batches(): List<StyleIF>?
+    fun styles(): List<StyleIF>?
 
     fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCardIF>>  // Pair(mvr, cvr)
     fun writeMvrsForRound(round: Int): Int
     fun auditdir() = "none"
+
+    fun samplingCards(): CloseableIterable<SamplingCardIF> = sortedManifest().cards
 }
 
 // when the MvrManager supplies the audited mvrs, its a test

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManager.kt
@@ -23,20 +23,25 @@ open class PersistedMvrManager(val auditRecord: AuditRecord, val mvrWrite: Boole
     val contestsUA = auditRecord.contests.filter { it.preAuditStatus == TestH0Status.InProgress }
     val publisher = Publisher(auditRecord.location)
 
-    private val batches = auditRecord.readCardStyles() ?: auditRecord.readCardPools()  // styles are preferred
-    val sortedManifest = auditRecord.readSortedManifest(batches)
-    fun auditableCards(): CloseableIterator<AuditableCardIF> = sortedManifest.cards.iterator()
+    val styles by lazy { auditRecord.readCardStyles() ?: auditRecord.readCardPools() } // styles are preferred
+    val sortedManifest by lazy { auditRecord.readSortedManifest(styles) }
+    val auditableCards: CloseableIterator<AuditableCardIF> by lazy {  sortedManifest.cards.iterator() }
+
+    override fun auditdir() = auditRecord.location
 
     override fun sortedManifest() = sortedManifest
-    override fun batches() = auditRecord.readCardStyles()
+    override fun styles() = auditRecord.readCardStyles()
     override fun pools() = auditRecord.readCardPools() // could test if batches are cardPools
-    override fun auditdir() = auditRecord.location
+
+    override fun samplingCards(): CloseableIterable<SamplingCardIF> {
+        return auditRecord.readSamplingCards() ?: sortedManifest().cards
+    }
 
     override fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCardIF>>  {
         val mvrsForRound = readMvrsForRound(round)
         val sampleNumbers = mvrsForRound.map { it.prn }
 
-        val sampledCards = findSamples(sampleNumbers, auditableCards())
+        val sampledCards = findSamples(sampleNumbers, auditableCards)
         require(sampledCards.size == mvrsForRound.size)
         val mvrCardPairs = mvrsForRound.zip(sampledCards)
 
@@ -65,7 +70,7 @@ open class PersistedMvrManager(val auditRecord: AuditRecord, val mvrWrite: Boole
         val sampleNumbers = resultSamples.unwrap()
 
         val mvrCardIter = readCardsCsvIterator(publisher.sortedMvrsFile())
-        val mergedMvrIter = MergeBatchesIntoCardManifestIterator(mvrCardIter, batches ?: emptyList())
+        val mergedMvrIter = MergeBatchesIntoCardManifestIterator(mvrCardIter, styles ?: emptyList())
 
         val sampledMvrs = findSamples(sampleNumbers, mergedMvrIter)
         require(sampledMvrs.size == sampleNumbers.size)
@@ -84,7 +89,7 @@ open class PersistedMvrManager(val auditRecord: AuditRecord, val mvrWrite: Boole
     // return complete list of mvrs used for this round
     private fun readMvrsForRound(round: Int): List<AuditableCard> {
         val mvrCardIter = readCardsCsvIterator(publisher.sampleMvrsFile(round))
-        val mergedMvrIter = MergeBatchesIntoCardManifestIterator(mvrCardIter, batches ?: emptyList())
+        val mergedMvrIter = MergeBatchesIntoCardManifestIterator(mvrCardIter, styles ?: emptyList())
         val mvrCards = mutableListOf<AuditableCard>()
         while (mergedMvrIter.hasNext()) { mvrCards.add(mergedMvrIter.next())}
         return mvrCards
@@ -101,7 +106,7 @@ open class PersistedMvrManager(val auditRecord: AuditRecord, val mvrWrite: Boole
         require(sampledPrnsResult.isOk)
         val sampledPrns = sampledPrnsResult.unwrap()
 
-        val mergedMvrIter = MergeBatchesIntoCardManifestIterator(mvrs.iterator(), batches ?: emptyList())
+        val mergedMvrIter = MergeBatchesIntoCardManifestIterator(mvrs.iterator(), styles ?: emptyList())
 
         val sampledMvrs = findSamples(sampledPrns, mergedMvrIter) // what does this do
         require(sampledMvrs.size == sampledPrns.size)
@@ -120,12 +125,12 @@ open class PersistedMvrManager(val auditRecord: AuditRecord, val mvrWrite: Boole
 
     fun readCardsAndMerge(filename: String): CloseableIterator<AuditableCard> {
         val mvrCardIter = readCardsCsvIterator(filename)
-        return MergeBatchesIntoCardManifestIterator(mvrCardIter, batches ?: emptyList())
+        return MergeBatchesIntoCardManifestIterator(mvrCardIter, styles ?: emptyList())
     }
 
     fun readCardsAndMergeList(filename: String): List<AuditableCard> {
         val mvrCardIter = readCardsCsvIterator(filename)
-        val mergedMvrIter = MergeBatchesIntoCardManifestIterator(mvrCardIter, batches ?: emptyList())
+        val mergedMvrIter = MergeBatchesIntoCardManifestIterator(mvrCardIter, styles ?: emptyList())
         val mvrCards = mutableListOf<AuditableCard>()
         while (mergedMvrIter.hasNext()) { mvrCards.add(mergedMvrIter.next())}
         return mvrCards

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManagerTest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManagerTest.kt
@@ -15,7 +15,7 @@ class PersistedMvrManagerTest(auditRecord: AuditRecord): MvrManagerTestIF, Persi
 
     // extract the cards with sampleNumbers from the cardManifest, optionally fuzz them, and write them to sampleMvrsFile
     override fun setMvrsBySampleNumber(sampleNumbers: List<Long>, round: Int): List<AuditableCardIF> {
-        val cards = findSamples(sampleNumbers, auditableCards())
+        val cards = findSamples(sampleNumbers, auditableCards)
 
         var lastRN = 0L
         cards.forEachIndexed { idx, mvr ->

--- a/core/src/main/proto/AuditableCard.proto
+++ b/core/src/main/proto/AuditableCard.proto
@@ -1,0 +1,28 @@
+syntax = "proto3";
+
+package org.cryptobiotic.rlauxe.persist.protobuf;
+
+option java_package = "org.cryptobiotic.rlauxe.persist.protobuf";
+option java_outer_classname = "Protobuf";
+
+message Card {
+    string id = 1;        // enough info to find the card for a manual audit.
+    string location = 2;  // enough info to find the card for a manual audit.
+    uint32 index = 3;     // index into the original, canonical list of cards
+    fixed64 prn = 4;      // psuedo random number
+    bool phantom = 5;
+    optional uint32 poolId = 6;    // must be set if its from a CardPool
+
+    string styleName = 10;
+    repeated VotesEntry votes = 11; // these define the votes: Map<Int, IntArray>
+
+    // or
+    //repeated uint32 contestIds = 7;     // these define the votes: Map<Int, IntArray>
+    //repeated uint32 contestStarts = 8;
+    //repeated uint32 candidates = 9;
+}
+
+message VotesEntry {
+    uint32 contest = 1;
+    repeated uint32 cands = 2;
+}

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditRound.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditRound.kt
@@ -29,7 +29,7 @@ class TestAuditRound {
         mvrs.mapIndexed { idx, it -> AuditableCard(it, idx, prng.next()) }
 
         val auditRound = AuditRound(1, contestRounds, samplePrns = emptyList())
-        consistentSampling(auditRound, mvrManager.sortedManifest())
+        consistentSampling(auditRound, mvrManager.samplingCards())
 
         contestRounds.forEach { contestRound ->
             val firstAssertion = contestRound.assertionRounds.first()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestRunRound.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestRunRound.kt
@@ -30,6 +30,6 @@ class TestRunRound {
             contestRound.included = false
         }
 
-        resampleAndSaveResults(auditdir, lastRound as AuditRound)
+        resampleAndSaveResults(auditRecord as AuditRecord, lastRound as AuditRound)
     }
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/dhondt/TestBelgiumContest.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/dhondt/TestBelgiumContest.kt
@@ -10,6 +10,7 @@ import org.cryptobiotic.rlauxe.persist.AuditRecord
 import org.cryptobiotic.rlauxe.testdataDir
 import org.cryptobiotic.rlauxe.util.doublePrecision
 import org.cryptobiotic.rlauxe.persist.CardManifest
+import org.cryptobiotic.rlauxe.workflow.PersistedMvrManager
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -23,7 +24,8 @@ class TestBelgiumContest {
     init {
         val auditdir = "$testdataDir/cases/belgium/2024limited/Anvers/audit"
         val auditRecord = AuditRecord.read(auditdir) as AuditRecord
-        cardManifest = auditRecord.readSortedManifest()
+        val mvrManager = PersistedMvrManager(auditRecord)
+        cardManifest = mvrManager.sortedManifest()
         config = auditRecord.config
         contests = auditRecord.contests
         rounds = auditRecord.rounds

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
@@ -37,7 +37,7 @@ class TestConsistentSampling {
         ////    auditRound.newmvrs = newMvrs
         ////    auditRound.samplePrns = sampledCards.map { it.prn }
         ////    contestRound.maxSampleAllowed = sampledCards.size
-        consistentSampling(auditRound, mvrManager.sortedManifest())
+        consistentSampling(auditRound, mvrManager.samplingCards())
         println("nsamples needed = ${auditRound.samplePrns.size}\n")
         assertEquals(auditRound.samplePrns.size, auditRound.nmvrs)
         assertEquals(auditRound.nmvrs, auditRound.newmvrs)
@@ -76,7 +76,7 @@ class TestConsistentSampling {
         val mvrManager = MvrManagerForTesting(cvrs, cvrs, Random.nextLong())
 
         val auditRound = AuditRound(1, contestRounds, samplePrns = emptyList())
-        consistentSampling(auditRound, mvrManager.sortedManifest())
+        consistentSampling(auditRound, mvrManager.samplingCards())
         println("nsamples needed = ${auditRound.samplePrns.size}\n")
 
         // must be ordered
@@ -133,7 +133,7 @@ class TestConsistentSampling {
                 auditRound.roundIdx,
                 auditRound.contestRounds,
                 mvrManager.pools(),
-                mvrManager.batches(),
+                mvrManager.styles(),
                 mvrManager.sortedManifest()
             )
             estimate.run(nthreads=null, contestOnly=null)
@@ -156,7 +156,7 @@ class TestConsistentSampling {
             //    contestRound.done = true
             removeContestsAndSample(
                 sampleControl,
-                mvrManager.sortedManifest(),
+                mvrManager.samplingCards(),
                 auditRound,
                 emptySet(),
             )

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestOneShot.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestOneShot.kt
@@ -3,7 +3,7 @@ package org.cryptobiotic.rlauxe.estimate
 import org.cryptobiotic.rlauxe.persist.AuditRecord
 import org.cryptobiotic.rlauxe.persist.Publisher
 import org.cryptobiotic.rlauxe.testdataDir
-import kotlin.test.Test
+import org.cryptobiotic.rlauxe.workflow.PersistedMvrManager
 
 class TestOneShot {
 
@@ -28,6 +28,7 @@ class TestOneShot {
         val record = AuditRecord.read(auditdir)
         if (record == null) throw RuntimeException("record is null")
         require (record is AuditRecord)
+        val mvrManager = PersistedMvrManager(record)
 
         val roundIdx = 4
         val auditRound = record.rounds[roundIdx-1]
@@ -36,9 +37,9 @@ class TestOneShot {
             record.config,
             roundIdx,
             auditRound.contestRounds,
-            pools = record.readCardPools(),
-            batches = record.readCardStyles(),
-            cardManifest = record.readSortedManifest(),
+            pools = mvrManager.pools(),
+            styles = mvrManager.styles(),
+            cardManifest = mvrManager.sortedManifest(),
         )
         estaudit.run()
     }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/TestCompositeRecord.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/TestCompositeRecord.kt
@@ -17,7 +17,7 @@ class TestCompositeRecord {
         val workflow = PersistedWorkflow(compositeRecord, mvrWrite = false)
         val manager = workflow.mvrManager()
         println("pools = ${manager.pools()}")
-        println("batches = ${manager.batches()}")
+        println("batches = ${manager.styles()}")
         val manifest = manager.sortedManifest()
         println("manifest.ncards = ${manifest.ncards}")
 
@@ -34,7 +34,7 @@ class TestCompositeRecord {
         val workflow = PersistedWorkflow(compositeRecord, mvrWrite = false)
         val manager = workflow.mvrManager()
         println("pools = ${manager.pools()}")
-        println("batches = ${manager.batches()}")
+        println("batches = ${manager.styles()}")
         val manifest = manager.sortedManifest()
         println("manifest.ncards = ${manifest.ncards}")
 
@@ -52,7 +52,7 @@ class TestCompositeRecord {
         val workflow = PersistedWorkflow(countyAudit, mvrWrite = false)
         val manager = workflow.mvrManager()
         println("pools = ${manager.pools()?.size}")
-        println("batches = ${manager.batches()?.size}")
+        println("batches = ${manager.styles()?.size}")
         val manifest = manager.sortedManifest()
         println("manifest.ncards = ${manifest.ncards}")
     }
@@ -67,7 +67,7 @@ class TestCompositeRecord {
         val workflow = PersistedWorkflow(countyAudit, mvrWrite = false)
         val manager = workflow.mvrManager()
         println("pools = ${manager.pools()?.size}")
-        println("batches = ${manager.batches()?.size}")
+        println("batches = ${manager.styles()?.size}")
         val manifest = manager.sortedManifest()
         println("manifest.ncards = ${manifest.ncards}")
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/csv/TestSamplingCards.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/csv/TestSamplingCards.kt
@@ -1,0 +1,150 @@
+package org.cryptobiotic.rlauxe.persist.csv
+
+import org.cryptobiotic.rlauxe.audit.CardWithBatchName
+import org.cryptobiotic.rlauxe.audit.SamplingCardIF
+import org.cryptobiotic.rlauxe.persist.AuditRecord
+import org.cryptobiotic.rlauxe.persist.CountyAudit
+import org.cryptobiotic.rlauxe.persist.Publisher
+import org.cryptobiotic.rlauxe.testdataDir
+import org.cryptobiotic.rlauxe.util.CloseableIterator
+import org.cryptobiotic.rlauxe.util.Closer
+import org.cryptobiotic.rlauxe.util.Stopwatch
+import org.cryptobiotic.rlauxe.workflow.PersistedMvrManager
+import java.io.FileOutputStream
+import java.io.OutputStream
+import java.util.concurrent.TimeUnit
+import kotlin.test.Test
+
+class TestSamplingCards {
+
+    @Test
+    fun writeSamplingCards() {
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val publisher = Publisher("$topdir/audit")
+
+        val countyAudit = AuditRecord.read(topdir) as CountyAudit
+        val mvrManager = PersistedMvrManager(countyAudit)
+        val styles = mvrManager.styles()!! // TODO maybe not optional ?
+
+        val cardIter: CloseableIterator<CardWithBatchName> = readCardsCsvIterator(publisher.sortedCardsFile())
+
+        val filenameOut = publisher.cardsSamplingFile()
+        val outputStream: OutputStream = FileOutputStream(filenameOut)
+
+        val stopwatch = Stopwatch()
+        val ncards = writeSamplingCards(cardIter, outputStream, styles)
+        outputStream.close()
+        cardIter.close()
+
+        println("writeProtoFile ncards = $ncards, took $stopwatch")
+    }
+
+    @Test
+    fun readSamplingCards() {
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val publisher = Publisher("$topdir/audit")
+
+        val countyAudit = AuditRecord.read(topdir) as CountyAudit
+        val mvrManager = PersistedMvrManager(countyAudit)
+        val styles = mvrManager.styles()!! // TODO maybe not optional ?
+
+        val stopwatch = Stopwatch()
+
+        var ncards = 0
+        val cardIter = SamplingCardIterator(publisher.cardsSamplingFile(), styles, 100_000)
+        while (cardIter.hasNext()) { //  && ncards < 1000_000) {
+            val card = cardIter.next()
+            ncards++
+        }
+        cardIter.close()
+
+        println("readSamplingCards ncards = $ncards, took $stopwatch")
+    }
+
+    @Test
+    fun timeConsistentSampling() {
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val publisher = Publisher("$topdir/audit")
+
+        val countyAudit = AuditRecord.read(topdir) as CountyAudit
+        val mvrManager = PersistedMvrManager(countyAudit)
+        val styles = mvrManager.styles()!!
+        val cardIter = SamplingCardIterator(publisher.cardsSamplingFile(), styles, 100_000)
+
+        runConsistentSampling(cardIter)
+        // ncards = 4982786, included = 142470869 that took 37.95 s= 0.007615819744215385 ms/card
+        // ncards = 4982786, included = 142470869 that took 39.62 s= 0.007950973611951226 ms/card
+    }
+
+    @Test
+    fun timeConsistentSamplingCached() {
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val publisher = Publisher("$topdir/audit")
+
+        val countyAudit = AuditRecord.read(topdir) as CountyAudit
+        val mvrManager = PersistedMvrManager(countyAudit)
+
+        val stopwatch = Stopwatch()
+        val styles = mvrManager.styles()!!
+
+        val cardIter = SamplingCardIterator(publisher.cardsSamplingFile(), styles, 100_000)
+        val samplingCards = mutableListOf<SamplingCard>()
+        while (cardIter.hasNext()) {
+            samplingCards.add(cardIter.next())
+        }
+        val ncards = samplingCards.size
+        println("caching took $stopwatch ncards = $ncards = ${stopwatch.elapsed(TimeUnit.MILLISECONDS)/ncards.toDouble()} ms/card")
+        // caching took 10.37 s ncards = 4982786 = 0.0020805629621661456 ms/card
+
+        runConsistentSampling(Closer(samplingCards.iterator()))
+        // ncards = 4982786, included = 142470869 that took 23.37 s= 0.004688541711404022 ms/card
+        // ncards = 4982786, included = 142470869 that took 25.84 s= 0.005185452475783628 ms/card
+    }
+
+    fun runConsistentSampling(cardIter: CloseableIterator<SamplingCardIF>) {
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val countyAudit = AuditRecord.read(topdir) as CountyAudit
+        val mvrManager = PersistedMvrManager(countyAudit)
+        val contestsUA = mvrManager.contestsUA
+
+        val stopwatch = Stopwatch()
+
+        var ncards = 0
+        var included = 0
+        var haveSampleSize = 0
+
+        while (cardIter.hasNext()) {
+            val card = cardIter.next()
+            ncards++
+
+            var include = false
+            contestsUA.forEach { contest ->
+                // does this contest want this card ?
+                if (card.hasContest(contest.id)) {
+                    include = true
+                    included++
+                }
+            }
+
+            /* if (include) {
+                if (!previousSamples.contains(card.prn))
+                    newMvrs++
+            } */
+
+            contestsUA.forEach { contest ->
+                if (card.hasContest(contest.id)) {
+                    if (include) {
+                        haveSampleSize++
+                        // TODO do all at once at the end for speed ??
+                        //if (!previousSamples.contains(card.prn)) {
+                        //    haveNewSampleSize++
+                        //}
+                    }
+                }
+            }
+
+        }
+
+        println("ncards = $ncards, included = $included that took $stopwatch= ${stopwatch.elapsed(TimeUnit.MILLISECONDS)/ncards.toDouble()} ms/card")
+    }
+}

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/TestProtoCard.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/TestProtoCard.kt
@@ -1,0 +1,354 @@
+package org.cryptobiotic.rlauxe.persist.protobuf
+
+import kotlinx.serialization.decodeFromByteArray
+import kotlinx.serialization.encodeToByteArray
+import kotlinx.serialization.protobuf.ProtoBuf
+import org.cryptobiotic.rlauxe.audit.CardStyle
+import org.cryptobiotic.rlauxe.audit.CardWithBatchName
+import org.cryptobiotic.rlauxe.persist.Publisher
+import org.cryptobiotic.rlauxe.persist.csv.readCardsCsvIterator
+import org.cryptobiotic.rlauxe.testdataDir
+import org.cryptobiotic.rlauxe.util.CloseableIterator
+import org.cryptobiotic.rlauxe.util.Stopwatch
+import org.cryptobiotic.rlauxe.util.dfn
+import java.io.BufferedReader
+import java.io.File
+import java.io.FileOutputStream
+import java.io.InputStream
+import java.io.InputStreamReader
+import java.io.OutputStream
+import java.util.concurrent.TimeUnit
+import kotlin.collections.component1
+import kotlin.collections.component2
+import kotlin.collections.iterator
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class TestProtoCard {
+
+    // @Test
+    fun testConvert(card: CardWithBatchName) {
+        val protoCard: ProtoCard = card.publishProto()
+        val bytes = ProtoBuf.encodeToByteArray(protoCard)
+        println(bytes.toHexString())
+        val obj = ProtoBuf.decodeFromByteArray<ProtoCard>(bytes)
+        println(obj)
+    }
+
+    /*
+    fun testProtoCardConversion(cards: List<CardIF>, filename: String) {
+        val json = contests.publishJson()
+        val jsonReader = Json { explicitNulls = false; ignoreUnknownKeys = true; prettyPrint = true }
+        FileOutputStream(filename).use { out ->
+            jsonReader.encodeToStream(json, out)
+            out.close()
+        }
+    } */
+
+    @Test
+    fun writeProtoFile () {
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val publisher = Publisher("$topdir/audit")
+        val cardIter: CloseableIterator<CardWithBatchName> = readCardsCsvIterator(publisher.cardManifestFile())
+
+        val protoFilename = "${topdir}/audit/cards.proto"
+        val outputStream: OutputStream = FileOutputStream(protoFilename)
+
+        val stopwatch = Stopwatch()
+        val ncards = writeProtoCards(cardIter, outputStream)
+        outputStream.close()
+        println("writeProtoFile ncards = $ncards, took $stopwatch")
+    }
+
+    @Test
+    fun timeReadProto () {
+        val protoFilename = "${testdataDir}/temp/cards.proto"
+        val bufferSize = 100_000
+
+        val stopwatch = Stopwatch()
+        var ncards = 0L
+
+        var accum = 0
+        val protoIter: CloseableIterator<AuditableCardProto> = AuditableCardProtoIterator(protoFilename, bufferSize)
+        while (protoIter.hasNext()) { //  && ncards < 1000_000) {
+            val card = protoIter.next()
+            accum += card.index() // prevent optimization
+            ncards++
+        }
+
+        val msPer = stopwatch.elapsed(TimeUnit.MILLISECONDS) / ncards.toDouble()
+        val secPer = msPer / 1000
+
+        println("timeReadProto ($bufferSize):  ncards = $ncards, accum=$accum took $stopwatch = $msPer ms/card")
+        val totalCards = 4982747
+        println("time to read all cards = ${dfn(totalCards * secPer, 3)} secs")
+    }
+    // ===========================
+    //ok 16 sec reading: use proto, CardUsingArrays, init votes lazily
+    //
+    //vs 52?
+    //should speed up Consistent sampling by 3x ??
+
+    @Test
+    fun timeReadCsv () {
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val publisher = Publisher("$topdir/audit")
+
+        val stopwatch = Stopwatch()
+        var ncards = 0L
+        val bufferSize = 100_000
+
+        val inputStream = File(publisher.cardManifestFile()).inputStream()
+        val csvIter: CloseableIterator<AuditableCardProto> = CsvCardUsingArrays(inputStream, bufferSize)
+        while (csvIter.hasNext() && ncards < 1000000) {
+            val card = csvIter.next()
+            ncards++
+        }
+
+        val msPer = stopwatch.elapsed(TimeUnit.MILLISECONDS) / ncards.toDouble()
+        val secPer = msPer / 1000
+
+        println("timeReadCsv ($bufferSize):  ncards = $ncards, took $stopwatch = $msPer ms/card")
+        val totalCards = 4982747
+        println("time to read all cards = ${dfn(totalCards * secPer, 3)} secs")
+    }
+
+    // @Test
+    fun testProtoAndCsvAgreeOnCardWithBatchName () {
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val publisher = Publisher("$topdir/audit")
+        val currentCardIter: CloseableIterator<CardWithBatchName> = readCardsCsvIterator(publisher.cardManifestFile())
+
+        val protoFilename = "${testdataDir}/temp/cards.proto"
+        val bufferSize = 100_000
+        val stopwatch = Stopwatch()
+        var ncards = 0L
+
+        val protoIter: CloseableIterator<CardWithBatchName> = ProtoCardBunchIterator(protoFilename, bufferSize)
+        while (protoIter.hasNext() && currentCardIter.hasNext() && ncards < 100_000) {
+            val cardFromCsv = currentCardIter.next()
+            val cardFromProto = protoIter.next()
+            assertEquals(cardFromCsv, cardFromProto)
+            ncards++
+        }
+
+/*
+        val inputStream = File(publisher.cardManifestFile()).inputStream()
+        val csvIter: CloseableIterator<CardUsingArrays> = IteratorCardUsingArrays(inputStream, bufferSize)
+        while (csvIter.hasNext() && ncards < 1000000) {
+            val card = csvIter.next()
+            ncards++
+        } */
+
+        val msPer = stopwatch.elapsed(TimeUnit.MILLISECONDS) / ncards.toDouble()
+        val secPer = msPer / 1000
+
+        println("timeReadCsv ($bufferSize):  ncards = $ncards, took $stopwatch = $msPer ms/card")
+        val totalCards = 4982747
+        println("time to read all cards = ${dfn(totalCards * secPer, 3)} secs")
+    }
+
+    @Test
+    fun testProtoAndCsvAgreeOnCardUsingArrays () {
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val publisher = Publisher("$topdir/audit")
+        val bufferSize = 100_000
+
+        val inputStream = File(publisher.cardManifestFile()).inputStream()
+        val csvIter: CloseableIterator<AuditableCardProto> = CsvCardUsingArrays(inputStream, bufferSize)
+
+        val protoFilename = "${testdataDir}/temp/cards.proto"
+        val stopwatch = Stopwatch()
+        var ncards = 0L
+
+        val protoIter: CloseableIterator<AuditableCardProto> = AuditableCardProtoIterator(protoFilename, bufferSize)
+        while (protoIter.hasNext() && csvIter.hasNext() && ncards < 100_000) {
+            val cardFromCsv = csvIter.next()
+            val cardFromProto = protoIter.next()
+            assertEquals(cardFromCsv, cardFromProto)
+            ncards++
+        }
+
+        val msPer = stopwatch.elapsed(TimeUnit.MILLISECONDS) / ncards.toDouble()
+        val secPer = msPer / 1000
+
+        println("timeReadCsv ($bufferSize):  ncards = $ncards, took $stopwatch = $msPer ms/card")
+        val totalCards = 4982747
+        println("time to read all cards = ${dfn(totalCards * secPer, 3)} secs")
+    }
+
+    @Test
+    fun testCsvAgreeOnCards () {
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val publisher = Publisher("$topdir/audit")
+        val bufferSize = 100_000
+
+        val inputStream = File(publisher.cardManifestFile()).inputStream()
+        val csvIter: CloseableIterator<AuditableCardProto> = CsvCardUsingArrays(inputStream, bufferSize)
+
+        val stopwatch = Stopwatch()
+        var ncards = 0L
+
+        val currentCardIter: CloseableIterator<CardWithBatchName> = readCardsCsvIterator(publisher.cardManifestFile())
+        while (currentCardIter.hasNext() && csvIter.hasNext() && ncards < 1000) {
+            val c1 = csvIter.next()
+            val c2 = currentCardIter.next()
+            assertTrue(checkEqual(c1, c2))
+            // println("ok ${c1.id}")
+            ncards++
+        }
+
+        val msPer = stopwatch.elapsed(TimeUnit.MILLISECONDS) / ncards.toDouble()
+        val secPer = msPer / 1000
+
+        println("timeReadCsv ($bufferSize):  ncards = $ncards, took $stopwatch = $msPer ms/card")
+        val totalCards = 4982747
+        println("time to read all cards = ${dfn(totalCards * secPer, 3)} secs")
+    }
+
+    // @Test
+    fun testProtoAgreeOnCards () {
+        val bufferSize = 100_000
+
+        val stopwatch = Stopwatch()
+        var ncards = 0L
+
+        val protoFilename = "${testdataDir}/temp/cards.proto"
+        val protoIter: CloseableIterator<CardWithBatchName> = ProtoCardBunchIterator(protoFilename, bufferSize)
+
+        val protoIterWithArrays: CloseableIterator<AuditableCardProto> = AuditableCardProtoIterator(protoFilename, bufferSize)
+        while (protoIterWithArrays.hasNext() && protoIter.hasNext() && ncards < 1000) {
+            val c1 = protoIterWithArrays.next()
+            val c2 = protoIter.next()
+            assertTrue(checkEqual(c1, c2))
+            // println("ok ${c1.id}")
+            ncards++
+        }
+        println("timeReadCsv ($bufferSize):  ncards = $ncards, took $stopwatch")
+    }
+}
+
+fun checkEqual(c1: AuditableCardProto, c2: CardWithBatchName): Boolean {
+    assertEquals(c1.id(), c2.id())
+    assertEquals(c1.location(), c2.location())
+    assertEquals(c1.index(), c2.index())
+    assertEquals(c1.prn(), c2.prn())
+    assertEquals(c1.poolId(), c2.poolId())
+    assertEquals(c1.styleName(), c2.styleName())
+
+    assertEquals(c1.votes == null, c2.votes == null)
+    if (c1.votes != null) {
+        val c1votes = c1.votes
+        for ((contestId, candidates) in c1.votes) {
+            val otherCands = c2.votes!![contestId]
+            assertTrue(candidates.contentEquals(otherCands))
+        }
+    }
+    return true
+}
+
+////////////
+
+
+class CsvCardUsingArrays(input: InputStream, bufferSize: Int): CloseableIterator<AuditableCardProto> {
+    // was val reader = BufferedReader(InputStreamReader(input, "ISO-8859-1")) for some reason
+    val reader = BufferedReader(InputStreamReader(input),bufferSize)
+    var nextLine: String? = null
+    var countLines  = 0
+
+    init {
+        reader.readLine() // get rid of header line
+    }
+
+    override fun hasNext() : Boolean {
+        if (nextLine == null) {
+            countLines++
+            nextLine = reader.readLine()
+        }
+        return nextLine != null
+    }
+
+    override fun next(): AuditableCardProto {
+        if (!hasNext()) throw NoSuchElementException()
+        val result =  readCardWithArrays(nextLine!!)
+        nextLine = null
+        return result
+    }
+
+    override fun close() {
+        reader.close()
+    }
+}
+
+
+fun readCardWithArrays(line: String): AuditableCardProto {
+    val tokens = line.split(",")
+    val ttokens = tokens.map { it.trim() }
+
+    var idx = 0
+    val id = ttokens[idx++]
+    val locationToken = ttokens[idx++]
+    val location = locationToken.ifEmpty { null }
+    val index = ttokens[idx++].toInt()
+    val sampleNum = ttokens[idx++].toLong(radix=16)
+    val phantom = ttokens[idx++] == "yes"
+    val poolIdToken = ttokens[idx++]
+    val poolId = if (poolIdToken.isEmpty()) null else poolIdToken.toInt()
+    val styleName = ttokens[idx++].trim()
+
+    // if clca, list of actual contests and their votes
+    // if (idx < ttokens.size-1) {
+    val contestsStr = ttokens[idx++].trim()
+    val contestsTokenTrimmed = contestsStr.split(" ").map { it.trim() }
+
+    val contestIds = mutableListOf<Int>()
+
+    contestsTokenTrimmed.forEach { tok ->
+        if (tok.isNotEmpty()) contestIds.add(tok.toInt())
+    }
+
+    val contestStarts = mutableListOf<Int>()
+    val candidates = mutableListOf<Int>()
+
+    val hasVotes = (idx + contestIds.size) < ttokens.size
+
+    val votes = if (!hasVotes) null else {
+        val work = mutableListOf<IntArray>()
+        while (idx < ttokens.size && (work.size < contestIds.size)) {
+            val vtokens = ttokens[idx]
+            val candArray =
+                if (vtokens.isEmpty()) intArrayOf()
+                else vtokens.split(" ").map { it.trim().toInt() }.toIntArray()
+            work.add(candArray)
+            idx++
+        }
+        require(contestIds.size == work.size) { "contests.size (${contestIds.size}) != votes.size (${work.size})" }
+        contestIds.zip(work).toMap()
+    }
+
+    if (votes != null) {
+        var start = 0
+        contestIds.forEach {
+            val cands = votes[it]!!
+            candidates.addAll(cands.toList())
+            contestStarts.add(start)
+            start += cands.size
+        }
+    }
+
+    return AuditableCardProto(
+        id,
+        if (location == id) null else location,
+        index, sampleNum, phantom, poolId,
+        contestIds.toIntArray(),
+        contestStarts.toIntArray(),
+        candidates.toIntArray(),
+        CardStyle.fromCvrBatch,
+        // styleName=styleName
+    )
+    //}
+    //return CardUsingArrays(id, location, index, sampleNum, phantom, poolId,null, , styleName=styleName)
+}
+
+

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/TestProtobuf.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/TestProtobuf.kt
@@ -1,22 +1,18 @@
-package org.cryptobiotic.rlauxe.persist.proto
+package org.cryptobiotic.rlauxe.persist.protobuf
 
 import kotlinx.serialization.decodeFromByteArray
 import kotlinx.serialization.encodeToByteArray
 import kotlinx.serialization.protobuf.ProtoBuf
-import org.cryptobiotic.rlauxe.audit.AuditableCardProto
 import org.cryptobiotic.rlauxe.audit.CardWithBatchName
+import org.cryptobiotic.rlauxe.persist.AuditRecord
+import org.cryptobiotic.rlauxe.persist.CountyAudit
 import org.cryptobiotic.rlauxe.persist.Publisher
-import org.cryptobiotic.rlauxe.persist.csv.CsvCardUsingArrays
 import org.cryptobiotic.rlauxe.persist.csv.readCardsCsvIterator
-import org.cryptobiotic.rlauxe.persist.protobuf.ProtoCard
-import org.cryptobiotic.rlauxe.persist.protobuf.AuditableCardProtoIterator
-import org.cryptobiotic.rlauxe.persist.protobuf.ProtoCardBunchIterator
-import org.cryptobiotic.rlauxe.persist.protobuf.publishProto
-import org.cryptobiotic.rlauxe.persist.protobuf.writeProtoCards
 import org.cryptobiotic.rlauxe.testdataDir
 import org.cryptobiotic.rlauxe.util.CloseableIterator
 import org.cryptobiotic.rlauxe.util.Stopwatch
 import org.cryptobiotic.rlauxe.util.dfn
+import org.cryptobiotic.rlauxe.workflow.PersistedMvrManager
 import java.io.File
 import java.io.FileOutputStream
 import java.io.OutputStream
@@ -28,7 +24,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
-class TestProtoCard {
+class TestProtobuf {
 
     // @Test
     fun testConvert(card: CardWithBatchName) {
@@ -50,30 +46,37 @@ class TestProtoCard {
     } */
 
     @Test
-    fun writeProtoFile () {
+    fun writeProtobufFile () {
         val topdir = "${testdataDir}/cases/corla/consistent"
         val publisher = Publisher("$topdir/audit")
         val cardIter: CloseableIterator<CardWithBatchName> = readCardsCsvIterator(publisher.cardManifestFile())
 
-        val protoFilename = "${topdir}/audit/cards.proto"
+        val protoFilename = "${topdir}/audit/cards.protobuf"
         val outputStream: OutputStream = FileOutputStream(protoFilename)
 
         val stopwatch = Stopwatch()
-        val ncards = writeProtoCards(cardIter, outputStream)
+        // fun writeProtobufCards(cards: CloseableIterator<CardIF>, output: OutputStream): Int {
+        val ncards = writeProtobufCards(cardIter, outputStream)
         outputStream.close()
         println("writeProtoFile ncards = $ncards, took $stopwatch")
     }
 
     @Test
-    fun timeReadProto () {
-        val protoFilename = "${testdataDir}/temp/cards.proto"
+    fun timeReadProtobuf () {
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val protoFilename = "${topdir}/audit/cards.protobuf"
         val bufferSize = 100_000
+
+        val countyAudit = AuditRecord.read(topdir) as CountyAudit
+        val mvrManager = PersistedMvrManager(countyAudit)
+        val styles = mvrManager.styles()
 
         val stopwatch = Stopwatch()
         var ncards = 0L
 
         var accum = 0
-        val protoIter: CloseableIterator<AuditableCardProto> = AuditableCardProtoIterator(protoFilename, bufferSize)
+        // class ProtobufCardIterator(filename: String, bufferSize: Int, val styles: List<StyleIF>? = null): CloseableIterator<AuditableCardProtobuf> {
+        val protoIter: CloseableIterator<AuditableCardProtobuf> = ProtobufCardIterator(protoFilename, bufferSize, styles)
         while (protoIter.hasNext()) { //  && ncards < 1000_000) {
             val card = protoIter.next()
             accum += card.index() // prevent optimization
@@ -83,93 +86,32 @@ class TestProtoCard {
         val msPer = stopwatch.elapsed(TimeUnit.MILLISECONDS) / ncards.toDouble()
         val secPer = msPer / 1000
 
-        println("timeReadProto ($bufferSize):  ncards = $ncards, accum=$accum took $stopwatch = $msPer ms/card")
-        val totalCards = 4982747
-        println("time to read all cards = ${dfn(totalCards * secPer, 3)} secs")
-    }
-    // ===========================
-    //ok 16 sec reading: use proto, CardUsingArrays, init votes lazily
-    //
-    //vs 52?
-    //should speed up Consistent sampling by 3x ??
-
-    @Test
-    fun timeReadCsv () {
-        val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
-
-        val stopwatch = Stopwatch()
-        var ncards = 0L
-        val bufferSize = 100_000
-
-        val inputStream = File(publisher.cardManifestFile()).inputStream()
-        val csvIter: CloseableIterator<AuditableCardProto> = CsvCardUsingArrays(inputStream, bufferSize)
-        while (csvIter.hasNext() && ncards < 1000000) {
-            val card = csvIter.next()
-            ncards++
-        }
-
-        val msPer = stopwatch.elapsed(TimeUnit.MILLISECONDS) / ncards.toDouble()
-        val secPer = msPer / 1000
-
-        println("timeReadCsv ($bufferSize):  ncards = $ncards, took $stopwatch = $msPer ms/card")
-        val totalCards = 4982747
-        println("time to read all cards = ${dfn(totalCards * secPer, 3)} secs")
-    }
-
-    // @Test
-    fun testProtoAndCsvAgreeOnCardWithBatchName () {
-        val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
-        val currentCardIter: CloseableIterator<CardWithBatchName> = readCardsCsvIterator(publisher.cardManifestFile())
-
-        val protoFilename = "${testdataDir}/temp/cards.proto"
-        val bufferSize = 100_000
-        val stopwatch = Stopwatch()
-        var ncards = 0L
-
-        val protoIter: CloseableIterator<CardWithBatchName> = ProtoCardBunchIterator(protoFilename, bufferSize)
-        while (protoIter.hasNext() && currentCardIter.hasNext() && ncards < 100_000) {
-            val cardFromCsv = currentCardIter.next()
-            val cardFromProto = protoIter.next()
-            assertEquals(cardFromCsv, cardFromProto)
-            ncards++
-        }
-
-/*
-        val inputStream = File(publisher.cardManifestFile()).inputStream()
-        val csvIter: CloseableIterator<CardUsingArrays> = IteratorCardUsingArrays(inputStream, bufferSize)
-        while (csvIter.hasNext() && ncards < 1000000) {
-            val card = csvIter.next()
-            ncards++
-        } */
-
-        val msPer = stopwatch.elapsed(TimeUnit.MILLISECONDS) / ncards.toDouble()
-        val secPer = msPer / 1000
-
-        println("timeReadCsv ($bufferSize):  ncards = $ncards, took $stopwatch = $msPer ms/card")
+        println("timeReadProtobuf ($bufferSize):  ncards = $ncards, accum=$accum took $stopwatch = $msPer ms/card")
         val totalCards = 4982747
         println("time to read all cards = ${dfn(totalCards * secPer, 3)} secs")
     }
 
     @Test
-    fun testProtoAndCsvAgreeOnCardUsingArrays () {
-        val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
+    fun testProtoAndCsvAgree () {
         val bufferSize = 100_000
 
-        val inputStream = File(publisher.cardManifestFile()).inputStream()
-        val csvIter: CloseableIterator<AuditableCardProto> = CsvCardUsingArrays(inputStream, bufferSize)
+        val topdir = "${testdataDir}/cases/corla/consistent"
+        val countyAudit = AuditRecord.read(topdir) as CountyAudit
+        val mvrManager = PersistedMvrManager(countyAudit)
+        val styles = mvrManager.styles()
 
-        val protoFilename = "${testdataDir}/temp/cards.proto"
+        val publisher = Publisher("$topdir/audit")
+        val csvIter: CloseableIterator<CardWithBatchName> = readCardsCsvIterator(publisher.cardManifestFile())
+
+        val protoFilename = "${topdir}/audit/cards.protobuf"
         val stopwatch = Stopwatch()
         var ncards = 0L
 
-        val protoIter: CloseableIterator<AuditableCardProto> = AuditableCardProtoIterator(protoFilename, bufferSize)
+        val protoIter: CloseableIterator<AuditableCardProtobuf> = ProtobufCardIterator(protoFilename, bufferSize, styles)
         while (protoIter.hasNext() && csvIter.hasNext() && ncards < 100_000) {
             val cardFromCsv = csvIter.next()
             val cardFromProto = protoIter.next()
-            assertEquals(cardFromCsv, cardFromProto)
+            assertTrue(checkEqual(cardFromCsv, cardFromProto))
             ncards++
         }
 
@@ -232,7 +174,7 @@ class TestProtoCard {
     }
 }
 
-fun checkEqual(c1: AuditableCardProto, c2: CardWithBatchName): Boolean {
+fun checkEqual(c1: CardWithBatchName, c2: AuditableCardProtobuf): Boolean {
     assertEquals(c1.id(), c2.id())
     assertEquals(c1.location(), c2.location())
     assertEquals(c1.index(), c2.index())

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/TestConsistentSamplerFromShangrla.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/TestConsistentSamplerFromShangrla.kt
@@ -52,8 +52,8 @@ class TestConsistentSamplerFromShangrla {
 
         val auditRound = AuditRound(1, contestRounds, samplePrns = emptyList())
 
-        val ballotCards = MvrManagerForTesting(cvrs, cvrs, 12345678901L)
-        consistentSampling(auditRound, ballotCards.sortedManifest())
+        val mvrManager = MvrManagerForTesting(cvrs, cvrs, 12345678901L)
+        consistentSampling(auditRound, mvrManager.samplingCards())
         assertEquals(3, auditRound.samplePrns.size)  // TODO was 5
 
         // assertEquals(listOf(3, 2, 1, 5, 0), auditRound.sampleNumbers)
@@ -101,8 +101,8 @@ class TestConsistentSamplerFromShangrla {
         assertEquals(10, cards.size)
 
         val auditRound = AuditRound(1, contestRounds, samplePrns = emptyList())
-        val ballotCards = MvrManagerForTesting(cvrs, cvrs, 123456789012L)
-        consistentSampling(auditRound, ballotCards.sortedManifest())
+        val mvrManager = MvrManagerForTesting(cvrs, cvrs, 123456789012L)
+        consistentSampling(auditRound, mvrManager.samplingCards())
         assertEquals(7, auditRound.samplePrns.size)
     }
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistentConsistentSampling.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistentConsistentSampling.kt
@@ -29,7 +29,7 @@ class TestPersistentConsistentSampling {
         val previousSamples = auditRecord.rounds.previousSamplePrns(auditRound.roundIdx)
 
         val workflow = PersistedWorkflow(auditRecord, true)
-        consistentSampling(auditRound, workflow.mvrManager().sortedManifest(), previousSamples)
+        consistentSampling(auditRound, workflow.mvrManager().samplingCards(), previousSamples)
         //val actualNewMvrs = auditRound.contestRounds.associate { it.contestUA.id to it.actualNewMvrs }
         //println("last auditRound actualNewMvrs = $actualNewMvrs")
     }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManagerForTesting.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManagerForTesting.kt
@@ -45,7 +45,7 @@ class MvrManagerForTesting(
     }
 
     override fun pools() = pools
-    override fun batches() = pools
+    override fun styles() = pools
 
     override fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCardIF>> {
         if (mvrsForRound.isEmpty()) {

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManagerFromManifest.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManagerFromManifest.kt
@@ -40,7 +40,7 @@ class MvrManagerFromManifest(
     }
 
     override fun pools() = pools
-    override fun batches() = pools
+    override fun styles() = pools
 
     override fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCardIF>>  {
         if (mvrsRound.isEmpty()) {  // for SingleRoundAudit.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ commons-math = "3.6.1"
 commons-poi = "5.5.1"
 kandy-letsPlot = "0.8.3"
 kotlin-statistics = "0.8.3"
+protobuf = "4.34.1"
 serialization = "1.11.0"
 xmlutil-version = "0.91.3"
 
@@ -42,6 +43,7 @@ commons-csv = { module = "org.apache.commons:commons-csv", version.ref = "common
 commons-math = { module = "org.apache.commons:commons-math3", version.ref = "commons-math" }
 commons-poi = { module = "org.apache.poi:poi", version.ref = "commons-poi" }
 commons-poi-ooxml = { module = "org.apache.poi:poi-ooxml", version.ref = "commons-poi" }
+google-protobuf = { group = "com.google.protobuf", name = "protobuf-kotlin", version.ref = "protobuf" }
 pdvrieze-xmlutil-core-xml = { module = "io.github.pdvrieze.xmlutil:core-jvmcommon", version.ref = "xmlutil-version" }
 pdvrieze-xmlutil-serialization-xml = { module = "io.github.pdvrieze.xmlutil:serialization-jvm", version.ref = "xmlutil-version" }
 
@@ -66,3 +68,5 @@ xmlutil = ["pdvrieze-xmlutil-core-xml", "pdvrieze-xmlutil-serialization-xml", ]
 [plugins]
 # kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+google-protobuf-kotlin = { id = "com.google.protobuf", version.ref = "protobuf" }
+

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/ClcaDistributions.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/ClcaDistributions.kt
@@ -83,7 +83,10 @@ class ClcaDistributions {
         val auditRound = AuditRound(1, contestRounds = contestRounds, samplePrns = emptyList())
 
         // just want the sample estimation stuff
-        val optimistic = EstimateAudit("none", config,  auditRound.roundIdx, auditRound.contestRounds, mvrManager.pools(), mvrManager.batches(), mvrManager.sortedManifest())
+        val optimistic = EstimateAudit("none", config,  auditRound.roundIdx, auditRound.contestRounds,
+            mvrManager.pools(),
+            mvrManager.styles(),
+            mvrManager.sortedManifest())
         return optimistic.run()
 
         /* was

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SFoaSingleRoundAuditTaskGenerator.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SFoaSingleRoundAuditTaskGenerator.kt
@@ -52,7 +52,7 @@ class SfoaSingleRoundAuditTask(
 
         val rlauxAudit = PersistedWorkflow.readFrom(auditDir)!!
         val mvrManager = rlauxAudit.mvrManager()
-        val batches = mvrManager.batches()
+        val batches = mvrManager.styles()
 
         rlauxAudit.contestsUA().forEach { contestUA ->
             contestUA.clcaAssertions.forEach { cassertion ->

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SfSingleRoundAuditTaskGenerator.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SfSingleRoundAuditTaskGenerator.kt
@@ -54,7 +54,7 @@ class SfSingleRoundAuditTask(
 
         val rlauxAudit = PersistedWorkflow.readFrom(auditDir)!!
         val mvrManager = rlauxAudit.mvrManager()
-        val batches = mvrManager.batches()
+        val batches = mvrManager.styles()
 
         rlauxAudit.contestsUA().forEach { contestUA ->
             contestUA.clcaAssertions.forEach { cassertion ->

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,6 +1,7 @@
 pluginManagement {
     repositories {
         gradlePluginPortal()
+        google()
     }
 }
 plugins {


### PR DESCRIPTION
use SamplingCards binary file
countyAudit caches sampleCards
resampleAndSaveResults(auditRecord)
sampling return List<Prn>
PersistedMvrManager lazy fields

replace more AuditableCard with AuditableCardIF
change "batches" to "styles"

check if google protobuf better than kotlin Proto (no) check if ProtoCardBunch better than single Proto delimited (no)