### PR TITLE
ClcaAssorter hasStyle -> useReportedMargin, no default

### DIFF
--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/belgium/CreateBelgiumElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/belgium/CreateBelgiumElection.kt
@@ -24,7 +24,7 @@ class BelgiumClca (
     val allCvrs: List<Cvr>
 
     init {
-        val contestUA = ContestWithAssertions(contestd, isClca=true).addAssertionsFromAssorters(contestd.assorters)
+        val contestUA = ContestWithAssertions(contestd, isClca=true, hasStyle=true).addAssertionsFromAssorters(contestd.assorters)
         contestsUA = listOf(contestUA)
         infoMap = contestsUA.associate { it.id to it.contest.info() }
         allCvrs = contestd.createSimulatedCvrs()

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoPolling.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoPolling.kt
@@ -17,7 +17,7 @@ class CreateColoradoPolling (
 
     init {
         contestsPolling = contestsUA.map { contestClca ->
-            ContestWithAssertions(contestClca.contest, isClca=false, NpopIn=contestClca.Npop).addStandardAssertions()
+            ContestWithAssertions(contestClca.contest, isClca=false, NpopIn=contestClca.Npop, hasStyle=true).addStandardAssertions()
         }
     }
 

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateUniformElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateUniformElection.kt
@@ -19,7 +19,6 @@ open class CreateUniformElection (
     val stateElection: CountyContestBuilder,
     val auditType: AuditType,
     val auditdir: String,
-    val hasStyle: Boolean,
     val pollingMode: PollingMode?,
     val name: String? = null,
 ): ElectionBuilder {
@@ -34,7 +33,7 @@ open class CreateUniformElection (
         val builders: List<CorlaContestBuilder> = stateElection.corlaContestBuilders
         val npopMap: Map<Int, Int> = builders.associate { it.info.id to it.Npop!! }.toMap()
 
-        contestsUA = ContestWithAssertions.make(stateElection.contests, npopMap, auditType.isClca(), hasStyle)
+        contestsUA = ContestWithAssertions.make(stateElection.contests, npopMap, auditType.isClca(), hasStyle=false)
     }
 
     override fun electionInfo() =
@@ -83,14 +82,14 @@ fun createUniformElection(
     name: String? = null,
 ) {
     val stopwatch = Stopwatch()
+    require (roundConfig.sampling.sampling == Sampling.uniform)
 
     val (mergedContestInfo: List<MergedContestInfo>, mergedCountyInfo, statewideContests) = mergeContestInfo()
 
     val countyElection = CountyContestBuilder()
 
     val election =
-        CreateUniformElection(countyElection, creation.auditType, auditdir, pollingMode=null, name=name,
-        hasStyle = roundConfig.sampling.sampling == Sampling.consistent)
+        CreateUniformElection(countyElection, creation.auditType, auditdir, pollingMode=null, name=name)
 
     // skip the simulated cvrs
     // createElectionRecord(election, auditDir = auditdir, clear = false)

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElection.kt
@@ -197,7 +197,7 @@ fun makeClcaContestsSF(infos: Map<Int, ContestInfo>, allCvrTabs: Map<Int, Contes
 
         val contestUA: ContestWithAssertions = if (!cvrTab.isIrv) {
             val contest = Contest(info, cvrTab.votes, useNc, cvrTab.ncardsTabulated)
-            ContestWithAssertions(contest, NpopIn=contestNbs[contestId]).addStandardAssertions()
+            ContestWithAssertions(contest, NpopIn=contestNbs[contestId], hasStyle=true).addStandardAssertions()
         } else {
             makeRaireContest(info, cvrTab, useNc, Nbin=contestNbs[contestId]!!) // HERE
         }
@@ -238,7 +238,7 @@ fun makePollingContestsSF(infos: Map<Int, ContestInfo>, allCvrTabs: Map<Int, Con
             if (!contestSumTab.isIrv) { // cant do IRV
                 val info = infos[contestId]!!
                 val contest = Contest(info, contestSumTab.votes, useNc, contestSumTab.ncardsTabulated)
-                val contestUA = ContestWithAssertions(contest, isClca = false, NpopIn=contestNbs[contestId]).addStandardAssertions()
+                val contestUA = ContestWithAssertions(contest, isClca = false, NpopIn=contestNbs[contestId], hasStyle=true).addStandardAssertions()
                 contestsUAs.add(contestUA)
             }
         }

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/irv/TestReadRaireBallotsCsv.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/irv/TestReadRaireBallotsCsv.kt
@@ -37,8 +37,8 @@ class TestReadRaireBallotsCsv {
             assertTrue(0.5 < margin2mean(cassertion.assorter.dilutedMargin()))
             cvrs.forEach {
                 assertTrue(cassertion.cassorter.assorter().assort(it) in 0.0..cassertion.cassorter.assorter().upperBound())
-                if (!it.phantom) assertEquals(cassertion.cassorter.noerror(), cassertion.cassorter.bassort(it, it, hasStyle=true))
-                else assertEquals(cassertion.cassorter.noerror()/2, cassertion.cassorter.bassort(it, it, hasStyle=true))
+                if (!it.phantom) assertEquals(cassertion.cassorter.noerror(), cassertion.cassorter.bassort(it, it))
+                else assertEquals(cassertion.cassorter.noerror()/2, cassertion.cassorter.bassort(it, it))
             }
         }
     }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCardM.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCardM.kt
@@ -51,9 +51,8 @@ data class AuditableCardM (
         this.style = style
         return this
     }
-    override fun style(): StyleIF? = style // TODO
+    override fun style(): StyleIF? = style // could work harder so its not null
 
-    // TODO could ignore useCvr
     private val votes: Map<Int, IntArray>? by lazy {
         if (contestIds.isEmpty()) null else {
             val lastIndex = contestIds.size - 1
@@ -70,6 +69,7 @@ data class AuditableCardM (
         }
     }
 
+    // TODO could ignore useCvr
     private val useCvr = CardStyle.useVotes(styleName)
     init {
         if (useCvr && votes == null) {
@@ -86,7 +86,7 @@ data class AuditableCardM (
     override fun styleName() = styleName
 
     override fun votes(): Map<Int, IntArray>? = votes
-    override fun votes(contestId: Int): IntArray? = votes?.get(contestId)
+    override fun votes(contestId: Int): IntArray? = votes?.get(contestId) // use instead of votes
 
     override fun hasContest(contestId: Int): Boolean {
         return if (!useCvr && style != null) style!!.hasContest(contestId)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ClcaAssorter.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ClcaAssorter.kt
@@ -1,13 +1,10 @@
 package org.cryptobiotic.rlauxe.core
 
-import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.betting.ClcaErrorRates
 import org.cryptobiotic.rlauxe.util.dfn
-import org.cryptobiotic.rlauxe.util.margin2mean
 import org.cryptobiotic.rlauxe.util.roundUp
 import kotlin.math.ln
 
-private val logger = KotlinLogging.logger("ClcaAssorter")
 
 /** See SHANGRLA Section 3.2.
  * Let bi denote the ith ballot, and let ci denote the cast-vote record for the ith ballot.
@@ -35,12 +32,12 @@ private val logger = KotlinLogging.logger("ClcaAssorter")
 open class ClcaAssorter(
     val info: ContestInfo,
     val assorter: AssorterIF,   // A
-    val hasStyle: Boolean = true,
+    val useReportedMargin: Boolean, // aka useStyle
     check: Boolean = true,
 ) {
     // in SHANGRLA 3.2, we have "Define v ≡ 2Āc − 1, the reported assorter margin."
     // see docs/notes/clcaNotes.md
-    val assorterMargin = if (hasStyle) assorter.reportedMargin() else assorter.dilutedMargin()
+    val assorterMargin = if (useReportedMargin) assorter.reportedMargin() else assorter.dilutedMargin()
 
     open fun classname() = this::class.simpleName
 
@@ -139,8 +136,8 @@ open class ClcaAssorter(
     // [2, (fol+2)/(fol+1), (2*fol+1)/(fol+1),  1, fol/(fol+1), 1/(fol+1), 0] * noerror
 
     // TODO use instance variable for hasStyle vs card.hasStyle()
-    open fun bassort(mvr: CvrIF, cvr:CvrIF, hasStyle:Boolean? = null): Double {
-        val overstatement = overstatementError(mvr, cvr, hasStyle ?: this.hasStyle) // ωi eq (1)
+    open fun bassort(mvr: CvrIF, cvr:CvrIF): Double { // }, hasStyle:Boolean? = null): Double {
+        val overstatement = overstatementError(mvr, cvr) // ωi eq (1)
         val tau = (1.0 - overstatement / this.assorter.upperBound()) // τi eq (6)
         return tau * noerror   // Bi eq (7)
     }
@@ -200,14 +197,14 @@ open class ClcaAssorter(
     // (0-u)        cvr has vote for loser, mvr has vote for winner : p2u = 2 vote understatement
     // could just use this.undervotes
 
-    fun overstatementError(mvr: CvrIF, cvr: CvrIF, hasStyle: Boolean): Double {
+    fun overstatementError(mvr: CvrIF, cvr: CvrIF): Double {
         // # SHANGRLA
         // if use_style and not cvr.has_contest(self.contest.id):
         //    raise ValueError(
         //      f"use_style==True but {cvr=} does not contain contest {self.contest.id}"
         //    )
         // if hasStyle, we use the cvr as the populations, so how did this happen?
-        if (hasStyle and !cvr.hasContest(info.id)) {
+        if (useReportedMargin and !cvr.hasContest(info.id)) {
             //val trace = Throwable().stackTraceToString()
             //logger.error { "hasCompleteCvrs==True but cvr=${cvr} does not contain contest ${info.name} (${info.id})\n$trace" }
             // TODO if we were using hasStyle in assorter.assort(), it would return 0.0 for cvr_assort, see Issue#552
@@ -227,7 +224,7 @@ open class ClcaAssorter(
         val mvr_assort =
             if (mvr.phantom()) 0.0
             else if (!mvr.hasContest(info.id)) {
-                if (hasStyle) 0.0 else 0.5
+                if (useReportedMargin) 0.0 else 0.5
             }
             else this.assorter.assort(mvr, usePhantoms = false)
 
@@ -241,7 +238,7 @@ open class ClcaAssorter(
     }
 
     override fun toString() = buildString {
-        append("${classname()} for contest ${info.name} (${info.id}) hasStyle=$hasStyle assorterMargin=${assorterMargin}")
+        append("${classname()} for contest ${info.name} (${info.id}) useReportedMargin=$useReportedMargin assorterMargin=${assorterMargin}")
         appendLine(" noerror=${dfn(noerror, 8)}")
         appendLine("  assorter=${assorter.desc()}")
     }
@@ -252,7 +249,7 @@ open class ClcaAssorter(
         if (this === other) return true
         if (other !is ClcaAssorter) return false
 
-        if (assorterMargin != other.assorterMargin) return false
+        if (useReportedMargin != other.useReportedMargin) return false
         if (info != other.info) return false
         if (assorter != other.assorter) return false
 
@@ -260,8 +257,8 @@ open class ClcaAssorter(
     }
 
     override fun hashCode(): Int {
-        var result = info.hashCode()
-        result = 31 * result + assorterMargin.hashCode()
+        var result = useReportedMargin.hashCode()
+        result = 31 * result + info.hashCode()
         result = 31 * result + assorter.hashCode()
         return result
     }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ContestWithAssertions.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/core/ContestWithAssertions.kt
@@ -13,7 +13,7 @@ import org.cryptobiotic.rlauxe.util.tabulateAuditableCards
 open class ContestWithAssertions(
     val contest: ContestIF,
     val isClca: Boolean = true,  // clca or oneaudit
-    val hasStyle: Boolean = true,
+    val hasStyle: Boolean = true, // TODO does it matter for polling ??
     NpopIn: Int? = null,
 ) {
     val id = contest.id

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditClcaAssorter.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditClcaAssorter.kt
@@ -89,9 +89,6 @@ constraint by subtracting the minimum possible value then re-scaling so that the
 null mean is 1/2 once again, which reproduces the original assorter, A:
  */
 
-private val logger = KotlinLogging.logger("OneAuditClcaAssorter")
-
-
 // for a specific assorter, all the averages in each pool
 data class AssortAvgsInPools (
     val assortAverage: Map<Int, Double>, // poolId -> average assort value
@@ -101,8 +98,7 @@ class OneAuditClcaAssorter(
     info: ContestInfo,
     assorter: AssorterIF,   // A(mvr) Use this assorter for the CVRs
     val poolAverages: AssortAvgsInPools,
-    // hasStyle: Boolean, // always use diluted margin
-) : ClcaAssorter(info, assorter, false) {
+) : ClcaAssorter(info, assorter, false) { // always use diluted margin
 
     override fun classname() = this::class.simpleName
 
@@ -113,11 +109,10 @@ class OneAuditClcaAssorter(
     fun poolAverage(poolId: Int?) = poolAverages.assortAverage[poolId]
 
     // B(bi, ci)
-    override fun bassort(mvr: CvrIF, cvr: CvrIF, hasStyle: Boolean?): Double {
-        val useStyle = hasStyle ?: this.hasStyle
-        // TODO why not cvr: AuditableCard ??
-        if (cvr.poolId() == null) {
-            return super.bassort(mvr, cvr, hasStyle) // here we use the standard assorter
+    override fun bassort(mvr: CvrIF, cvr: CvrIF): Double {
+
+        if (cvr.poolId() == null) { // poolId discriminates OneAudit pools vs cvrs
+            return super.bassort(mvr, cvr)
         }
 
         // TODO add verifier of poolAvg existence
@@ -127,7 +122,7 @@ class OneAuditClcaAssorter(
             return 0.0
         }
 
-        val overstatement = overstatementPoolError(mvr, poolAverage, useStyle) // ωi
+        val overstatement = overstatementPoolError(mvr, poolAverage) // ωi
         val tau = (1.0 - overstatement / this.assorter.upperBound()) // τi eq (6)
 
         val result =  tau * noerror()  // Bi eq (7)
@@ -139,11 +134,11 @@ class OneAuditClcaAssorter(
         return result
     }
 
-    fun overstatementPoolError(mvr: CvrIF, poolAvgAssortValue: Double, hasStyle: Boolean): Double {
+    fun overstatementPoolError(mvr: CvrIF, poolAvgAssortValue: Double): Double {
         val mvr_assort =
             if (mvr.phantom()) 0.0
             else if (!mvr.hasContest(info.id)) {
-                if (hasStyle) 0.0 else 0.5
+                if (useReportedMargin) 0.0 else 0.5
             }
             else this.assorter.assort(mvr, usePhantoms = false)
 
@@ -225,17 +220,21 @@ class OneAuditClcaAssorter(
 
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
+        if (other !is OneAuditClcaAssorter) return false
         if (!super.equals(other)) return false
 
-        other as OneAuditClcaAssorter
+        if (poolAverages != other.poolAverages) return false
 
-        return info == other.info
+        return true
     }
 
     override fun hashCode(): Int {
         var result = super.hashCode()
-        result = 31 * result + info.hashCode()
+        result = 31 * result + poolAverages.hashCode()
         return result
+    }
+
+    companion object {
+        private val logger = KotlinLogging.logger("OneAuditClcaAssorter")
     }
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditContestBuilder.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/oneaudit/OneAuditContestBuilder.kt
@@ -24,7 +24,7 @@ fun makeOneAuditContests(
 ): List<ContestWithAssertions> {
 
     val contestsUA = wantContests.filter{ !it.isIrv() }.map { contest ->
-        val cua = ContestWithAssertions(contest, true, NpopIn=npopMap[contest.id]).addStandardAssertions()
+        val cua = ContestWithAssertions(contest, true, NpopIn=npopMap[contest.id], hasStyle = false).addStandardAssertions()
         if (contest is DHondtContest) {
             cua.addAssertionsFromAssorters(contest.assorters)
         } else {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AssorterJson.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AssorterJson.kt
@@ -28,7 +28,7 @@ data class ClcaAssorterJson(
     val assorter: AssorterIFJson, // replicating the passorter
     val poolAverages: AssortAvgsInPoolsJson?, // consider putting these in another file ??
     val oaAssortRates: OneAuditAssortValueRatesJson?, // TODO may be very large, perhaps rehydrate from cardPool.csv ??
-    val hasStyle: Boolean = true,
+    val hasStyle: Boolean,
 )
 
 fun ClcaAssorter.publishJson() : ClcaAssorterJson {
@@ -38,7 +38,7 @@ fun ClcaAssorter.publishJson() : ClcaAssorterJson {
             this.assorter.publishJson(),
             poolAverages.publishJson(),
             oaAssortRates.publishJson(),
-            this.hasStyle,
+            this.useReportedMargin,
         )
 
     } else {
@@ -47,7 +47,7 @@ fun ClcaAssorter.publishJson() : ClcaAssorterJson {
             this.assorter.publishJson(),
             null,
             null,
-            this.hasStyle,
+            this.useReportedMargin,
         )
     }
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditRound.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestAuditRound.kt
@@ -17,7 +17,7 @@ class TestAuditRound {
     fun testAuditRound() {
         val test = MultiContestTestData(20, 11, 20000)
         val contestsUAs: List<ContestWithAssertions> = test.contests.map {
-            ContestWithAssertions(it, isClca = true).addStandardAssertions()
+            ContestWithAssertions(it, isClca=true, hasStyle=true).addStandardAssertions()
         }
         val (mvrs, cards, pools, styles) = test.makeMvrCardAndPops()
         val mvrManager = MvrManagerForTesting(mvrs, mvrs, Random.nextLong())

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestAssertions.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestAssertions.kt
@@ -134,7 +134,7 @@ class TestAssertions {
         assertEquals(" Plurality winner=4 loser=0 reportedMargin=24.9160% dilutedMargin=24.9160%", firstAssertion.toString())
         assertEquals("contest 0 winner: 4 loser: 0 upper: 1.0", firstAssertion.id())
 
-        val expectShow = """ cassorter: ClcaAssorter for contest AvB (0) hasStyle=true assorterMargin=0.24915950691072095 noerror=0.57115426
+        val expectShow = """ cassorter: ClcaAssorter for contest AvB (0) useReportedMargin=true assorterMargin=0.24915950691072095 noerror=0.57115426
   assorter= Plurality winner=4 loser=0 reportedMargin=24.9160% dilutedMargin=24.9160%
 """
         assertEquals(expectShow, firstAssertion.show())

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaAssortValues.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaAssortValues.kt
@@ -8,7 +8,6 @@ import org.cryptobiotic.rlauxe.util.sfn
 import kotlin.test.*
 
 class TestClcaAssortValues {
-    val hasStyle = true
 
     @Test
     fun testDhondt() {
@@ -29,7 +28,7 @@ class TestClcaAssortValues {
         assertNotEquals(assorter2, assorter)
         assertNotEquals(assorter2.hashCode(), assorter.hashCode())
 
-        val cassorter = ClcaAssorter(info, assorter)
+        val cassorter = ClcaAssorter(info, assorter, true)
         println(cassorter)
 
         val winner = Cvr("winner", mapOf(0 to intArrayOf(0)))
@@ -41,7 +40,7 @@ class TestClcaAssortValues {
         val taus = Taus(cassorter.assorter().upperBound())
         println("${taus.values()} * noerror=${cassorter.noerror}")
         println("${taus.names()}")
-        testAll(cassorter, taus, listOf(winner,other,loser, phantom), hasStyle=hasStyle)
+        testAll(cassorter, taus, listOf(winner,other,loser, phantom), hasStyle=true)
     }
 // output:
 // ClcaAssorter for contest AvB (0)
@@ -80,7 +79,7 @@ class TestClcaAssortValues {
         val contest =  Contest(info, votes, 2000, Ncast=2000)
         val assorter = PluralityAssorter.makeWithVotes(contest, winner = 0, loser = 1)
         println("assorter margins = ${assorter.reportedMargin} ${assorter.dilutedMargin}")
-        val cassorter = ClcaAssorter(info, assorter)
+        val cassorter = ClcaAssorter(info, assorter, true)
 
         val winner = Cvr("winner", mapOf(0 to intArrayOf(0)))
         val loser =  Cvr("loser", mapOf(0 to intArrayOf(1)))
@@ -92,8 +91,8 @@ class TestClcaAssortValues {
         println("${taus.values()} * noerror=${cassorter.noerror}")
         println("${taus.names()}")
 
-
-        testAll(cassorter, taus, listOf(winner,other,loser, phantom), hasStyle=false)
+        val cassorterNo = ClcaAssorter(info, assorter, false)
+        testAll(cassorterNo, taus, listOf(winner,other,loser, phantom), hasStyle=false)
     }
     // output:
     // PluralityAssorter
@@ -127,7 +126,8 @@ class TestClcaAssortValues {
         val votes = mapOf(0 to 1010, 1 to 990) // Map<Int, Int>
         val contest =  Contest(info, votes, 2000, Ncast=2000)
         val assorter = PluralityAssorter.makeWithVotes(contest, winner = 0, loser = 1)
-        val cassorter = ClcaAssorter(info, assorter)
+        val cassorter = ClcaAssorter(info, assorter, true)
+        val cassorterNo = ClcaAssorter(info, assorter, false)
 
         val winner = Cvr("winner", mapOf(0 to intArrayOf(0)))
         val loser =  Cvr("loser", mapOf(0 to intArrayOf(1)))
@@ -135,10 +135,10 @@ class TestClcaAssortValues {
         val missing =Cvr("missing", mapOf(1 to intArrayOf(2)))
 
         println("PluralityWithMissing hasStyle=false")
-        val taus = Taus(cassorter.assorter().upperBound())
-        println("${taus.values()} * noerror=${cassorter.noerror}")
+        val taus = Taus(cassorterNo.assorter().upperBound())
+        println("${taus.values()} * noerror=${cassorterNo.noerror}")
         println("${taus.names()}")
-        testAll(cassorter, taus, listOf(winner,other,loser,missing), hasStyle=false)
+        testAll(cassorterNo, taus, listOf(winner,other,loser,missing), hasStyle=false)
 
         println("\nPluralityWithMissing hasStyle=true")
         println("${taus.values()} * noerror=${cassorter.noerror}")
@@ -150,7 +150,7 @@ class TestClcaAssortValues {
         val triples = mutableListOf<Triple<Double, Cvr, Cvr>>()
         cvrs.forEach { cvr ->
             cvrs.forEach { mvr ->
-                val bassort = cassorter.bassort(mvr=mvr, cvr=cvr, hasStyle=hasStyle)
+                val bassort = cassorter.bassort(mvr=mvr, cvr=cvr)
                 triples.add(Triple(bassort, cvr, mvr))
             }
         }
@@ -173,13 +173,13 @@ class TestClcaAssortValues {
             else cassorter.assorter.assort(mvr, usePhantoms = false)
 
         val expect = expectV(cvrAssort=cvrValue, mvrAssort=mvrValue, cassorter.assorter().upperBound())
-        val actual = cassorter.bassort(mvr=mvr, cvr=cvr, hasStyle=hasStyle) / cassorter.noerror() // hasStyle ??
+        val actual = cassorter.bassort(mvr=mvr, cvr=cvr) / cassorter.noerror() // hasStyle ??
         val tauName = taus.nameOf(expect)
         println("  ${sfn(what, 15)} tau= ${df(actual)} '${sfn(tauName,7)}')")
 
         if (expect.isNaN() && actual.isNaN()) return
         if (expect != actual) {
-            cassorter.bassort(mvr=mvr, cvr=cvr, hasStyle=hasStyle) / cassorter.noerror() // hasStyle ??
+            cassorter.bassort(mvr=mvr, cvr=cvr) / cassorter.noerror() // hasStyle ??
         }
         assertEquals( expect, actual)
     }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaAssorter.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaAssorter.kt
@@ -26,7 +26,6 @@ Possible assort values are bassort in [0, 1/2, 1, 3/2, 2] * noerror, where:
 
 // See SHANGRLA 3.2
 class TestClcaAssorter {
-
     @Test
     fun testBasics() {
         val info = ContestInfo(
@@ -55,20 +54,20 @@ class TestClcaAssorter {
 
         ////////////////////////////////////////////////////////////////////////////////////////////////
 
-        val cassorter = ClcaAssorter(info, assorter)
+        val cassorter = ClcaAssorter(info, assorter, true)
         assertEquals(.01, mean2margin(awinnerAvg), doublePrecision)
         assertEquals(margin, cassorter.assorterMargin, doublePrecision)
-        assertEquals(0.0, cassorter.overstatementError(winnerCvr, winnerCvr, true))
-        assertEquals(-1.0, cassorter.overstatementError(winnerCvr, loserCvr, true))
-        assertEquals(-0.5, cassorter.overstatementError(winnerCvr, otherCvr, true))
+        assertEquals(0.0, cassorter.overstatementError(winnerCvr, winnerCvr))
+        assertEquals(-1.0, cassorter.overstatementError(winnerCvr, loserCvr))
+        assertEquals(-0.5, cassorter.overstatementError(winnerCvr, otherCvr))
 
-        assertEquals(1.0, cassorter.overstatementError(loserCvr, winnerCvr, true))
-        assertEquals(0.0, cassorter.overstatementError(loserCvr, loserCvr, true))
-        assertEquals(0.5, cassorter.overstatementError(loserCvr, otherCvr, true))
+        assertEquals(1.0, cassorter.overstatementError(loserCvr, winnerCvr))
+        assertEquals(0.0, cassorter.overstatementError(loserCvr, loserCvr))
+        assertEquals(0.5, cassorter.overstatementError(loserCvr, otherCvr))
 
-        assertEquals(0.5, cassorter.overstatementError(otherCvr, winnerCvr, true))
-        assertEquals(-0.5, cassorter.overstatementError(otherCvr, loserCvr, true))
-        assertEquals(0.0, cassorter.overstatementError(otherCvr, otherCvr, true))
+        assertEquals(0.5, cassorter.overstatementError(otherCvr, winnerCvr))
+        assertEquals(-0.5, cassorter.overstatementError(otherCvr, loserCvr))
+        assertEquals(0.0, cassorter.overstatementError(otherCvr, otherCvr))
         // overstatementError in [-1, -.5, 0, .5, 1]
 
         val noerror = 1.0 / (2.0 - margin)
@@ -78,17 +77,17 @@ class TestClcaAssorter {
 
         // bassort(mvr: Cvr, cvr:Cvr)
         // (1 − ωi /upper) / (2 − margin/upper), upper == assorter.upper
-        assertEquals(noerror, cassorter.bassort(winnerCvr, winnerCvr, true))         // no error
-        assertEquals(2 * noerror, cassorter.bassort(winnerCvr, loserCvr, true))      // cvr flipped vote from winner to loser
-        assertEquals(1.5 * noerror, cassorter.bassort(winnerCvr, otherCvr, true))    // flipped vote from winner to other
+        assertEquals(noerror, cassorter.bassort(winnerCvr, winnerCvr))         // no error
+        assertEquals(2 * noerror, cassorter.bassort(winnerCvr, loserCvr))      // cvr flipped vote from winner to loser
+        assertEquals(1.5 * noerror, cassorter.bassort(winnerCvr, otherCvr))    // flipped vote from winner to other
 
-        assertEquals(0.0, cassorter.bassort(loserCvr, winnerCvr, true))              // flipped vote from loser to winner
-        assertEquals(noerror, cassorter.bassort(loserCvr, loserCvr, true))           // no error
-        assertEquals(0.5 * noerror, cassorter.bassort(loserCvr, otherCvr, true))       // flipped vote from loser to other
+        assertEquals(0.0, cassorter.bassort(loserCvr, winnerCvr))              // flipped vote from loser to winner
+        assertEquals(noerror, cassorter.bassort(loserCvr, loserCvr))           // no error
+        assertEquals(0.5 * noerror, cassorter.bassort(loserCvr, otherCvr))       // flipped vote from loser to other
 
-        assertEquals(0.5 * noerror, cassorter.bassort(otherCvr, winnerCvr, true))      // flipped vote from other to winner
-        assertEquals(1.5 * noerror, cassorter.bassort(otherCvr, loserCvr, true))       // flipped vote from other to loser
-        assertEquals(noerror, cassorter.bassort(otherCvr, otherCvr, true))           // no error
+        assertEquals(0.5 * noerror, cassorter.bassort(otherCvr, winnerCvr))      // flipped vote from other to winner
+        assertEquals(1.5 * noerror, cassorter.bassort(otherCvr, loserCvr))       // flipped vote from other to loser
+        assertEquals(noerror, cassorter.bassort(otherCvr, otherCvr))           // no error
 
         // so bassort in [0, 2 / (2 - margin)] = [0, 2 / (3 - 2 * Aavg)] in {0, .5, 1, 1.5, 2} * noerror
         // so bassort in [0, 2*noerror], where noerror > .5. since margin > 0, since awinnerAvg > .5.
@@ -120,19 +119,19 @@ class TestClcaAssorter {
 
         val awinner = PluralityAssorter.makeWithVotes(contest, winner = 0, loser = 1)
         val awinnerAvg = cvrs.map { awinner.assort(it) }.average()
-        val cwinner = ClcaAssorter(info, awinner)
-        val cwinnerAvg = cvrs.map { cwinner.bassort(it, it, true) }.average()
+        val cwinner = ClcaAssorter(info, awinner, true)
+        val cwinnerAvg = cvrs.map { cwinner.bassort(it, it) }.average()
         println("cwinnerAvg=$cwinnerAvg <= awinnerAvg=$awinnerAvg")
         assertTrue(cwinnerAvg <= awinnerAvg)
         assertTrue(cwinnerAvg > 0.5)
 
         val aloser = PluralityAssorter.makeWithVotes(contest, winner = 1, loser = 0)
         val aloserAvg = cvrs.map { aloser.assort(it) }.average()
-        val closer = ClcaAssorter(info, aloser, check=false)
+        val closer = ClcaAssorter(info, aloser, true, check=false)
         assertEquals(mean2margin(aloserAvg), closer.assorterMargin, doublePrecision)
         assertEquals(aloserAvg, margin2mean(closer.assorterMargin))
 
-        val closerAvg = cvrs.map { closer.bassort(it, it, true) }.average()
+        val closerAvg = cvrs.map { closer.bassort(it, it) }.average()
         println("closerAvg=$closerAvg < aloserAvg=$aloserAvg")
         assertTrue(closerAvg < 0.5)
     }
@@ -194,8 +193,8 @@ class TestClcaAssorter {
     fun testNwayPlurality(contest : Contest, cvrs: List<Cvr>, winner: Int, loser:Int): Double {
         val assort = PluralityAssorter.makeWithVotes(contest, winner, loser)
         val assortAvg = cvrs.map { assort.assort(it) }.average()
-        val cwinner = ClcaAssorter(contest.info, assort, check=false)
-        val cwinnerAvg = cvrs.map { cwinner.bassort(it, it, true) }.average()
+        val cwinner = ClcaAssorter(contest.info, assort, true, check=false)
+        val cwinnerAvg = cvrs.map { cwinner.bassort(it, it) }.average()
         assertEquals(assortAvg, margin2mean(cwinner.assorterMargin), doublePrecision)
 
         println(" ($winner, $loser)= $cwinnerAvg")
@@ -278,42 +277,43 @@ class TestClcaAssorter {
         assertEquals(0.0, assorter.assort(phantomCvr, true))  // cvr is a phantom
         // so assort in {0, .5, 1}
 
-        val cassorter = ClcaAssorter(info, assorter)
+        val cassorter = ClcaAssorter(info, assorter, true)
+        val cassorterNo = ClcaAssorter(info, assorter, false)
         val noerror = cassorter.noerror()
         assertEquals(margin, cassorter.assorterMargin, doublePrecision)
         assertEquals(awinnerAvg, margin2mean(cassorter.assorterMargin))
 
-        assertEquals(0.0, cassorter.overstatementError(winnerCvr, winnerCvr, true))
-        assertEquals(-1.0, cassorter.overstatementError(winnerCvr, loserCvr, true))
-        assertEquals(-0.5, cassorter.overstatementError(winnerCvr, otherCvr, true))
-        assertEquals(-0.5, cassorter.overstatementError(winnerCvr, phantomCvr, true))
+        assertEquals(0.0, cassorter.overstatementError(winnerCvr, winnerCvr))
+        assertEquals(-1.0, cassorter.overstatementError(winnerCvr, loserCvr))
+        assertEquals(-0.5, cassorter.overstatementError(winnerCvr, otherCvr))
+        assertEquals(-0.5, cassorter.overstatementError(winnerCvr, phantomCvr))
 
-        assertEquals(1.0, cassorter.overstatementError(loserCvr, winnerCvr, true))
-        assertEquals(0.0, cassorter.overstatementError(loserCvr, loserCvr, true))
-        assertEquals(0.5, cassorter.overstatementError(loserCvr, otherCvr, true))
-        assertEquals(0.5, cassorter.overstatementError(loserCvr, phantomCvr, true))
+        assertEquals(1.0, cassorter.overstatementError(loserCvr, winnerCvr))
+        assertEquals(0.0, cassorter.overstatementError(loserCvr, loserCvr))
+        assertEquals(0.5, cassorter.overstatementError(loserCvr, otherCvr))
+        assertEquals(0.5, cassorter.overstatementError(loserCvr, phantomCvr))
 
-        assertEquals(0.5, cassorter.overstatementError(otherCvr, winnerCvr, true))
-        assertEquals(-0.5, cassorter.overstatementError(otherCvr, loserCvr, true))
-        assertEquals(0.0, cassorter.overstatementError(otherCvr, otherCvr, true))
+        assertEquals(0.5, cassorter.overstatementError(otherCvr, winnerCvr))
+        assertEquals(-0.5, cassorter.overstatementError(otherCvr, loserCvr))
+        assertEquals(0.0, cassorter.overstatementError(otherCvr, otherCvr))
 
-        assertEquals(1.0, cassorter.overstatementError(phantomCvr, winnerCvr, true)) // check
-        assertEquals(0.0, cassorter.overstatementError(phantomCvr, loserCvr, true)) // check
-        assertEquals(0.5, cassorter.overstatementError(phantomCvr, phantomCvr, true)) // check, usual case
+        assertEquals(1.0, cassorter.overstatementError(phantomCvr, winnerCvr)) // check
+        assertEquals(0.0, cassorter.overstatementError(phantomCvr, loserCvr)) // check
+        assertEquals(0.5, cassorter.overstatementError(phantomCvr, phantomCvr)) // check, usual case
         // so overstatementError in [-1, -.5, 0, .5, 1]
 
         val cvrs = listOf(winnerCvr, loserCvr, otherCvr, phantomCvr)
         for (mvr in cvrs) {
             for (cvr in cvrs) {
-                println("cvr-mvr overstatement ${cvr.id}-${mvr.id} = ${cassorter.overstatementError(mvr, cvr, true)} " +
-                        "bassort=${cassorter.bassort(mvr, cvr, true)/noerror}")
+                println("cvr-mvr overstatement ${cvr.id}-${mvr.id} = ${cassorter.overstatementError(mvr, cvr)} " +
+                        "bassort=${cassorter.bassort(mvr, cvr)/noerror}")
             }
         }
 
         // TODO hasStyle parameter doesnt matter unless mvr doesnt have the contest. See testHasStyles below.
         for (mvr in cvrs) {
             for (cvr in cvrs) {
-                assertEquals(cassorter.overstatementError(mvr, cvr, false), cassorter.overstatementError(mvr, cvr, true))
+                assertEquals(cassorterNo.overstatementError(mvr, cvr), cassorter.overstatementError(mvr, cvr))
             }
         }
 
@@ -322,25 +322,25 @@ class TestClcaAssorter {
         println("noerror = $noerror")
 
         // bassort in [0, .5, 1, 1.5, 2] * noerror = [twoOver, oneOver, nuetral, oneUnder, twoUnder]
-        assertEquals(noerror, cassorter.bassort(winnerCvr, winnerCvr, true))         // no error
-        assertEquals(2 * noerror, cassorter.bassort(winnerCvr, loserCvr, true))      // cvr flipped vote from winner to loser
-        assertEquals(1.5 * noerror, cassorter.bassort(winnerCvr, otherCvr, true))    // cvr flipped vote from winner to other
-        assertEquals(1.5 * noerror, cassorter.bassort(winnerCvr, phantomCvr, true))  // found winner: oneUnder
+        assertEquals(noerror, cassorter.bassort(winnerCvr, winnerCvr))         // no error
+        assertEquals(2 * noerror, cassorter.bassort(winnerCvr, loserCvr))      // cvr flipped vote from winner to loser
+        assertEquals(1.5 * noerror, cassorter.bassort(winnerCvr, otherCvr))    // cvr flipped vote from winner to other
+        assertEquals(1.5 * noerror, cassorter.bassort(winnerCvr, phantomCvr))  // found winner: oneUnder
 
-        assertEquals(0.0, cassorter.bassort(loserCvr, winnerCvr, true))              // cvr flipped vote from loser to winner
-        assertEquals(noerror, cassorter.bassort(loserCvr, loserCvr, true))           // no error
-        assertEquals(0.5*noerror, cassorter.bassort(loserCvr, otherCvr, true))       // cvr flipped vote from loser to other
-        assertEquals(0.5*noerror, cassorter.bassort(loserCvr, phantomCvr, true))     // found loser: oneOver
+        assertEquals(0.0, cassorter.bassort(loserCvr, winnerCvr))              // cvr flipped vote from loser to winner
+        assertEquals(noerror, cassorter.bassort(loserCvr, loserCvr))           // no error
+        assertEquals(0.5*noerror, cassorter.bassort(loserCvr, otherCvr))       // cvr flipped vote from loser to other
+        assertEquals(0.5*noerror, cassorter.bassort(loserCvr, phantomCvr))     // found loser: oneOver
 
-        assertEquals(0.5*noerror, cassorter.bassort(otherCvr, winnerCvr, true))      // cvr flipped vote from other to winner
-        assertEquals(1.5*noerror, cassorter.bassort(otherCvr, loserCvr, true))       // cvr flipped vote from other to loser
-        assertEquals(noerror, cassorter.bassort(otherCvr, otherCvr, true))           // no error
+        assertEquals(0.5*noerror, cassorter.bassort(otherCvr, winnerCvr))      // cvr flipped vote from other to winner
+        assertEquals(1.5*noerror, cassorter.bassort(otherCvr, loserCvr))       // cvr flipped vote from other to loser
+        assertEquals(noerror, cassorter.bassort(otherCvr, otherCvr))           // no error
 
-        assertEquals(0.0, cassorter.bassort(phantomCvr, winnerCvr, true))           // no mvr, cvr reported winner, : twoOver
-        assertEquals(noerror, cassorter.bassort(phantomCvr, loserCvr, true))                 // no mvr, cvr reported loser: nuetral
-        assertEquals(0.5*noerror, cassorter.bassort(phantomCvr, phantomCvr, true))  // no mvr, no cvr: oneOver (common case i assume)
-        assertEquals(1.5*noerror, cassorter.bassort(winnerCvr, phantomCvr, true))   // mvr reported winner, no cvr: oneUnder
-        assertEquals(.5*noerror, cassorter.bassort(loserCvr, phantomCvr, true))     // mvr reported lose, no cvr: oneOver
+        assertEquals(0.0, cassorter.bassort(phantomCvr, winnerCvr))           // no mvr, cvr reported winner, : twoOver
+        assertEquals(noerror, cassorter.bassort(phantomCvr, loserCvr))                 // no mvr, cvr reported loser: nuetral
+        assertEquals(0.5*noerror, cassorter.bassort(phantomCvr, phantomCvr))  // no mvr, no cvr: oneOver (common case i assume)
+        assertEquals(1.5*noerror, cassorter.bassort(winnerCvr, phantomCvr))   // mvr reported winner, no cvr: oneUnder
+        assertEquals(.5*noerror, cassorter.bassort(loserCvr, phantomCvr))     // mvr reported lose, no cvr: oneOver
     }
 
     @Test
@@ -359,36 +359,36 @@ class TestClcaAssorter {
         val contest = makeContestFromCvrs(info, cvrs)
 
         val assorter = PluralityAssorter.makeWithVotes(contest, winner = 0, loser = 1)
-        val cassorterHasStyle = ClcaAssorter(info, assorter)
+        val cassorterHasStyle = ClcaAssorter(info, assorter, true)
+        val cassorterNoStyle = ClcaAssorter(info, assorter, false)
         val noerror = cassorterHasStyle.noerror()
         println("  noerror = $noerror")
 
         val differentContest = Cvr("diff", mapOf(1 to IntArray(0)))
 
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(winnerCvr, differentContest, false))
-        assertEquals(Double.NaN, cassorterHasStyle.overstatementError(winnerCvr, differentContest, true))
+        assertEquals(-0.5, cassorterNoStyle.overstatementError(winnerCvr, differentContest))
+        assertEquals(Double.NaN, cassorterHasStyle.overstatementError(winnerCvr, differentContest))
         /* val mess = assertFailsWith<RuntimeException> {
-            assertEquals(0.0, cassorterHasStyle.overstatementError(winnerCvr, differentContest, true))
+            assertEquals(0.0, cassorterHasStyle.overstatementError(winnerCvr, differentContest))
         }.message!!
         assertTrue(mess.contains("does not contain contest")) */
 
-        assertEquals(1.0, cassorterHasStyle.overstatementError(differentContest, winnerCvr, true))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(differentContest, loserCvr, true))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(differentContest, otherCvr, true))
+        assertEquals(1.0, cassorterHasStyle.overstatementError(differentContest, winnerCvr))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(differentContest, loserCvr))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(differentContest, otherCvr))
 
-        assertEquals(0.0 * noerror, cassorterHasStyle.bassort(differentContest, winnerCvr, true))
-        assertEquals(1.0 * noerror, cassorterHasStyle.bassort(differentContest, loserCvr, true))
-        assertEquals(0.5 * noerror, cassorterHasStyle.bassort(differentContest, otherCvr, true))
+        assertEquals(0.0 * noerror, cassorterHasStyle.bassort(differentContest, winnerCvr))
+        assertEquals(1.0 * noerror, cassorterHasStyle.bassort(differentContest, loserCvr))
+        assertEquals(0.5 * noerror, cassorterHasStyle.bassort(differentContest, otherCvr))
 
         // hasStyle = false
-        val cassorterNoStyle = ClcaAssorter(info, assorter)
-        assertEquals(0.5, cassorterNoStyle.overstatementError(differentContest, winnerCvr, false))
-        assertEquals(-0.5, cassorterNoStyle.overstatementError(differentContest, loserCvr, false))
-        assertEquals(0.0, cassorterNoStyle.overstatementError(differentContest, otherCvr, false))
+        assertEquals(0.5, cassorterNoStyle.overstatementError(differentContest, winnerCvr))
+        assertEquals(-0.5, cassorterNoStyle.overstatementError(differentContest, loserCvr))
+        assertEquals(0.0, cassorterNoStyle.overstatementError(differentContest, otherCvr))
 
-        assertEquals(0.5 * noerror, cassorterNoStyle.bassort(differentContest, winnerCvr, false))
-        assertEquals(1.5 * noerror, cassorterNoStyle.bassort(differentContest, loserCvr, false))
-        assertEquals(1.0 * noerror, cassorterNoStyle.bassort(differentContest, otherCvr, false))
+        assertEquals(0.5 * noerror, cassorterNoStyle.bassort(differentContest, winnerCvr))
+        assertEquals(1.5 * noerror, cassorterNoStyle.bassort(differentContest, loserCvr))
+        assertEquals(1.0 * noerror, cassorterNoStyle.bassort(differentContest, otherCvr))
     }
 
     @Test
@@ -440,6 +440,6 @@ class TestClcaAssorter {
 
 fun ClcaAssorter.calcClcaAssorterMargin(cvrPairs: Iterable<Pair<Cvr, Cvr>>): Double {
     val mean = cvrPairs.filter{ it.first.hasContest(info.id) }
-        .map { bassort(it.first, it.second, true) }.average()
+        .map { bassort(it.first, it.second) }.average()
     return mean2margin(mean)
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaDilutedVsReportedMargin.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestClcaDilutedVsReportedMargin.kt
@@ -1,23 +1,13 @@
 package org.cryptobiotic.rlauxe.core
 
-import org.cryptobiotic.rlauxe.estimate.calcAssorterMargin
-import org.cryptobiotic.rlauxe.util.tabulateCvrs
 import org.cryptobiotic.rlauxe.util.doublePrecision
-import org.cryptobiotic.rlauxe.estimate.makeCvrsByExactMean
-import org.cryptobiotic.rlauxe.estimate.partition
-import org.cryptobiotic.rlauxe.util.makePhantomCvrs
 import org.cryptobiotic.rlauxe.util.*
-import kotlin.random.Random
 import kotlin.test.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertIs
-import kotlin.test.assertNotNull
-
 
 class TestClcaDilutedVsReportedMargins {
 
     // isnt it a problem that we get noerror when the contest isnt even on the card? it should not count one way or another = 1/2
-
 
     // whether cassorter == assorter.reportedMargin() or assorter.dilutedMargin(). the average is noerror when hasStyle = false
     // so what determines whether assorter.reportedMargin() or assorter.dilutedMargin() is correct ??
@@ -55,14 +45,14 @@ class TestClcaDilutedVsReportedMargins {
         println(contest)
         assertEquals(cvrs.size, contest.Nc)
         // make dilutedMargin different than reportedMargin by setting NpopIn != contest.Nc
-        val contestUA = ContestWithAssertions(contest, isClca = true, NpopIn = contest.Nc + 2).addStandardAssertions()
+        val contestUA = ContestWithAssertions(contest, isClca = true, NpopIn = contest.Nc + 2, hasStyle = false).addStandardAssertions()
         val assertions = contestUA.clcaAssertions
 
         assertions.forEach {
             val assorter = it.assorter
             val cassorter = it.cassorter
 
-            val assortAvg = cvrs.map { cvr -> cassorter.bassort(cvr, cvr, false) }.average()
+            val assortAvg = cvrs.map { cvr -> cassorter.bassort(cvr, cvr) }.average()
             println("${cassorter.shortName()}: cvrMean=${assortAvg} noerror = ${cassorter.noerror}")
             assertEquals(assortAvg, cassorter.noerror, doublePrecision)
         }
@@ -79,7 +69,7 @@ class TestClcaDilutedVsReportedMargins {
             val assorter = it.assorter
             val cassorter = it.cassorter
             showAverage(plusOtherCvrs, cassorter)
-            val assortAvg = plusOtherCvrs.map { cvr -> cassorter.bassort(cvr, cvr, false) }.average()
+            val assortAvg = plusOtherCvrs.map { cvr -> cassorter.bassort(cvr, cvr) }.average()
             println("${cassorter.shortName()}: cvrMean=${assortAvg} noerror = ${cassorter.noerror}")
             assertEquals(assortAvg, cassorter.noerror, doublePrecision)
         }
@@ -87,7 +77,7 @@ class TestClcaDilutedVsReportedMargins {
 
     fun showAverage(cvrs: List<Cvr>, cassorter: ClcaAssorter) {
         cvrs.forEach {
-            println("cvr=$it, bassort= ${cassorter.bassort(it, it, false)}")
+            println("cvr=$it, bassort= ${cassorter.bassort(it, it)}")
         }
     }
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestShangrlaAssertions.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/core/TestShangrlaAssertions.kt
@@ -2,7 +2,6 @@ package org.cryptobiotic.rlauxe.core
 
 import org.cryptobiotic.rlauxe.estimate.makeCvr
 import org.cryptobiotic.rlauxe.util.listToMap
-import org.cryptobiotic.rlauxe.util.margin2mean
 import kotlin.test.Test
 import kotlin.test.assertEquals
 
@@ -193,72 +192,73 @@ class TestShangrlaAssertions {
         //                        - CVR.as_vote(c.get_vote_for("AvB", losr))
         //                        + 1)/2), upper_bound=1))
         val aliceVsBob = PluralityAssorter.makeWithVotes(plur_con_test, winner = 0, loser = 1)
-        val cassorter = ClcaAssorter(plur_con_test.info, aliceVsBob)
+        val cassorter = ClcaAssorter(plur_con_test.info, aliceVsBob, true)
+        val cassorterNo = ClcaAssorter(plur_con_test.info, aliceVsBob, false)
 
         //        assert aVb.assorter.overstatement(mvrs[0], cvrs[0], use_style=True) == 0
         //        assert aVb.assorter.overstatement(mvrs[0], cvrs[0], use_style=False) == 0
-        assertEquals(0.0, cassorter.overstatementError(mvr0, cvr0, hasStyle = true))
-        assertEquals(0.0, cassorter.overstatementError(mvr0, cvr0, hasStyle = false))
+        assertEquals(0.0, cassorter.overstatementError(mvr0, cvr0))
+        assertEquals(0.0, cassorterNo.overstatementError(mvr0, cvr0))
 
         //
         //        assert aVb.assorter.overstatement(mvrs[0], cvrs[1], use_style=True) == -1
         //        assert aVb.assorter.overstatement(mvrs[0], cvrs[1], use_style=False) == -1
-        assertEquals(-1.0, cassorter.overstatementError(mvr0, cvr1, hasStyle = true))
-        assertEquals(-1.0, cassorter.overstatementError(mvr0, cvr1, hasStyle = false))
+        assertEquals(-1.0, cassorter.overstatementError(mvr0, cvr1))
+        assertEquals(-1.0, cassorterNo.overstatementError(mvr0, cvr1))
 
         //
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[0], use_style=True) == 1/2
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[0], use_style=False) == 1/2
-        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasStyle = true))
-        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasStyle = false))
+        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0))
+        assertEquals(0.5, cassorterNo.overstatementError(mvr2, cvr0))
 
         //
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[1], use_style=True) == -1/2
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[1], use_style=False) == -1/2
-        assertEquals(-0.5, cassorter.overstatementError(mvr2, cvr1, hasStyle = true))
-        assertEquals(-0.5, cassorter.overstatementError(mvr2, cvr1, hasStyle = false))
+        assertEquals(-0.5, cassorter.overstatementError(mvr2, cvr1))
+        assertEquals(-0.5, cassorterNo.overstatementError(mvr2, cvr1))
 
         //
         //
         //        assert aVb.assorter.overstatement(mvrs[1], cvrs[0], use_style=True) == 1
         //        assert aVb.assorter.overstatement(mvrs[1], cvrs[0], use_style=False) == 1
-        assertEquals(1.0, cassorter.overstatementError(mvr1, cvr0, hasStyle = true))
-        assertEquals(1.0, cassorter.overstatementError(mvr1, cvr0, hasStyle = false))
+        assertEquals(1.0, cassorter.overstatementError(mvr1, cvr0))
+        assertEquals(1.0, cassorterNo.overstatementError(mvr1, cvr0))
 
         //
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[0], use_style=True) == 1/2
         //        assert aVb.assorter.overstatement(mvrs[2], cvrs[0], use_style=False) == 1/2
-        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasStyle = true))
-        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0, hasStyle = false))
+        assertEquals(0.5, cassorter.overstatementError(mvr2, cvr0))
+        assertEquals(0.5, cassorterNo.overstatementError(mvr2, cvr0))
 
         //
         //        assert aVb.assorter.overstatement(mvrs[3], cvrs[0], use_style=True) == 1
         //        assert aVb.assorter.overstatement(mvrs[3], cvrs[0], use_style=False) == 1/2
-        assertEquals(1.0, cassorter.overstatementError(wrongContestMvr, cvr0, hasStyle = true))
-        assertEquals(0.5, cassorter.overstatementError(wrongContestMvr, cvr0, hasStyle = false))
+        assertEquals(1.0, cassorter.overstatementError(wrongContestMvr, cvr0))
+        assertEquals(0.5, cassorterNo.overstatementError(wrongContestMvr, cvr0))
 
-        assertEquals(0.0, cassorter.overstatementError(wrongContestMvr, wrongContestMvr, hasStyle = false))
-        assertEquals(Double.NaN, cassorter.overstatementError(wrongContestMvr, wrongContestMvr, hasStyle = true))
+        assertEquals(0.0, cassorterNo.overstatementError(wrongContestMvr, wrongContestMvr))
+        assertEquals(Double.NaN, cassorter.overstatementError(wrongContestMvr, wrongContestMvr))
         /*val mess = assertFailsWith<RuntimeException>{
-            cassorter.overstatementError(wrongContestMvr, wrongContestMvr, hasStyle = true)
+            cassorter.overstatementError(wrongContestMvr, wrongContestMvr)
         }.message
         assertEquals("hasCompleteCvrs==True but cvr=wrongContest (false)  1: [1] does not contain contest AvB (0)", mess) */
 
         //
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[4], use_style=True) == 1/2
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[4], use_style=False) == 1/2
-        assertEquals(0.5, cassorter.overstatementError(mvr4, cvr4, hasStyle = true))
-        assertEquals(0.5, cassorter.overstatementError(mvr4, cvr4, hasStyle = false))
+        assertEquals(0.5, cassorter.overstatementError(mvr4, cvr4))
+        assertEquals(0.5, cassorterNo.overstatementError(mvr4, cvr4))
 
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[0], use_style=True) == 1
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[0], use_style=False) == 1
-        assertEquals(1.0, cassorter.overstatementError(mvr4, cvr0, hasStyle = true))
-        assertEquals(1.0, cassorter.overstatementError(mvr4, cvr0, hasStyle = false))
+        assertEquals(1.0, cassorter.overstatementError(mvr4, cvr0))
+        assertEquals(1.0, cassorterNo.overstatementError(mvr4, cvr0))
 
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[1], use_style=True) == 0
         //        assert aVb.assorter.overstatement(mvrs[4], cvrs[1], use_style=False) == 0
-        assertEquals(0.0, cassorter.overstatementError(mvr4, cvr1, hasStyle = true))
-        assertEquals(0.0, cassorter.overstatementError(mvr4, cvr1, hasStyle = false))
+        assertEquals(0.0, cassorter.overstatementError(mvr4, cvr1))
+        assertEquals(0.0, cassorterNo.overstatementError(mvr4, cvr1))
     }
 
     // plurality assort = {1, 0, .5} if vote is for { winner, loser, neither}
@@ -294,99 +294,100 @@ class TestShangrlaAssertions {
     fun test_overstatement_plurality() { // agrees with SHANGRLA
         // winner = alice, loser = bob
         val aliceVsBobP = PluralityAssorter(plur_con_test.info, winner = 0, loser = 1).setMargins(0.2)
-        val cassorterHasStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP)
+        val cassorterHasStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP, true)
+        val cassorterNoStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP, false)
 
         // mvr == cvr, always get noerror
-        assertEquals(0.0, cassorterHasStyle.overstatementError(aliceMvr, aliceMvr, hasStyle = true)) // 1
-        assertEquals(0.0, cassorterHasStyle.overstatementError(bobMvr, bobMvr, hasStyle = true))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, candyMvr, hasStyle = true))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, undervoteMvr, hasStyle = true))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(aliceMvr, aliceMvr)) // 1
+        assertEquals(0.0, cassorterHasStyle.overstatementError(bobMvr, bobMvr))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, candyMvr))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, undervoteMvr))
 
-        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, wrongContestMvr, hasStyle = false))
-        assertEquals(Double.NaN, cassorterHasStyle.overstatementError(wrongContestMvr, wrongContestMvr, hasStyle = true))
+        assertEquals(0.0, cassorterNoStyle.overstatementError(wrongContestMvr, wrongContestMvr))
+        assertEquals(Double.NaN, cassorterHasStyle.overstatementError(wrongContestMvr, wrongContestMvr))
         /* val mess1 = assertFailsWith<RuntimeException>{
             assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(wrongContestMvr, wrongContestMvr)) // ??, hasCompleteCvrs = false))
         }.message
         assertEquals("hasCompleteCvrs==True but cvr=wrongContest (false)  1: [1] does not contain contest AvB (0)", mess1) */
 
-        assertEquals(1.0, cassorterHasStyle.overstatementError(bobMvr, aliceMvr, hasStyle = true)) // 2
-        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, candyMvr, hasStyle = true))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, undervoteMvr, hasStyle = true))
-        assertEquals(-1.0, cassorterHasStyle.overstatementError(aliceMvr, bobMvr, hasStyle = true))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, candyMvr, hasStyle = true))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, undervoteMvr, hasStyle = true))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(candyMvr, bobMvr, hasStyle = true))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(candyMvr, aliceMvr, hasStyle = true))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, danMvr, hasStyle = true))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(undervoteMvr, bobMvr, hasStyle = true)) // none = other
-        assertEquals(0.5, cassorterHasStyle.overstatementError(undervoteMvr, aliceMvr, hasStyle = true))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, danMvr, hasStyle = true))
+        assertEquals(1.0, cassorterHasStyle.overstatementError(bobMvr, aliceMvr)) // 2
+        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, candyMvr))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, undervoteMvr))
+        assertEquals(-1.0, cassorterHasStyle.overstatementError(aliceMvr, bobMvr))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, candyMvr))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, undervoteMvr))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(candyMvr, bobMvr))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(candyMvr, aliceMvr))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, danMvr))
+        assertEquals(-0.5, cassorterHasStyle.overstatementError(undervoteMvr, bobMvr)) // none = other
+        assertEquals(0.5, cassorterHasStyle.overstatementError(undervoteMvr, aliceMvr))
+        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, danMvr))
 
         // exaclty the same as above, since hasStyle only has an effect when the contest is not in the MVR or CVR
-        assertEquals(1.0, cassorterHasStyle.overstatementError(bobMvr, aliceMvr, hasStyle = false)) // 3
-        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, candyMvr, hasStyle = false))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, undervoteMvr, hasStyle = false))
-        assertEquals(-1.0, cassorterHasStyle.overstatementError(aliceMvr, bobMvr, hasStyle = false))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, candyMvr, hasStyle = false))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, undervoteMvr, hasStyle = false))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(candyMvr, bobMvr, hasStyle = false))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(candyMvr, aliceMvr, hasStyle = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, danMvr, hasStyle = false))
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(undervoteMvr, bobMvr, hasStyle = false))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(undervoteMvr, aliceMvr, hasStyle = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, danMvr, hasStyle = false))
+        assertEquals(1.0, cassorterNoStyle.overstatementError(bobMvr, aliceMvr)) // 3
+        assertEquals(0.5, cassorterNoStyle.overstatementError(bobMvr, candyMvr))
+        assertEquals(0.5, cassorterNoStyle.overstatementError(bobMvr, undervoteMvr))
+        assertEquals(-1.0, cassorterNoStyle.overstatementError(aliceMvr, bobMvr))
+        assertEquals(-0.5, cassorterNoStyle.overstatementError(aliceMvr, candyMvr))
+        assertEquals(-0.5, cassorterNoStyle.overstatementError(aliceMvr, undervoteMvr))
+        assertEquals(-0.5, cassorterNoStyle.overstatementError(candyMvr, bobMvr))
+        assertEquals(0.5, cassorterNoStyle.overstatementError(candyMvr, aliceMvr))
+        assertEquals(0.0, cassorterNoStyle.overstatementError(candyMvr, danMvr))
+        assertEquals(-0.5, cassorterNoStyle.overstatementError(undervoteMvr, bobMvr))
+        assertEquals(0.5, cassorterNoStyle.overstatementError(undervoteMvr, aliceMvr))
+        assertEquals(0.0, cassorterNoStyle.overstatementError(undervoteMvr, danMvr))
 
         //// contest does not appear on the MVR, hasStyle = true
         // we get an overstatementError of {1, 0, 1/2} depending if the CVR showed a vote for the {winner, loser, other}
-        assertEquals(1.0, cassorterHasStyle.overstatementError(wrongContestMvr, aliceMvr, hasStyle = true)) // 4
-        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, bobMvr, hasStyle = true))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(wrongContestMvr, candyMvr, hasStyle = true))
-        assertEquals(0.5, cassorterHasStyle.overstatementError(wrongContestMvr, undervoteMvr, hasStyle = true)) // none = other
+        assertEquals(1.0, cassorterHasStyle.overstatementError(wrongContestMvr, aliceMvr)) // 4
+        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, bobMvr))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(wrongContestMvr, candyMvr))
+        assertEquals(0.5, cassorterHasStyle.overstatementError(wrongContestMvr, undervoteMvr)) // none = other
 
         //// contest does not appear on the MVR, hasStyle = false
         // we get an overstatementError of {1/2, -1/2, 0} depending if the CVR showed a vote for the {winner, loser, other}
-        assertEquals(0.5, cassorterHasStyle.overstatementError(wrongContestMvr, aliceMvr, hasStyle = false)) // 5
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(wrongContestMvr, bobMvr, hasStyle = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, candyMvr, hasStyle = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(wrongContestMvr, undervoteMvr, hasStyle = false)) // none = other
+        assertEquals(0.5, cassorterNoStyle.overstatementError(wrongContestMvr, aliceMvr)) // 5
+        assertEquals(-0.5, cassorterNoStyle.overstatementError(wrongContestMvr, bobMvr))
+        assertEquals(0.0, cassorterNoStyle.overstatementError(wrongContestMvr, candyMvr))
+        assertEquals(0.0, cassorterNoStyle.overstatementError(wrongContestMvr, undervoteMvr)) // none = other
 
         //// contest does not appear on the CVR, hasStyle = false
         // we get an overstatementError of {-1/2, 1/2, 0} depending if the MVR showed a vote for the {winner, loser, other}
-        assertEquals(-0.5, cassorterHasStyle.overstatementError(aliceMvr, wrongContestMvr, hasStyle = false)) // 6
-        assertEquals(0.5, cassorterHasStyle.overstatementError(bobMvr, wrongContestMvr, hasStyle = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(candyMvr, wrongContestMvr, hasStyle = false))
-        assertEquals(0.0, cassorterHasStyle.overstatementError(undervoteMvr, wrongContestMvr, hasStyle = false)) // none = other
+        assertEquals(-0.5, cassorterNoStyle.overstatementError(aliceMvr, wrongContestMvr)) // 6
+        assertEquals(0.5, cassorterNoStyle.overstatementError(bobMvr, wrongContestMvr))
+        assertEquals(0.0, cassorterNoStyle.overstatementError(candyMvr, wrongContestMvr))
+        assertEquals(0.0, cassorterNoStyle.overstatementError(undervoteMvr, wrongContestMvr)) // none = other
     }
 
     @Test
     fun test_overstatement_plurality_assort() { // agrees with SHANGRLA
         // winner = alice, loser = bob
         val aliceVsBobP = PluralityAssorter(plur_con_test.info, winner = 0, loser = 1).setMargins(0.2)
-        val cassorterHasStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP)
+        val cassorterHasStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP, true)
 
         // mvr == cvr, always get noerror
-        assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(aliceMvr, aliceMvr, true)) // 1
-        assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(bobMvr, bobMvr, true))
-        assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(candyMvr, candyMvr, true))
+        assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(aliceMvr, aliceMvr)) // 1
+        assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(bobMvr, bobMvr))
+        assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(candyMvr, candyMvr))
 
-        assertEquals(0.0 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(bobMvr, aliceMvr, true)) // 2
-        assertEquals(0.5 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(bobMvr, candyMvr, true))
-        assertEquals(2.0 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(aliceMvr, bobMvr, true))
-        assertEquals(1.5 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(aliceMvr, candyMvr, true))
-        assertEquals(1.5 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(candyMvr, bobMvr, true))
-        assertEquals(0.5 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(candyMvr, aliceMvr, true))
-        assertEquals(1.0 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(candyMvr, danMvr, true))
+        assertEquals(0.0 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(bobMvr, aliceMvr)) // 2
+        assertEquals(0.5 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(bobMvr, candyMvr))
+        assertEquals(2.0 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(aliceMvr, bobMvr))
+        assertEquals(1.5 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(aliceMvr, candyMvr))
+        assertEquals(1.5 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(candyMvr, bobMvr))
+        assertEquals(0.5 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(candyMvr, aliceMvr))
+        assertEquals(1.0 * cassorterHasStyle.noerror, cassorterHasStyle.bassort(candyMvr, danMvr))
 
         //// contest does not appear on the MVR
         // we get an assort value of {0, noerror, noerror/2} depending if the CVR showed a vote for the {winner, loser, other},
-        assertEquals(0.0, cassorterHasStyle.bassort(wrongContestMvr, aliceMvr, true)) // 4
-        assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(wrongContestMvr, bobMvr, true))
-        assertEquals(cassorterHasStyle.noerror/2, cassorterHasStyle.bassort(wrongContestMvr, candyMvr, true))
+        assertEquals(0.0, cassorterHasStyle.bassort(wrongContestMvr, aliceMvr)) // 4
+        assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(wrongContestMvr, bobMvr))
+        assertEquals(cassorterHasStyle.noerror/2, cassorterHasStyle.bassort(wrongContestMvr, candyMvr))
 
-        assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(wrongContestMvr, bobMvr, true))
-        assertEquals(cassorterHasStyle.noerror/2, cassorterHasStyle.bassort(wrongContestMvr, candyMvr, true))
-        assertEquals(0.0, cassorterHasStyle.bassort(wrongContestMvr, aliceMvr, true)) // 4
-        assertEquals(Double.NaN, cassorterHasStyle.bassort(wrongContestMvr, wrongContestMvr, true)) // 4
+        assertEquals(cassorterHasStyle.noerror, cassorterHasStyle.bassort(wrongContestMvr, bobMvr))
+        assertEquals(cassorterHasStyle.noerror/2, cassorterHasStyle.bassort(wrongContestMvr, candyMvr))
+        assertEquals(0.0, cassorterHasStyle.bassort(wrongContestMvr, aliceMvr)) // 4
+        assertEquals(Double.NaN, cassorterHasStyle.bassort(wrongContestMvr, wrongContestMvr)) // 4
 
         /* val mess = assertFailsWith<RuntimeException>{
             cassorterHasStyle.bassort(wrongContestMvr, wrongContestMvr)
@@ -394,32 +395,32 @@ class TestShangrlaAssertions {
         assertEquals("hasCompleteCvrs==True but cvr=wrongContest (false)  1: [1] does not contain contest AvB (0)", mess) */
 
         /////////////
-        val cassorterNoStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP)
+        val cassorterNoStyle = ClcaAssorter(plur_con_test.info, aliceVsBobP, false)
 
         // You have cvrs but use_style = false, which must mean that undervotes werent recorded. Now we examine an mvr
         // that doesnt have that contest on it, and neither does the cvr.
-        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, wrongContestMvr, hasStyle = false))
+        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, wrongContestMvr))
 
-        assertEquals(0.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, aliceMvr, hasStyle = false)) // 3
-        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, candyMvr, hasStyle = false))
-        assertEquals(2.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, bobMvr, hasStyle = false))
-        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, candyMvr, hasStyle = false))
-        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, bobMvr, hasStyle = false))
-        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, aliceMvr, hasStyle = false))
-        assertEquals(1.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, danMvr, hasStyle = false))
+        assertEquals(0.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, aliceMvr)) // 3
+        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, candyMvr))
+        assertEquals(2.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, bobMvr))
+        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, candyMvr))
+        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, bobMvr))
+        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, aliceMvr))
+        assertEquals(1.0 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, danMvr))
 
         //// contest does not appear on the MVR
         // we get an assort value of {0, noerror, noerror/2} depending if the CVR showed a vote for the {winner, loser, other},
 
         // we get an assort value of {noerror/2, 1.5 * noerror, noerror} depending if the CVR showed a vote for the {winner, loser, other},
-        assertEquals(cassorterNoStyle.noerror/2, cassorterNoStyle.bassort(wrongContestMvr, aliceMvr, hasStyle = false)) // 5
-        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, bobMvr, hasStyle = false))
-        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, candyMvr, hasStyle = false))
+        assertEquals(cassorterNoStyle.noerror/2, cassorterNoStyle.bassort(wrongContestMvr, aliceMvr)) // 5
+        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, bobMvr))
+        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(wrongContestMvr, candyMvr))
 
         // we get an assort value of {1.5, noerror/2, noerror} depending if the MVR showed a vote for the {winner, loser, other},
-        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, wrongContestMvr, hasStyle = false))
-        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, wrongContestMvr, hasStyle = false))
-        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, wrongContestMvr, hasStyle = false))
+        assertEquals(1.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(aliceMvr, wrongContestMvr))
+        assertEquals(0.5 * cassorterNoStyle.noerror, cassorterNoStyle.bassort(bobMvr, wrongContestMvr))
+        assertEquals(cassorterNoStyle.noerror, cassorterNoStyle.bassort(candyMvr, wrongContestMvr))
     }
 
 }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimateOld/TestMakeFuzzedCvrs.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimateOld/TestMakeFuzzedCvrs.kt
@@ -167,7 +167,7 @@ class TestMakeFuzzedCvrs {
                     var count = 0
                     fcvrs.forEachIndexed { idx, fcvr ->
                         if (fcvr.hasContest(contest.id)) {
-                            samples.addSample(minAssort.bassort(fcvr, cvrs[idx], true))
+                            samples.addSample(minAssort.bassort(fcvr, cvrs[idx]))
                             ccount++
                             if (cvrs[idx] != fcvr) count++
                         }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOABasics.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/oneaudit/TestOABasics.kt
@@ -96,25 +96,25 @@ class TestOABasics {
         // it doesnt matter what the cvr is, it just matters that its in the pool, so cvr_assort always = poolAverage
         // bassort(mvr: Cvr, cvr: Cvr)
         println("Pool")
-        println(" bassort(winnerVote, anyVote)=${oaAssorter.bassort(winnerPool, winnerPool, true)} ")
-        println(" bassort(otherVote, anyVote)=${oaAssorter.bassort(otherPool, winnerPool, true)} ")
-        println(" bassort(loserVote, anyVote)=${oaAssorter.bassort(loserPool, winnerPool, true)} ")
-        println(" bassort(underVote, anyVote)=${oaAssorter.bassort(underPool, winnerPool, true)} ")
-        println(" bassort(missingContest, anyVote)=${oaAssorter.bassort(missingContest, winnerPool, true)} ")
+        println(" bassort(winnerVote, anyVote)=${oaAssorter.bassort(winnerPool, winnerPool)} ")
+        println(" bassort(otherVote, anyVote)=${oaAssorter.bassort(otherPool, winnerPool)} ")
+        println(" bassort(loserVote, anyVote)=${oaAssorter.bassort(loserPool, winnerPool)} ")
+        println(" bassort(underVote, anyVote)=${oaAssorter.bassort(underPool, winnerPool)} ")
+        println(" bassort(missingContest, anyVote)=${oaAssorter.bassort(missingContest, winnerPool)} ")
         println("bassort = ([2, 1.5, 1] - poolAvg) / (2 - assorterMargin)} ")
 
         println()
-        assertEquals(otherVote, oaAssorter.bassort(otherPool, winnerPool, true), doublePrecision)
-        assertEquals(loserVote, oaAssorter.bassort(loserPool, winnerPool, true), doublePrecision)
-        assertEquals(winnerVote, oaAssorter.bassort(winnerPool, winnerPool, true), doublePrecision)
+        assertEquals(otherVote, oaAssorter.bassort(otherPool, winnerPool), doublePrecision)
+        assertEquals(loserVote, oaAssorter.bassort(loserPool, winnerPool), doublePrecision)
+        assertEquals(winnerVote, oaAssorter.bassort(winnerPool, winnerPool), doublePrecision)
 
-        assertEquals(otherVote, oaAssorter.bassort(otherPool, loserPool, true), doublePrecision)
-        assertEquals(loserVote, oaAssorter.bassort(loserPool, loserPool, true), doublePrecision)
-        assertEquals(winnerVote, oaAssorter.bassort(winnerPool, loserPool, true), doublePrecision)
+        assertEquals(otherVote, oaAssorter.bassort(otherPool, loserPool), doublePrecision)
+        assertEquals(loserVote, oaAssorter.bassort(loserPool, loserPool), doublePrecision)
+        assertEquals(winnerVote, oaAssorter.bassort(winnerPool, loserPool), doublePrecision)
 
-        assertEquals(otherVote, oaAssorter.bassort(otherPool, otherPool, true), doublePrecision)
-        assertEquals(loserVote, oaAssorter.bassort(loserPool, otherPool, true), doublePrecision)
-        assertEquals(winnerVote, oaAssorter.bassort(winnerPool, otherPool, true), doublePrecision)
+        assertEquals(otherVote, oaAssorter.bassort(otherPool, otherPool), doublePrecision)
+        assertEquals(loserVote, oaAssorter.bassort(loserPool, otherPool), doublePrecision)
+        assertEquals(winnerVote, oaAssorter.bassort(winnerPool, otherPool), doublePrecision)
 
         //////////
 
@@ -123,19 +123,19 @@ class TestOABasics {
         val otherCvr = Cvr("other", mapOf(contestId to intArrayOf(2)))
 
         println("CVR pool")
-        println(" bassort(winnerCvr, winnerCvr)=${oaAssorter.bassort(winnerCvr, winnerCvr, true)} ")  // noerror
-        println(" bassort(otherCvr, winnerCvr)=${oaAssorter.bassort(otherCvr, winnerCvr, true)} ") // noerror/2
-        println(" bassort(loserCvr, winnerCvr)=${oaAssorter.bassort(loserCvr, winnerCvr, true)} ") // 0
+        println(" bassort(winnerCvr, winnerCvr)=${oaAssorter.bassort(winnerCvr, winnerCvr)} ")  // noerror
+        println(" bassort(otherCvr, winnerCvr)=${oaAssorter.bassort(otherCvr, winnerCvr)} ") // noerror/2
+        println(" bassort(loserCvr, winnerCvr)=${oaAssorter.bassort(loserCvr, winnerCvr)} ") // 0
         println()
-        println(" bassort(winnerCvr, otherCvr)=${oaAssorter.bassort(winnerCvr, otherCvr, true)} ") // 1.5 * noerror
-        println(" bassort(otherCvr, otherCvr)=${oaAssorter.bassort(otherCvr, otherCvr, true)} ") // noerror
-        println(" bassort(loserCvr, otherCvr)=${oaAssorter.bassort(loserCvr, otherCvr, true)} ") // noerror/2
+        println(" bassort(winnerCvr, otherCvr)=${oaAssorter.bassort(winnerCvr, otherCvr)} ") // 1.5 * noerror
+        println(" bassort(otherCvr, otherCvr)=${oaAssorter.bassort(otherCvr, otherCvr)} ") // noerror
+        println(" bassort(loserCvr, otherCvr)=${oaAssorter.bassort(loserCvr, otherCvr)} ") // noerror/2
         println()
-        println(" bassort(winnerCvr, loserCvr)=${oaAssorter.bassort(winnerCvr, loserCvr, true)} ") // 2 * noerror
-        println(" bassort(otherCvr, loserCvr)=${oaAssorter.bassort(otherCvr, loserCvr, true)} ") // 1.5 * noerror
-        println(" bassort(loserCvr, loserCvr)=${oaAssorter.bassort(loserCvr, loserCvr, true)} ") // noerror
+        println(" bassort(winnerCvr, loserCvr)=${oaAssorter.bassort(winnerCvr, loserCvr)} ") // 2 * noerror
+        println(" bassort(otherCvr, loserCvr)=${oaAssorter.bassort(otherCvr, loserCvr)} ") // 1.5 * noerror
+        println(" bassort(loserCvr, loserCvr)=${oaAssorter.bassort(loserCvr, loserCvr)} ") // noerror
         println()
-        println("bassort = [0, .5, 1, 1.5, 2] * noerror=${oaAssorter.bassort(loserCvr, loserCvr, true)} ")
+        println("bassort = [0, .5, 1, 1.5, 2] * noerror=${oaAssorter.bassort(loserCvr, loserCvr)} ")
     }
 
     @Test

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAssertionJson.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAssertionJson.kt
@@ -25,7 +25,7 @@ class TestAssertionJson {
     fun testClcaAssertionRoundtrip() {
         val assertion = makeAssertion()
         // was hasUndervotes=false
-        val cassorter =  ClcaAssorter(assertion.info, assertion.assorter)
+        val cassorter =  ClcaAssorter(assertion.info, assertion.assorter, false)
         val target = ClcaAssertion(assertion.info, cassorter)
 
         val json = target.publishJson()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/TestOAShangrla.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/shangrla/TestOAShangrla.kt
@@ -76,7 +76,7 @@ class TestOAShangrla {
         //
         // mvr_assort: 1.0, cvr_assort: 1.0
         //overstatement=0.7446845752661285 margin=0.6571495728340697
-        // assertEquals(0.6515990033578625, cassorter.overstatementError(otherNoCvr, winnerNoCvr, true), .0001)
+        // assertEquals(0.6515990033578625, cassorter.overstatementError(otherNoCvr, winnerNoCvr), .0001)
         // assertEquals(0.6515990033578625, cassorter.bassort(otherNoCvr, winnerNoCvr), .0001)
 
         val pool = pools[0]
@@ -116,15 +116,15 @@ class TestOAShangrla {
         println("poolAvgAssort=$poolAvgAssort loserVoteNoCvr=$loserVoteNoCvr winnerVoteNoCvr=$winnerVoteNoCvr otherVoteNoCvr=$otherVoteNoCvr")
 
         // mvr assort always return poolAvg because it has a poolId
-        println(" mvr winner bassort=${cassorter.bassort(winnerNoCvr, winnerNoCvr, true)} ")
-        println(" mvr loser bassort=${cassorter.bassort(loserNoCvr, winnerNoCvr, true)} ")
-        println(" mvr other bassort=${cassorter.bassort(otherNoCvr, winnerNoCvr, true)} ")
+        println(" mvr winner bassort=${cassorter.bassort(winnerNoCvr, winnerNoCvr)} ")
+        println(" mvr loser bassort=${cassorter.bassort(loserNoCvr, winnerNoCvr)} ")
+        println(" mvr other bassort=${cassorter.bassort(otherNoCvr, winnerNoCvr)} ")
 
-        assertEquals(winnerVoteNoCvr, cassorter.bassort(winnerNoCvr, winnerNoCvr, true), .0001)
-        assertEquals(loserVoteNoCvr, cassorter.bassort(loserNoCvr, winnerNoCvr, true), .0001)
-        assertEquals(otherVoteNoCvr, cassorter.bassort(otherNoCvr, winnerNoCvr, true), .0001)
+        assertEquals(winnerVoteNoCvr, cassorter.bassort(winnerNoCvr, winnerNoCvr), .0001)
+        assertEquals(loserVoteNoCvr, cassorter.bassort(loserNoCvr, winnerNoCvr), .0001)
+        assertEquals(otherVoteNoCvr, cassorter.bassort(otherNoCvr, winnerNoCvr), .0001)
 
-        val expect = """OneAuditClcaAssorter for contest OneAuditTest (1) hasStyle=false assorterMargin=0.6572 noerror=0.74471254
+        val expect = """OneAuditClcaAssorter for contest OneAuditTest (1) useReportedMargin=false assorterMargin=0.6572 noerror=0.74471254
   assorter= Plurality winner=0 loser=1 reportedMargin=65.7200% dilutedMargin=65.7200%
 """
         assertEquals(expect, cassorter.toString())

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCardBuilders.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCardBuilders.kt
@@ -74,7 +74,7 @@ class TestCardBuilders {
                     var count = 0
                     fcvrs.forEachIndexed { idx, fcvr ->
                         if (fcvr.hasContest(contest.id)) {
-                            samples.addSample(minAssort.bassort(fcvr, cvrs[idx], true))
+                            samples.addSample(minAssort.bassort(fcvr, cvrs[idx]))
                             ccount++
                             if (cvrs[idx] != fcvr) count++
                         }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCvrBuilders.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/util/TestCvrBuilders.kt
@@ -65,7 +65,7 @@ class TestCvrBuilders {
                     var count = 0
                     fcvrs.forEachIndexed { idx, fcvr ->
                         if (fcvr.hasContest(contest.id)) {
-                            samples.addSample(minAssort.bassort(fcvr, cvrs[idx], true))
+                            samples.addSample(minAssort.bassort(fcvr, cvrs[idx]))
                             ccount++
                             if (cvrs[idx] != fcvr) count++
                         }
@@ -103,7 +103,7 @@ class TestCvrBuilders {
                     var countChanged = 0
                     cvrsForClca.forEachIndexed { idx, fcvr ->
                         if (fcvr.hasContest(contest.id)) {
-                            samples.addSample(minAssort.bassort(fcvr, cvrs[idx], true))
+                            samples.addSample(minAssort.bassort(fcvr, cvrs[idx]))
                             ccount++
                             if (cvrs[idx] != fcvr) countChanged++
                         }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaStartFuzz.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaStartFuzz.kt
@@ -174,7 +174,7 @@ class TestClcaElection(
             allCvrs.addAll(rcvrs)
         }
 
-        val regularContests = testData.contests.map { ContestWithAssertions(it, isClca=true).addStandardAssertions() }
+        val regularContests = testData.contests.map { ContestWithAssertions(it, isClca=true, hasStyle=true).addStandardAssertions() }
         contestsUA.addAll(regularContests)
         contestsUA.forEach { println("  $it") }
         println()
@@ -280,7 +280,7 @@ class TestPollingElection(
 
         // testMvrs = makeFuzzedCvrsForClca(contests.map{ it.info() } , cvrs, fuzzMvrs)
 
-        contestsUA = testData.contests.map { ContestWithAssertions(it, isClca=false).addStandardAssertions() }
+        contestsUA = testData.contests.map { ContestWithAssertions(it, isClca=false, hasStyle=true).addStandardAssertions() }
         contestsUA.forEach { println("  $it") }
 
         println()

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/ClcaAttackSamplers.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/ClcaAttackSamplers.kt
@@ -36,7 +36,7 @@ data class ClcaAttackSampler(val cvrs : List<Cvr>, val cassorter: ClcaAssorter,
         mvrs = mmvrs.toList()
 
         // TODO hasStyle ??
-        sampleCount = cvrs.mapIndexed { idx, it -> cassorter.bassort(mvrs[idx], it, hasStyle=hasStyle)}.sum()
+        sampleCount = cvrs.mapIndexed { idx, it -> cassorter.bassort(mvrs[idx], it)}.sum()
         sampleMean = sampleCount / N
     }
 
@@ -46,12 +46,12 @@ data class ClcaAttackSampler(val cvrs : List<Cvr>, val cassorter: ClcaAssorter,
             val cvr = cvrs[permutedIndex[idx]]
             val mvr = mvrs[permutedIndex[idx]]
             idx++
-            cassorter.bassort(mvr, cvr, hasStyle=hasStyle)
+            cassorter.bassort(mvr, cvr)
         } else {
             val chooseIdx = Random.nextInt(N) // with Replacement
             val cvr = cvrs[chooseIdx]
             val mvr = mvrs[chooseIdx]
-            cassorter.bassort(mvr, cvr, hasStyle=hasStyle)
+            cassorter.bassort(mvr, cvr)
         }
         count++
         return assortVal
@@ -96,7 +96,7 @@ data class ClcaFlipErrorsSampler(val cvrs : List<Cvr>, val cassorter: ClcaAssort
         flippedVotes = flipExactVotes(mmvrs, mvrMean)
         mvrs = mmvrs.toList()
 
-        sampleCount = cvrs.mapIndexed { idx, it -> cassorter.bassort(mvrs[idx], it, hasStyle=hasStyle)}.sum()
+        sampleCount = cvrs.mapIndexed { idx, it -> cassorter.bassort(mvrs[idx], it)}.sum()
         sampleMean = sampleCount / cvrs.size
     }
 
@@ -106,12 +106,12 @@ data class ClcaFlipErrorsSampler(val cvrs : List<Cvr>, val cassorter: ClcaAssort
             val cvr = cvrs[permutedIndex[idx]]
             val mvr = mvrs[permutedIndex[idx]]
             idx++
-            cassorter.bassort(mvr, cvr, hasStyle=hasStyle)
+            cassorter.bassort(mvr, cvr)
         } else {
             val chooseIdx = Random.nextInt(cvrs.size) // with Replacement
             val cvr = cvrs[chooseIdx]
             val mvr = mvrs[chooseIdx]
-            cassorter.bassort(mvr, cvr, hasStyle=hasStyle)
+            cassorter.bassort(mvr, cvr)
         }
         count++
         return assortVal

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/CvrSimulation.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimate/CvrSimulation.kt
@@ -31,7 +31,7 @@ fun simulateCvrsFromMargin(Nc: Int, margin: Double, undervotePct: Double, phanto
         Nc = Nc,
         Ncast = roundToClosest(nvotes + Nu)
     )
-    val cu = ContestWithAssertions(contest, true, NpopIn = Npop)
+    val cu = ContestWithAssertions(contest, true, NpopIn = Npop, hasStyle=true)
     val config = Config.from(AuditType.CLCA, contestSampleCutoff = limit)
     return Pair( cu, simulateCvrsForContest(cu, config))
 }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimateOld/ClcaFuzzSamplerTracker.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/estimateOld/ClcaFuzzSamplerTracker.kt
@@ -42,7 +42,7 @@ class ClcaFuzzSamplerTracker(
             val (mvr, card) = cvrPairs[permutedIndex[idx]]
             idx++
             if (card.hasContest(contest.id)) { // should always be true
-                val nextVal = cassorter.bassort(mvr, card, hasStyle=card.hasExactContests())
+                val nextVal = cassorter.bassort(mvr, card)
                 clcaErrorTracker.addSample(nextVal, card.poolId() == null) // dont track errors from oa pools
                 welford.update(nextVal)
                 return nextVal

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/util/ContestsForTesting.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/util/ContestsForTesting.kt
@@ -88,7 +88,7 @@ fun makeContestFromFakeCvrs(info: ContestInfo, ncvrs: Int): Contest {
 }
 
 fun makeContestUAfromCvrs(info: ContestInfo, cvrs: List<Cvr>, isComparison: Boolean=true, NpopIn: Int? = null) : ContestWithAssertions {
-    return ContestWithAssertions( makeContestFromCvrs(info, cvrs), isClca=isComparison, NpopIn = NpopIn).addStandardAssertions()
+    return ContestWithAssertions( makeContestFromCvrs(info, cvrs), isClca=isComparison, NpopIn = NpopIn, hasStyle=true).addStandardAssertions()
 }
 
 fun makeContestUAFromCvrs(contests: List<Contest>, cvrs: List<Cvr>, hasStyle: Boolean=true): List<ContestWithAssertions> {
@@ -110,7 +110,7 @@ fun makeContestUAFromCvrs(contests: List<Contest>, cvrs: List<Cvr>, hasStyle: Bo
         if (contest == null)
             throw RuntimeException("no contest for contest id= $conId")
         val accumVotes = allVotes[conId]!!
-        val contestUA = ContestWithAssertions(contest, isClca=true).addStandardAssertions()
+        val contestUA = ContestWithAssertions(contest, isClca=true, hasStyle=true).addStandardAssertions()
         require(checkEquivilentVotes((contestUA.contest as Contest).votes, accumVotes))
         contestUA
     }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/Sampler.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/Sampler.kt
@@ -90,7 +90,7 @@ class ClcaSampler(
             val (mvr, card) = cvrPairs[permutedIndex[idx]]
             idx++
             if (card.hasContest(contestId)) {
-                val result = cassorter.bassort(mvr, card, card.hasExactContests())
+                val result = cassorter.bassort(mvr, card)
                 count++
                 return result
             }

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/WorkflowTesterClca.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/WorkflowTesterClca.kt
@@ -30,7 +30,7 @@ class WorkflowTesterClca(
         require (config.auditType == AuditType.CLCA)
 
         val regularContests = contestsToAudit.map {
-            val cua = ContestWithAssertions(it, true, NpopIn=Npops[it.id])
+            val cua = ContestWithAssertions(it, true, NpopIn=Npops[it.id], hasStyle=true)
             if (it is DHondtContest) {
                 cua.addAssertionsFromAssorters(it.assorters)
             } else {

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/WorkflowTesterPolling.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/workflow/WorkflowTesterPolling.kt
@@ -13,7 +13,7 @@ class WorkflowTesterPolling(
     contestsToAudit: List<ContestIF>, // the contests you want to audit
     val mvrManager: MvrManager,
 ): AuditWorkflow() {
-    private val contestsUA: List<ContestWithAssertions> = contestsToAudit.map { ContestWithAssertions(it, isClca=false).addStandardAssertions() }
+    private val contestsUA: List<ContestWithAssertions> = contestsToAudit.map { ContestWithAssertions(it, isClca=false, hasStyle=true).addStandardAssertions() }
     private val auditRounds = mutableListOf<AuditRoundIF>()
 
     init {

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/CompareAlphaPaper.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/alpha/CompareAlphaPaper.kt
@@ -37,10 +37,10 @@ class CompareAlphaPaper {
             val pairs = cvrs.zip(cvrs)
 
             val contest = makeContestFromCvrs(info, cvrs)
-            val contestUA = ContestWithAssertions(contest, isClca = false).addStandardAssertions()
+            val contestUA = ContestWithAssertions(contest, isClca = false, hasStyle=true).addStandardAssertions()
             val pollingAssertion = contestUA.assertions.first()
 
-            val contestUAc = ContestWithAssertions(contest, isClca = true).addStandardAssertions()
+            val contestUAc = ContestWithAssertions(contest, isClca = true, hasStyle=true).addStandardAssertions()
             val compareAssertion = contestUAc.clcaAssertions.first()
 
             for (eta in etas) {


### PR DESCRIPTION
cant pass hasStyle on bassort() or overstatementError() methods. 
OneAuditClcaAssorter.useReportedMargin always false. 
fix all the ClcaAssorter tests.