### PR TITLE
implement UniformSampling as an option

### DIFF
--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/Colorado2020corrected.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/Colorado2020corrected.kt
@@ -1,6 +1,6 @@
 package org.cryptobiotic.rlauxe.auditcenter
 
-class Colorado2020General: ColoradoInput(
+class Colorado2020corrected: ColoradoInput(
     generalCanonicalFile = "$general2020/canonicalTitleCase.csv",
     contestRoundFile = "$general2020/round_1/contest.csv",
     tabulateCountyFile = "$general2020/tabulate_county.csv",
@@ -30,20 +30,6 @@ class Colorado2020General: ColoradoInput(
             CanonicalContest("Adams County Ballot Issue 1A", listOf("Yes/For", "No/Against",)).addCounties(listOf("Adams"))
         )
         extras.forEach { result[it.contestName] = it }
-
-        // compare canonical contest counties and CountyTabulateCsv
-        //  countyTabulateCsv doesnt have 'Gunnison' from canonical
-        //  countyTabulateCsv doesnt have 'San Juan' from canonical
-
-        // remove these contests: TODO some? are in cvrs; see TestContestNames
-        //countyTabulate missing auditcenter 'Gunnison County Commissioner - District 1'
-        //countyTabulate missing auditcenter 'Gunnison County Commissioner - District 2'
-        //countyTabulate missing auditcenter 'Gunnison County Court Judge - Burgemeister'
-        //countyTabulate missing auditcenter 'Town of Marble - Board of Trustees'
-        //countyTabulate missing auditcenter 'Town of Marble Ballot Issue 2A'
-        //countyTabulate missing auditcenter 'San Juan County Commissioner - District 1'
-        //countyTabulate missing auditcenter 'San Juan County Commissioner - District 2'
-        //countyTabulate missing auditcenter 'San Juan County Court Judge - Edwards'
 
         //// Baca
         result.remove("Baca County Commissioner - District 1")
@@ -294,7 +280,7 @@ class Colorado2020General: ColoradoInput(
                 "Jackson County Commissioner Dist 2" -> "Jackson County Commissioner - District 2"
                 "Jackson County Commissioner Dist 3" -> "Jackson County Commissioner - District 3"
                 "District Court Judge - 8th Judicial District - Villaseñor" -> "District Court Judge - 8th Judicial District - Villasenor"
-                "Justice of the Colorado Supreme Court - Samour" -> "Jackson - Justice of the Colorado Supreme Court - Samour" // diverted target
+                // "Justice of the Colorado Supreme Court - Samour" -> "Jackson - Justice of the Colorado Supreme Court - Samour" // diverted target
                 else -> null
             }
 
@@ -357,7 +343,8 @@ class Colorado2020General: ColoradoInput(
                 "Proposition 116" -> "Proposition 116 (STATUTORY)"
                 "Proposition 117" -> "Proposition 117 (STATUTORY)"
                 "Proposition 118" -> "Proposition 118 (STATUTORY)"
-                "Colorado Supreme Court Justice - Hart" -> "Lincoln - Justice of the Colorado Supreme Court - Hart" // diverted target
+                // "Colorado Supreme Court Justice - Hart" -> "Lincoln - Justice of the Colorado Supreme Court - Hart" // diverted target
+                "Lincoln - Colorado Supreme Court Justice - Hart" -> "Justice of the Colorado Supreme Court - Hart"
                 else -> null
             }
 
@@ -478,7 +465,8 @@ class Colorado2020General: ColoradoInput(
             }
 
             "Prowers" -> when (name) {
-                "Amendment C (CONSTITUTIONAL)" -> "Prowers - Amendment C (CONSTITUTIONAL)" // diverted target
+                "Prowers - Amendment C (CONSTITUTIONAL)" -> "Amendment C (CONSTITUTIONAL)"
+                // "Amendment C (CONSTITUTIONAL)" -> "Prowers - Amendment C (CONSTITUTIONAL)" // diverted target
                 else -> null
             }
 
@@ -544,14 +532,16 @@ class Colorado2020General: ColoradoInput(
             "Teller" -> when (name) {
                 "City Councilmember" -> "City of Woodland Park Councilmember"
                 "Northeast Teller County Fire Protection District 7A" -> "Northeast Teller County Fire Protection District Ballot Issue 7A"
-                "Amendment C (Constitutional) " -> "Teller - Amendment C (CONSTITUTIONAL)" // diverted target
-                "Amendment 77 (Constitutional)" -> "Teller - Amendment 77 (CONSTITUTIONAL)"
+                "Teller - Amendment C (Constitutional) " -> "Amendment C (CONSTITUTIONAL)"
+                // "Amendment C (Constitutional) " -> "Teller - Amendment C (CONSTITUTIONAL)" // diverted target
+                // "Amendment 77 (Constitutional)" -> "Teller - Amendment 77 (CONSTITUTIONAL)" // diverted target
                 else -> null
             }
 
             "Washington" -> when (name) {
                 "Brush RE-2J School District BALLOT ISSUE" -> "Brush RE-2J School District Ballot Issue 3D"
-                "Proposition EE (Statutory)" -> "Washington - Proposition EE (STATUTORY)" // diverted target
+                "Washington - Proposition EE (Statutory)" -> "Proposition EE (STATUTORY)"
+                // "Proposition EE (Statutory)" -> "Washington - Proposition EE (STATUTORY)" // diverted target
                 else -> null
             }
 

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/ColoradoInput.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/ColoradoInput.kt
@@ -50,7 +50,12 @@ abstract class ColoradoInput(
     //    val counties =  mutableSetOf<String>()
 
     abstract fun canonicalContests(): Map<String, CanonicalContest>
-    fun counties() = canonicalContests().values.map { it.counties }.flatten().toSet().toList().sorted()
+    fun counties(): List<String>  = canonicalContests().values.map { it.counties }
+        .flatten()
+        .filter { it: String -> it !in skipCounties }
+        .toSet()
+        .toList()
+        .sorted()
 
     // data class CorlaContestRoundCsv(
     //    val contestName: String,
@@ -208,13 +213,26 @@ data class MergedContestInfo(
     val choices: List<String>,
     val counties: Set<String>,
 
-    // contestRound
+    // data class CorlaContestRoundCsv(
+    //    val contestName: String,
+    //    val auditReason: AuditReason,
+    //    val nwinners: Int,
+    //    val ballotCardCount: Int,         // population size = eg county size when uniform audit
+    //    val contestBallotCardCount: Int,  // Nc = number of cards with this contest on it
+    //    val winners: String,
+    //    val minMargin: Int,
+    //    val riskLimit: Double,  // TODO use this
+    //    val gamma: Double,      // and this ?? = 1.03905000
+    //    val optimisticSamplesToAudit: Int, // check if these ever differ
+    //    val estimatedSamplesToAudit: Int,
+    //)
     val auditReason: AuditReason,
-    val npop:Int,       // ballotCardCount
-    val nc:Int,         // contestBallotCardCount
-    val voteForN: Int,  // nwinners
-    val nsamples: Int,  // optimisticSamplesToAudit
-    val marginInVotes: Int, // minMargin
+    val npop:Int,       // ballot_card_count
+    val nc:Int,         // contest_ballot_card_count
+    val voteForN: Int,  // winners_allowed
+    val nsamples: Int,  // optimistic_samples_to_audit
+    val marginInVotes: Int, // min_margin
+    val riskLimit: Double, // risk_limit
 
     // mvr file
     val countyMvrs: Int,
@@ -224,7 +242,7 @@ data class MergedContestInfo(
 data class StrataInfo(
     val strataName: String,
     val nmvrs: Int, // countyMvr.countMvr
-    val ballotCardCount: Int,  // round.ballotCardCount
+    val ballotCardCount: Int,  // round.ballot_card_count
 )
 
 data class MergedInfo(
@@ -264,13 +282,15 @@ fun mergeContestInfo(input: ColoradoInput): MergedInfo {
             round?.nwinners ?: 1,
             round?.optimisticSamplesToAudit ?: 0,
             round?.minMargin ?: 0,
+            round?.riskLimit ?: 0.0,
 
-            compare ?. countMvr ?: 0,
-            compare ?. countStatewide ?: 0,
+            compare ?. countMvr ?: 0,    // ContestMvrCount.countMvr
+            compare ?. countStatewide ?: 0,   // ContestMvrCount.countStatewide
         )
     }
 
     // pick out the contests that are the targeted ones; should have a single contest
+    // TODO what if theres more than one targeted county contest ?? More than one county ??
     val strataInfo = mutableListOf<StrataInfo>()
     val statewideContests = mutableListOf<CorlaContestRoundCsv>()
     canonical.values.forEach { canonicalContest ->
@@ -278,7 +298,7 @@ fun mergeContestInfo(input: ColoradoInput): MergedInfo {
         if (round != null && round.auditReason == AuditReason.county_wide_contest) {
             if (canonicalContest.counties.size != 1)
                 println("*** ${canonicalContest.contestName} has ncounties != 1: ${canonicalContest.counties}")
-            val county: String = canonicalContest.counties.first()
+            val county: String = canonicalContest.counties.first() // use the first county
             val countyMvr: CountyMvrCount = countyMap[county]!!
 
             val countyInfo = StrataInfo(

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/CountyElectionSansCvrs.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/CountyElectionSansCvrs.kt
@@ -20,12 +20,12 @@ private val logger = KotlinLogging.logger("CountyElectionSansCvrs")
 // generate countyPools from auditcenter
 open class CountyElectionSansCvrs (
     val coloradoInput: ColoradoInput,
-    val auditdir: String,
+    val topdir: String,
     val hasStyle: Boolean,
     val name: String,
     val onlyCounty: String? = null,
 ): ElectionBuilder {
-    val publisher = Publisher(auditdir)
+    val publisher = Publisher(topdir)
     val ncards: Int
     val contestsUA: List<ContestWithAssertions>
     val countyPools: List<CountyPools>
@@ -262,7 +262,6 @@ open class CountyElectionSansCvrs (
 // Create audit where pools are from the precinct total. May be CLCA or OneAudit
 fun createCountyElectionSansCvrs(
     topdir: String,
-    auditdir: String,
     coloradoInput: ColoradoInput,
     creation: AuditCreationConfig,
     roundConfig: AuditRoundConfig,
@@ -274,21 +273,21 @@ fun createCountyElectionSansCvrs(
     clearDirectory(Path(topdir))
 
     val election =
-        CountyElectionSansCvrs(coloradoInput,  auditdir, name=name,
+        CountyElectionSansCvrs(coloradoInput,  topdir, name=name,
             hasStyle = roundConfig.sampling.sampling == Sampling.consistent,
             onlyCounty = onlyCounty)
 
-    createElectionRecord(election, auditDir = auditdir, roundConfig.sampling, clear = false) // cants clear because we have the mvrs written
+    createElectionRecord(election, topdir = topdir, roundConfig.sampling, clear = false) // cants clear because we have the mvrs written
     val config = Config(election.electionInfo(), creation, roundConfig)
 
-    createAuditRecord(config, election, auditDir = auditdir, externalSortDir = topdir, sortManifest = true)
+    createAuditRecord(config, election, topdir = topdir, externalSortDir = topdir, sortManifest = true)
 
     writeCountyData(topdir, coloradoInput.strataMap.values.toList())
     val contestMap = election.contestsUA.associate { it.contest.info().name to it }
     writeCountyContestData(topdir, contestMap, coloradoInput)
 
     if (startFirstRound) {
-        val result = startFirstRound(auditdir)
+        val result = startFirstRound(topdir)
         if (result.isErr) logger.error { result.toString() }
         logger.info { "createCorlaElection took $stopwatch" }
     }

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/CountyElectionWithCvrs.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/CountyElectionWithCvrs.kt
@@ -29,9 +29,10 @@ private val logger = KotlinLogging.logger("CountyElectionWithCvrs")
 open class CountyElectionWithCvrs (
     val counties: Map<String, String>, // countyName -> exportCvrFile
     val coloradoInput: ColoradoInput,
-    val auditdir: String,
+    val topdir: String,
     val hasStyle: Boolean,
     val name: String,
+    isUniform: Boolean,
 ): ElectionBuilder {
     val ncards: Int
     val contestsUA: List<ContestWithAssertions>
@@ -39,7 +40,7 @@ open class CountyElectionWithCvrs (
     val countyPools = mutableListOf<CountyPools>()
     val cvrPools = mutableListOf<CountyPools>()
 
-    val publisher = Publisher(auditdir)
+    val publisher = Publisher(topdir)
 
     init {
         val contestBuilder = CountyContestBuilder(coloradoInput)
@@ -107,21 +108,25 @@ open class CountyElectionWithCvrs (
         // val contests = contestBuilder.contests(ncast)
         // just leave it as Ncast = Nc, then the diff goes into the undervote
         val contests = contestBuilder.contests(emptyMap<Int, Int>())
-
-        // where do we get these? difference between the cvr card counts and the contest.Nc = round.contestBallotCardCount
-        // can put them is a seperate pool as long as you include them in the unsorted iterator
-        val phantoms = makePhantomCards(contests, 0) // TODO
-
-        this.ncards = totalCvrCardCount // or totalPoolCardCount?
-        // use Nc as Npop
-        contestsUA = contests.map {
+        contests.forEach {
             val contestCvrTab = totalCvrTabs[it.id]
             if (contestCvrTab != null) {
                 it.info().metadata["CvrNcards"] = contestCvrTab.ncards().toString()
                 it.info().metadata["CvrNvotes"] = contestCvrTab.nvotes().toString()
                 it.info().metadata["CvrNundervotes"] = contestCvrTab.undervotes().toString()
             }
-            ContestWithAssertions(it, true, hasStyle).addStandardAssertions()
+
+        }
+        // where do we get these? difference between the cvr card counts and the contest.Nc = round.contestBallotCardCount
+        // can put them is a seperate pool as long as you include them in the unsorted iterator
+        val phantoms = makePhantomCards(contests, 0) // TODO
+
+        this.ncards = totalCvrCardCount // or totalPoolCardCount?
+
+        contestsUA = contests.map {
+            // use strataSize or Nc as population size
+            val NpopIn = if (isUniform) it.info().metadata["CORLAstrataNcards"]!!.toInt() else null
+            ContestWithAssertions(it, true, hasStyle, NpopIn = NpopIn).addStandardAssertions()
         }
     }
 
@@ -204,26 +209,27 @@ fun countyElectionWithCvrs(
     roundConfig: AuditRoundConfig,
     startFirstRound: Boolean = true,
     name: String,
+    isUniform: Boolean,
 ) {
     val stopwatch = Stopwatch()
-    val auditdir = "$topdir/audit"
     clearDirectory(Path(topdir))
 
     val election =
         CountyElectionWithCvrs(counties, coloradoInput,
-            auditdir, name=name, hasStyle = roundConfig.sampling.sampling == Sampling.consistent)
+            topdir, name=name, hasStyle = roundConfig.sampling.sampling == Sampling.consistent,
+            isUniform=isUniform )
 
-    createElectionRecord(election, auditDir = auditdir, roundConfig.sampling, clear = false)
+    createElectionRecord(election, topdir = topdir, roundConfig.sampling, clear = false)
     val config = Config(election.electionInfo(), creation, roundConfig)
 
-    createAuditRecord(config, election, auditDir = auditdir, externalSortDir = topdir)
+    createAuditRecord(config, election, topdir = topdir, externalSortDir = topdir)
 
     writeCountyData(topdir, coloradoInput.strataMap.values.toList())
     val contestMap = election.contestsUA.associate { it.contest.info().name to it }
     writeCountyContestData(topdir, contestMap, coloradoInput)
 
     if (startFirstRound) {
-        val result = startFirstRound(auditdir)
+        val result = startFirstRound(topdir)
         if (result.isErr) logger.error { result.toString() }
     }
     logger.info { "createColorado2020 took $stopwatch" }

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/ReadMvrFile.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/ReadMvrFile.kt
@@ -137,14 +137,14 @@ fun readContestComparisonCsv(filename: String): CardComparisonResults {
                 // 6 consensus,record_type,audit_board_comment,timestamp,cvr_id,
                 // 11 audit_reason (optional)
                 val compareLine = ComparisonLine(
-                    line.get(0).trim(),
-                    line.get(1).trim(),
-                    line.get(2).trim(),
-                    line.get(3).trim(),
-                    line.get(4).trim(),
-                    line.get(5).trim(),
-                    line.get(10).toInt(),
-                    if (line.size() > 11) (line.get(11).trim() == "STATE_WIDE_CONTEST") else false,
+                    line.get(0).trim(), // county_name
+                    line.get(1).trim(), // contest_name
+                    line.get(2).trim(), // imprinted_id
+                    line.get(3).trim(), // ballot_type
+                    line.get(4).trim(), // choice_per_voting_computer
+                    line.get(5).trim(), // audit_board_selection
+                    line.get(10).toInt(), // cvr_id
+                    if (line.size() > 11) (line.get(11).trim() == "STATE_WIDE_CONTEST") else false, // audit_reason
                     )
                 val card = cards.getOrPut(compareLine.cvrId) { Card(compareLine.cvrId) }
                 card.add(compareLine)

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/ReadRoundContestCsv.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/auditcenter/ReadRoundContestCsv.kt
@@ -57,13 +57,13 @@ data class CorlaContestRoundCsv(
     val contestName: String,
     val auditReason: AuditReason,
     val nwinners: Int,
-    val ballotCardCount: Int,         // population size = county size when uniform audit
+    val ballotCardCount: Int,         // population size = eg county size when uniform audit
     val contestBallotCardCount: Int,  // Nc = number of cards with this contest on it
     val winners: String,
     val minMargin: Int,
-    val riskLimit: Double,
-    val gamma: Double,
-    val optimisticSamplesToAudit: Int,
+    val riskLimit: Double,  // TODO use this
+    val gamma: Double,      // and this ?? = 1.03905000
+    val optimisticSamplesToAudit: Int, // check if these ever differ
     val estimatedSamplesToAudit: Int,
 )
 

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/belgium/CreateBelgiumElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/belgium/CreateBelgiumElection.kt
@@ -61,17 +61,16 @@ fun createBelgiumElection(
     roundConfig: AuditRoundConfig,
     clear: Boolean = true): Result<AuditRoundIF, ErrorMessages>
 {
-    val auditdir = "$topdir/audit"
     val stopwatch = Stopwatch()
     val election = BelgiumClca(contestd, MvrSource.testPrivateMvrs)
 
-    createElectionRecord(election, auditDir = auditdir, clear = clear)
+    createElectionRecord(election, topdir = topdir, clear = clear)
     println("createBelgiumElection took $stopwatch")
 
     val config = Config(election.electionInfo(), creationConfig, roundConfig)
-    createAuditRecord(config, election, auditDir = auditdir) // , externalSortDir=topdir)
+    createAuditRecord(config, election, topdir = topdir) // , externalSortDir=topdir)
 
-    val result = startFirstRound(auditdir)
+    val result = startFirstRound(topdir)
     if (result.isErr) logger.error{ result.toString() }
     logger.info {"startFirstBoulderRound took $stopwatch" }
 
@@ -110,9 +109,8 @@ fun createAndRunAllRounds(electionName: String,
 
     createBelgiumElection(topdir=topdir, dcontest, creation, round)
 
-    val auditdir = "$topdir/audit"
     if (showVerify) {
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = showVerify)
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = showVerify)
         println()
         print(results)
         if (results.hasErrors) throw RuntimeException("createBelgiumElection failed to verify")
@@ -123,7 +121,7 @@ fun createAndRunAllRounds(electionName: String,
     var done = false
     var finalRound: AuditRoundIF? = null
     while (!done) {
-        val lastRound = runRound(inputDir = auditdir)
+        val lastRound = runRound(inputDir = topdir)
         if (lastRound != null) finalRound = lastRound
         done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5 || lastRound.roundIdx == stopRound
     }

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/boulder/CreateBoulderElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/boulder/CreateBoulderElection.kt
@@ -338,7 +338,7 @@ fun createBoulderElection(
     version: String,
     cvrExportFile: String,
     sovoFile: String,
-    auditdir: String,
+    topdir: String,
     creation: AuditCreationConfig,
     roundConfig: AuditRoundConfig,
     distributeOvervotes: List<Int>, // maybe no default
@@ -358,14 +358,14 @@ fun createBoulderElection(
         CreateBoulderElection(creation.auditType, export, sovo, distributeOvervotes, mvrSource = mvrSource,
             hasStyle = roundConfig.sampling.sampling == Sampling.consistent)
 
-    createElectionRecord(election, auditDir = auditdir)
+    createElectionRecord(election, topdir = topdir)
     println("CreateBoulderElection took $stopwatch")
 
     val config = Config(election.electionInfo(), creation, roundConfig)
-    createAuditRecord(config, election, auditDir = auditdir)
+    createAuditRecord(config, election, topdir = topdir)
 
     if (startFirstRound) {
-        val result = startFirstRound(auditdir)
+        val result = startFirstRound(topdir)
         if (result.isErr) logger.error { result.toString() }
     }
     logger.info{"startFirstBoulderRound took $stopwatch"}
@@ -375,7 +375,7 @@ fun createBoulderElectionWithSovo(
     version: String,
     cvrExportFile: String,
     sovo: BoulderStatementOfVotes,
-    auditdir: String,
+    topdir: String,
     creation: AuditCreationConfig,
     roundConfig: AuditRoundConfig,
     distributeOvervotes: List<Int>,
@@ -393,13 +393,13 @@ fun createBoulderElectionWithSovo(
             hasStyle = roundConfig.sampling.sampling == Sampling.consistent)
 
 
-    createElectionRecord(election, auditDir = auditdir)
+    createElectionRecord(election, topdir = topdir)
     println("CreateBoulderElection took $stopwatch")
 
     val config = Config(election.electionInfo(), creation, roundConfig)
-    createAuditRecord(config, election, auditDir = auditdir)
+    createAuditRecord(config, election, topdir = topdir)
 
-    val result = startFirstRound(auditdir)
+    val result = startFirstRound(topdir)
     if (result.isErr) logger.error{ result.toString() }
     logger.info{"startFirstBoulderRound took $stopwatch"}
 

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoPolling.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateColoradoPolling.kt
@@ -12,9 +12,9 @@ private val logger = KotlinLogging.logger("ColoradoPolling")
 class CreateColoradoPolling (
     coloradoInput: ColoradoInput,
     countyElection: CountyContestBuilder,
-    auditdir: String,
+    topdir: String,
     pollingMode: PollingMode,
-): CreateCorlaElection(coloradoInput, countyElection, AuditType.POLLING, auditdir, pollingMode=pollingMode, hasStyle = true) {
+): CreateCorlaElection(coloradoInput, countyElection, AuditType.POLLING, topdir, pollingMode=pollingMode, hasStyle = true) {
 
     val contestsPolling: List<ContestWithAssertions>
 

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateCorlaElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateCorlaElection.kt
@@ -24,12 +24,12 @@ open class CreateCorlaElection (
     val coloradoInput: ColoradoInput,
     val countyElection: CountyContestBuilder,
     val auditType: AuditType,
-    val auditdir: String,
+    val topdir: String,
     val hasStyle: Boolean,
     val pollingMode: PollingMode?,
     val name: String? = null,
 ): ElectionBuilder {
-    val publisher = Publisher(auditdir)
+    val publisher = Publisher(topdir)
     val ncards: Int
     val contestsUA: List<ContestWithAssertions>
     val countyPools: List<CountyPoolFromStyle>
@@ -59,7 +59,7 @@ open class CreateCorlaElection (
 
     override fun electionInfo() =
         ElectionInfo(
-            name ?: "Corla24$auditType$pollingMode", auditType, ncards(),
+            name ?: "Corla24$topdir$pollingMode", auditType, ncards(),
             contestsUA.size, pollingMode = pollingMode,
             mvrSource = MvrSource.testPrivateMvrs
         )
@@ -167,7 +167,6 @@ class CardsFromPool(val cardPool: CardPoolIF) : Iterator<Cvr> {
 // Create audit where pools are from the precinct total. May be CLCA or OneAudit
 fun createCorlaElection(
     topdir: String,
-    auditdir: String,
     coloradoInput: ColoradoInput,
     pollingMode: PollingMode? = null,
     creation: AuditCreationConfig,
@@ -181,23 +180,23 @@ fun createCorlaElection(
 
     val election = if (creation.auditType.isClca())
             CreateCorlaElection(coloradoInput, countyElection,
-                creation.auditType, auditdir, pollingMode=null, name=name,
+                creation.auditType, topdir, pollingMode=null, name=name,
                 hasStyle = roundConfig.sampling.sampling == Sampling.consistent)
         else
-            CreateColoradoPolling(coloradoInput, countyElection, auditdir, pollingMode!!) // TODO hasExact = false ??
+            CreateColoradoPolling(coloradoInput, countyElection, topdir, pollingMode!!) // TODO hasExact = false ??
 
     // TODO kludge in sampleControl for the moment
-    createElectionRecord(election, auditDir = auditdir, roundConfig.sampling, clear = false)
+    createElectionRecord(election, topdir = topdir, roundConfig.sampling, clear = false)
     val config = Config(election.electionInfo(), creation, roundConfig)
 
-    createAuditRecord(config, election, auditDir = auditdir, externalSortDir = topdir)
+    createAuditRecord(config, election, topdir = topdir, externalSortDir = topdir)
 
     writeCountyData(topdir, coloradoInput.strataMap.values.toList())
     val contestMap = election.contestsUA.associate { it.contest.info().name to it }
     writeCountyContestData(topdir, contestMap, coloradoInput)
 
     if (startFirstRound) {
-        val result = startFirstRound(auditdir)
+        val result = startFirstRound(topdir)
         if (result.isErr) logger.error { result.toString() }
         logger.info { "createCorlaElection took $stopwatch" }
     }

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateCountyAudits.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateCountyAudits.kt
@@ -40,12 +40,12 @@ private val debugUndervotes = true
 // obsolete
 class CreateCountyAudits(
     val countyName: String,
-    val auditdir: String,
+    val topdir: String,
     val stateElection: CountyContestBuilder,
     val countyContestTab: CountyTabAllContests,
     val hasStyle: Boolean,
 ): ElectionBuilder {
-    val publisher = Publisher(auditdir)
+    val publisher = Publisher(topdir)
     val ncards: Int
     val contestsUA: List<ContestWithAssertions>
     val countyCardPools: List<CardPoolIF>
@@ -63,7 +63,7 @@ class CreateCountyAudits(
         val contests = builders.map { it.makeContest() }
 
         // have to save the mvrs and generate the cardManifest from them
-        clearDirectory(Path(auditdir))
+        clearDirectory(Path(topdir))
         ncards = createAndSaveUnsortedMvrs(contests, countyCardPools, publisher)
 
         // read them back in as an Iterator, so we dont have to read all into memory
@@ -92,7 +92,7 @@ class CreateCountyAudits(
     override fun contestsUA() = contestsUA
 
     override fun cards(): CloseableIterator<AuditableCard> {
-        val publisher = Publisher(auditdir)
+        val publisher = Publisher(topdir)
         val unsortedMvrs: CloseableIterator<AuditableCard> = readCardsCsvIterator(publisher.unsortedMvrsFile(), styles = null)
         return TransformingIterator(unsortedMvrs) { mvr ->
             when {
@@ -108,7 +108,7 @@ class CreateCountyAudits(
     override fun unsortedMvrsInternal() = null
     override fun unsortedMvrsExternal() = null
     override fun toString(): String {
-        return "CorlaElectionBuilder(countyName='$countyName', auditdir='$auditdir')"
+        return "CorlaElectionBuilder(countyName='$countyName', topdir='$topdir')"
     }
 
     // for one county, one contest
@@ -176,30 +176,20 @@ fun createCountyAudits(
 
     val countyElection = CountyContestBuilder(coloradoInput)
     val contestTabByCounty: Map<String, CountyTabAllContests> = coloradoInput.countyTabsAllContests
-
-    /* createColoradoElection(
-        externalSortDir = topdir,
-        auditdir = "$topdir/audit", // or put it in audit ??
-        pollingMode = null,
-        creationConfig,
-        roundConfig,
-        startFirstRound = startFirstRound,
-        name = "Corla24County",
-    ) */
     val whichCounties = if (wantCounties.isNotEmpty()) wantCounties else contestTabByCounty.keys.toList()
 
     whichCounties.map { countyName ->
-        val election = CreateCountyAudits(countyName, "$topdir/$countyName/audit", countyElection,
+        val election = CreateCountyAudits(countyName, "$topdir/$countyName", countyElection,
             contestTabByCounty[countyName]!!,
             hasStyle = roundConfig.sampling.sampling == Sampling.consistent)
 
-        createElectionRecord(election, auditDir = election.auditdir, clear = false)
+        createElectionRecord(election, topdir = election.topdir, clear = false)
         val config = Config(election.electionInfo(), creationConfig, roundConfig)
 
-        createAuditRecord(config, election, auditDir = election.auditdir, externalSortDir = "$topdir/${election.countyName}")
+        createAuditRecord(config, election, topdir = election.topdir, externalSortDir = "$topdir/${election.countyName}")
 
         if (startFirstRound) {
-            val result = startFirstRound(election.auditdir)
+            val result = startFirstRound(election.topdir)
             if (result.isErr) logger.error { result.toString() }
         }
     }

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateUniformElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/corla/CreateUniformElection.kt
@@ -25,11 +25,11 @@ open class CreateUniformElection (
     val coloradoInput: ColoradoInput,
     val stateElection: CountyContestBuilder,
     val auditType: AuditType,
-    val auditdir: String,
+    val topdir: String,
     val pollingMode: PollingMode?,
     val name: String? = null,
 ): ElectionBuilder {
-    val publisher = Publisher(auditdir)
+    val publisher = Publisher(topdir)
     val ncards: Int
     val contestsUA: List<ContestWithAssertions>
 
@@ -83,7 +83,6 @@ open class CreateUniformElection (
 // Create audit using mvrs from Corla, dont write cards (!)
 fun createUniformElection(
     topdir: String,
-    auditdir: String,
     coloradoInput: ColoradoInput,
     creation: AuditCreationConfig,
     roundConfig: AuditRoundConfig,
@@ -96,18 +95,17 @@ fun createUniformElection(
     val countyElection = CountyContestBuilder(coloradoInput)
 
     val election =
-        CreateUniformElection(coloradoInput, countyElection, creation.auditType, auditdir, pollingMode=null, name=name)
+        CreateUniformElection(coloradoInput, countyElection, creation.auditType, topdir, pollingMode=null, name=name)
 
     // skip the simulated cvrs
-    // createElectionRecord(election, auditDir = auditdir, clear = false)
     val contestsUA = election.contestsUA()
 
     val results = VerifyResults()
-    results.addMessage("---VerifyElection on $auditdir")
+    results.addMessage("---VerifyElection on $topdir")
     preAuditContestCheck(contestsUA, roundConfig.sampling, results)
 
     // write contests
-    val publisher = Publisher(auditdir)
+    val publisher = Publisher(topdir)
     writeContestsJsonFile(contestsUA, publisher.contestsFile())
     logger.info{"createElectionRecord write ${contestsUA.size} contests to ${publisher.contestsFile()}"}
 
@@ -117,14 +115,14 @@ fun createUniformElection(
     logger.info{"createElectionRecord writeElectionInfoJsonFile to ${publisher.electionInfoFile()}\n  $electionInfo"}
 
     val config = Config(election.electionInfo(), creation, roundConfig)
-    createAuditRecord(config, election, auditDir = auditdir, externalSortDir = null, sortManifest = false)
+    createAuditRecord(config, election, topdir = topdir, externalSortDir = null, sortManifest = false)
 
     writeCountyData(topdir, coloradoInput.strataMap.values.toList())
     val contestMap = election.contestsUA.associate { it.contest.info().name to it }
     writeCountyContestData(topdir, contestMap, coloradoInput)
 
     if (startFirstRound) {
-        val result = startFirstRound(auditdir)
+        val result = startFirstRound(topdir)
         if (result.isErr) logger.error { result.toString() }
         logger.info { "createCorla took $stopwatch" }
     }

--- a/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElection.kt
+++ b/cases/src/main/kotlin/org/cryptobiotic/rlauxe/sf/CreateSfElection.kt
@@ -322,7 +322,7 @@ fun makeContestNcs(contestManifest: ContestManifest, contestInfos: List<ContestI
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 fun createSfElection(
-    auditdir: String,
+    topdir: String,
     castVoteRecordZip: String,
     contestManifestFilename: String,
     candidateManifestFile: String,
@@ -342,14 +342,14 @@ fun createSfElection(
         poolsHaveOneCardStyle=false,
         mvrSource = mvrSource
     )
-    createElectionRecord(election, auditDir = auditdir)
+    createElectionRecord(election, topdir = topdir)
     logger.info{"createSfElection took $stopwatch"}
     stopwatch.start()
 
     val config = Config(election.electionInfo(), creation, round)
-    createAuditRecord(config, election, auditDir = auditdir)
+    createAuditRecord(config, election, topdir = topdir)
 
-    val result = startFirstRound(auditdir)
+    val result = startFirstRound(topdir)
     if (result.isErr) logger.error{ result.toString() }
     logger.info{"startFirstSfRound took $stopwatch"}
 

--- a/cases/src/test/kotlin/org/cryptobiotic/cli/ShowIrvContests.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/cli/ShowIrvContests.kt
@@ -22,7 +22,7 @@ class ShowIrvContests {
         val stopwatch = Stopwatch()
 
         val topDir = "$testdataDir/cases/sf2024"
-        val publisher = Publisher("$topDir/clca/audit")
+        val publisher = Publisher("$topDir/clca")
         val contestsResults = readContestsJsonFile(publisher.contestsFile())
         val contestsUA = if (contestsResults .isOk) contestsResults.unwrap()
         else throw RuntimeException("Cannot read contests from ${publisher.contestsFile()} err = $contestsResults")

--- a/cases/src/test/kotlin/org/cryptobiotic/cli/ShowPoolSizes.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/cli/ShowPoolSizes.kt
@@ -10,17 +10,16 @@ import kotlin.test.Test
 
 class ShowPoolSizes {
 
-
     @Test
     fun showCardPools() {
-        showCardPoolSizes("sf2024/oa", "$testdataDir/cases/sf2024/oa/audit")
-        showCardPoolSizes("sf2024/oans", "$testdataDir/cases/sf2024/oans/audit")
-        showCardPoolSizes("boulder24/oa", "$testdataDir/cases/boulder24/oa/audit")
-        showCardPoolSizes("corla/oa", "$testdataDir/cases/corla/oneaudit/audit")
+        showCardPoolSizes("sf2024/oa", "$testdataDir/cases/sf2024/oa")
+        showCardPoolSizes("sf2024/oans", "$testdataDir/cases/sf2024/oans")
+        showCardPoolSizes("boulder24/oa", "$testdataDir/cases/boulder24/oa")
+        showCardPoolSizes("corla/oa", "$testdataDir/cases/corla/oneaudit")
     }
 
-    fun showCardPoolSizes(what: String, where: String) {
-        val publisher = Publisher(where)
+    fun showCardPoolSizes(what: String, topdir: String) {
+        val publisher = Publisher(topdir)
 
         val contestsResults = readContestsJsonFile(publisher.contestsFile())
         val allContests = if (contestsResults .isOk) contestsResults.unwrap().sortedBy { it.id } else return

--- a/cases/src/test/kotlin/org/cryptobiotic/create/TestGenerateAllUseCases.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/create/TestGenerateAllUseCases.kt
@@ -32,7 +32,7 @@ class TestGenerateAllUseCases {
 
     @Test
     fun createBoulder24oa() {
-        val auditdir = "$testdataDir/cases/boulder24/oa/audit"
+        val topdir = "$testdataDir/cases/boulder24/oa"
 
         val creation = AuditCreationConfig(AuditType.ONEAUDIT, riskLimit=.05, )
         val round = AuditRoundConfig(
@@ -44,7 +44,7 @@ class TestGenerateAllUseCases {
             "2024",
             "src/test/data/Boulder2024/2024-Boulder-County-General-Redacted-Cast-Vote-Record.zip",
             "src/test/data/Boulder2024/2024G-Boulder-County-Official-Statement-of-Votes.csv",
-            auditdir = auditdir,
+            topdir = topdir,
             creation,
             round,
             distributeOvervotes = listOf(0, 63)
@@ -53,7 +53,7 @@ class TestGenerateAllUseCases {
 
     @Test
     fun createBoulder24clca() { // simulate CVRs
-        val auditdir = "$testdataDir/cases/boulder24/clca/audit"
+        val topdir = "$testdataDir/cases/boulder24/clca"
 
         val creation = AuditCreationConfig(AuditType.CLCA, riskLimit=.05, )
         val round = AuditRoundConfig(
@@ -65,7 +65,7 @@ class TestGenerateAllUseCases {
             "2024",
             "src/test/data/Boulder2024/2024-Boulder-County-General-Redacted-Cast-Vote-Record.zip",
             "src/test/data/Boulder2024/2024G-Boulder-County-Official-Statement-of-Votes.csv",
-            auditdir = auditdir,
+            topdir = topdir,
             creation,
             round,
             distributeOvervotes = listOf(0, 63)
@@ -84,7 +84,7 @@ class TestGenerateAllUseCases {
                 sampling = Sampling.uniform),
             ClcaConfig(), null)
 
-        createUniformElection(topdir, "$topdir/audit",
+        createUniformElection(topdir,
             Colorado2024General(), creation, round, name = "Corla24Uniform")
     }
 
@@ -99,7 +99,7 @@ class TestGenerateAllUseCases {
                 sampling = Sampling.consistent),
             ClcaConfig(), null)
 
-        createCorlaElection(topdir, "$topdir/audit", Colorado2024General(),
+        createCorlaElection(topdir, Colorado2024General(),
             null, creation, round, name = "Corla24Consistent", startFirstRound = true)
     }
 
@@ -113,7 +113,7 @@ class TestGenerateAllUseCases {
             ContestSampleControl(minRecountMargin = .005, contestSampleCutoff = 10000, auditSampleCutoff = 20000),
             ClcaConfig(), null)
 
-        createCorlaElection(topdir, "$topdir/audit", Colorado2024General(), null, creation, round)
+        createCorlaElection(topdir,  Colorado2024General(), null, creation, round)
     }
 
    //  @Test
@@ -126,7 +126,7 @@ class TestGenerateAllUseCases {
             ContestSampleControl(minRecountMargin = .005, contestSampleCutoff = 200000, auditSampleCutoff = 100000),
             null, PollingConfig())
 
-        createCorlaElection(topdir, "$topdir/audit", Colorado2024General(),
+        createCorlaElection(topdir,  Colorado2024General(),
             pollingMode=PollingMode.withPools, creation, round)
     }
 
@@ -140,7 +140,7 @@ class TestGenerateAllUseCases {
             ContestSampleControl(minRecountMargin = .005, contestSampleCutoff = 200000, auditSampleCutoff = 100000),
             null, PollingConfig())
 
-        createCorlaElection(topdir, "$topdir/audit", Colorado2024General(),
+        createCorlaElection(topdir,  Colorado2024General(),
             pollingMode=PollingMode.withBatches, creation, round)
     }
 
@@ -154,7 +154,7 @@ class TestGenerateAllUseCases {
             ContestSampleControl(minRecountMargin = .005, contestSampleCutoff = 200000, auditSampleCutoff = 100000),
             null, PollingConfig())
 
-        createCorlaElection(topdir, "$topdir/audit", Colorado2024General(),
+        createCorlaElection(topdir,  Colorado2024General(),
             pollingMode=PollingMode.withoutBatches, creation, round,
             startFirstRound = false,
         )
@@ -162,7 +162,7 @@ class TestGenerateAllUseCases {
 
     // @Test
     fun makeSFPrecinctAndStyleOA() {
-        val auditdir = "$testdataDir/cases/sf2024/oaps/audit"
+        val topdir = "$testdataDir/cases/sf2024/oaps"
         val contestManifestFilename = "ContestManifest.json"
         val candidateManifestFile = "CandidateManifest.json"
 
@@ -185,12 +185,12 @@ class TestGenerateAllUseCases {
             mvrSource = mvrSource
         )
 
-        createElectionRecord(election, auditDir = auditdir)
+        createElectionRecord(election, topdir = topdir)
 
         val config = Config(election.electionInfo(), creation, round)
-        createAuditRecord(config, election, auditDir = auditdir)
+        createAuditRecord(config, election, topdir = topdir)
 
-        val result = startFirstRound(auditdir)
+        val result = startFirstRound(topdir)
         if (result.isErr) {
             println( result.toString() )
             fail()
@@ -199,7 +199,7 @@ class TestGenerateAllUseCases {
 
     @Test
     fun makeSFElectionOA() {
-        val auditdir = "$testdataDir/cases/sf2024/oa/audit"
+        val topdir = "$testdataDir/cases/sf2024/oa"
 
         val creation = AuditCreationConfig(AuditType.ONEAUDIT, riskLimit=.05, )
         val round = AuditRoundConfig(
@@ -208,7 +208,7 @@ class TestGenerateAllUseCases {
             ClcaConfig(), null)
 
         createSfElection(
-            auditdir=auditdir,
+            topdir=topdir,
             sfZipFile,
             "ContestManifest.json",
             "CandidateManifest.json",
@@ -220,7 +220,7 @@ class TestGenerateAllUseCases {
 
     @Test
     fun makeSFElectionClca() {
-        val auditdir = "$testdataDir/cases/sf2024/clca/audit"
+        val topdir = "$testdataDir/cases/sf2024/clca"
 
         val creation = AuditCreationConfig(AuditType.CLCA, riskLimit=.05, )
         val round = AuditRoundConfig(
@@ -229,7 +229,7 @@ class TestGenerateAllUseCases {
             ClcaConfig(), null)
 
         createSfElection(
-            auditdir=auditdir,
+            topdir=topdir,
             sfZipFile,
             "ContestManifest.json",
             "CandidateManifest.json",

--- a/cases/src/test/kotlin/org/cryptobiotic/create/TestRunAllRoundsAllUseCases.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/create/TestRunAllRoundsAllUseCases.kt
@@ -7,43 +7,43 @@ import org.junit.jupiter.api.Test
 class TestRunAllRoundsAllUseCases {
     @Test
     fun runBoulder24oa() {
-        val auditdir = "$testdataDir/cases/boulder24/oa/audit"
-        runAllRoundsAndVerify(auditdir)
+        val topdir = "$testdataDir/cases/boulder24/oa"
+        runAllRoundsAndVerify(topdir)
     }
 
     @Test
     fun runBoulder24clca() { // simulate CVRs
         val topdir = "$testdataDir/cases/boulder24/clca"
-        runAllRoundsAndVerify("$topdir/audit")
+        runAllRoundsAndVerify("$topdir")
     }
 
     @Test
     fun runColoradoClca() {
         val topdir = "$testdataDir/cases/corla/clca"
-        runAllRoundsAndVerify("$topdir/audit")
+        runAllRoundsAndVerify("$topdir")
     }
 
     @Test
     fun runColoradoPolling() {
         val topdir = "$testdataDir/cases/corla/polling"
-        runAllRoundsAndVerify("$topdir/audit")
+        runAllRoundsAndVerify("$topdir")
     }
 
     @Test
     fun runSFElectionOASP() {
         val topdir = "$testdataDir/cases/sf2024/oasp"
-        runAllRoundsAndVerify("$topdir/audit")
+        runAllRoundsAndVerify("$topdir")
     }
 
     @Test
     fun runSFElectionOA() {
         val topdir = "$testdataDir/cases/sf2024/oa"
-        runAllRoundsAndVerify("$topdir/audit")
+        runAllRoundsAndVerify("$topdir")
     }
 
     @Test
     fun runSFElectionClca() {
         val topdir = "$testdataDir/cases/sf2024/clca"
-        runAllRoundsAndVerify("$topdir/audit")
+        runAllRoundsAndVerify("$topdir")
     }
 }

--- a/cases/src/test/kotlin/org/cryptobiotic/create/TestRunRlaStartFuzz.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/create/TestRunRlaStartFuzz.kt
@@ -13,7 +13,6 @@ class TestRunRlaStartFuzz {
     @Test
     fun testCliRoundClca() {
         val topdir = "$testdataDir/persist/testRunCli/clca"
-        val auditdir = "$topdir/audit"
 
         RunRlaStartFuzz.main(
             arrayOf(
@@ -27,24 +26,23 @@ class TestRunRlaStartFuzz {
         )
 
         println("============================================================")
-        RunVerifyContests.main(arrayOf("-in", auditdir))
+        RunVerifyContests.main(arrayOf("-in", topdir))
 
         println("============================================================")
         var done = false
         while (!done) {
-            val lastRound = runRound(inputDir = auditdir)
+            val lastRound = runRound(inputDir = topdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
         }
 
         println("============================================================")
-        val status = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir=auditdir)
+        val status = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir=topdir)
         println(status)
     }
 
     @Test
     fun testCliRoundPolling() {
         val topdir = "$testdataDir/persist/testRunCli/polling"
-        val auditdir = "$topdir/audit"
 
         RunRlaStartFuzz.main(
             arrayOf(
@@ -59,16 +57,16 @@ class TestRunRlaStartFuzz {
 
         var done = false
         while (!done) {
-            val lastRound = runRound(inputDir = auditdir)
+            val lastRound = runRound(inputDir = topdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 7
         }
 
         println("============================================================")
-        val results = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir=auditdir)
+        val results = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir=topdir)
         println(results)
 
         println("============================================================")
-        val results2 = RunVerifyContests.runVerifyContests(auditdir, null, false)
+        val results2 = RunVerifyContests.runVerifyContests(topdir, null, false)
         println()
         print(results2)
 
@@ -79,7 +77,6 @@ class TestRunRlaStartFuzz {
     @Test
     fun testCliRoundRaire() {
         val topdir = "$testdataDir/persist/testRunCli/raire"
-        val auditdir = "$topdir/audit"
 
         RunRlaStartFuzz.main(
             arrayOf(
@@ -95,17 +92,17 @@ class TestRunRlaStartFuzz {
         )
 
         println("============================================================")
-        RunVerifyContests.main(arrayOf("-in", auditdir))
+        RunVerifyContests.main(arrayOf("-in", topdir))
 
         println("============================================================")
         var done = false
         while (!done) {
-            val lastRound = runRound(inputDir = auditdir)
+            val lastRound = runRound(inputDir = topdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
         }
 
         println("============================================================")
-        val status = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir=auditdir)
+        val status = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir=topdir)
         println(status)
     }
 
@@ -119,7 +116,6 @@ class TestRunRlaStartFuzz {
     @Test
     fun testCliOneAudit() {
         val topdir = "$testdataDir/persist/testRunCli/oneaudit"
-        val auditdir = "$topdir/audit"
 
         RunRlaStartFuzz.main(
             arrayOf(
@@ -135,7 +131,7 @@ class TestRunRlaStartFuzz {
         )
 
         println("============================================================")
-        val resultsvc = RunVerifyContests.runVerifyContests(auditdir, null, false)
+        val resultsvc = RunVerifyContests.runVerifyContests(topdir, null, false)
         println()
         print(resultsvc)
         if (resultsvc.hasErrors) fail()
@@ -143,12 +139,12 @@ class TestRunRlaStartFuzz {
         println("============================================================")
         var done = false
         while (!done) {
-            val lastRound = runRound(inputDir = auditdir)
+            val lastRound = runRound(inputDir = topdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
         }
 
         println("============================================================")
-        val results = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir = auditdir)
+        val results = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir = topdir)
         println(results)
 
         if (results.hasErrors) fail()

--- a/cases/src/test/kotlin/org/cryptobiotic/create/TestVerifyUseCases.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/create/TestVerifyUseCases.kt
@@ -10,8 +10,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifyBoulder24oa() {
-        val auditdir = "$testdataDir/cases/boulder24/oa/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = "$testdataDir/cases/boulder24/oa"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -19,8 +19,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifyBoulder24oaContest() {
-        val auditdir = "$testdataDir/cases/boulder24/oa/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, 17, show = true)
+        val topdir = "$testdataDir/cases/boulder24/oa"
+        val results = RunVerifyContests.runVerifyContests(topdir, 17, show = true)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -28,8 +28,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifyBoulderClca() {
-        val auditdir = "$testdataDir/cases/boulder24/clca/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = "$testdataDir/cases/boulder24/clca"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -37,8 +37,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifyBoulderClcaContest() {
-        val auditdir = "$testdataDir/cases/boulder24/clca/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, 20, show = show)
+        val topdir = "$testdataDir/cases/boulder24/clca"
+        val results = RunVerifyContests.runVerifyContests(topdir, 20, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -46,8 +46,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifyCorlaConsistent() {
-        val auditdir = "$testdataDir/cases/corla/consistent/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = "$testdataDir/cases/corla/consistent"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -55,8 +55,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifyCorlaUniform() {
-        val auditdir = "$testdataDir/cases/corla/uniform/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, 1, show = show)
+        val topdir = "$testdataDir/cases/corla/uniform"
+        val results = RunVerifyContests.runVerifyContests(topdir, 1, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -64,8 +64,8 @@ class TestVerifyUseCases {
 
     //@Test
     fun testRunVerifyCorlaPolling() {
-        val auditdir = "$testdataDir/cases/corla/polling/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = "$testdataDir/cases/corla/polling"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -73,8 +73,8 @@ class TestVerifyUseCases {
 
     //@Test
     fun testRunVerifyCorlaPollingContest() {
-        val auditdir = "$testdataDir/cases/corla/polling/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, 1, show = show)
+        val topdir = "$testdataDir/cases/corla/polling"
+        val results = RunVerifyContests.runVerifyContests(topdir, 1, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -82,8 +82,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifySf2024clca() {
-        val auditdir = "$testdataDir/cases/sf2024/clca/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = "$testdataDir/cases/sf2024/clca"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -91,8 +91,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifySf2024clcaContest() {
-        val auditdir = "$testdataDir/cases/sf2024/clca/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, 52, show = show)
+        val topdir = "$testdataDir/cases/sf2024/clca"
+        val results = RunVerifyContests.runVerifyContests(topdir, 52, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -100,8 +100,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifySf2024oa() {
-        val auditdir = "$testdataDir/cases/sf2024/oa/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = "$testdataDir/cases/sf2024/oa"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -109,8 +109,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifySf2024oaContest() {
-        val auditdir = "$testdataDir/cases/sf2024/oa/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, 16, show = true)
+        val topdir = "$testdataDir/cases/sf2024/oa"
+        val results = RunVerifyContests.runVerifyContests(topdir, 16, show = true)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -118,8 +118,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifySf2024oaps() {
-        val auditdir = "$testdataDir/cases/sf2024/oaps/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = "$testdataDir/cases/sf2024/oaps"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -127,8 +127,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifySf2024oapsContest() {
-        val auditdir = "$testdataDir/cases/sf2024/oaps/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, 16, show = true)
+        val topdir = "$testdataDir/cases/sf2024/oaps"
+        val results = RunVerifyContests.runVerifyContests(topdir, 16, show = true)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -136,8 +136,8 @@ class TestVerifyUseCases {
 
     // @Test
     fun testRunVerifySf2024oans() {
-        val auditdir = "$testdataDir/cases/sf2024/oans/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = "$testdataDir/cases/sf2024/oans"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -145,8 +145,8 @@ class TestVerifyUseCases {
 
     // @Test
     fun testRunVerifySf2024oansContest() {
-        val auditdir = "$testdataDir/cases/sf2024/oans/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, 1, show = true)
+        val topdir = "$testdataDir/cases/sf2024/oans"
+        val results = RunVerifyContests.runVerifyContests(topdir, 1, show = true)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -154,8 +154,8 @@ class TestVerifyUseCases {
 
     // @Test
     fun testRunVerifySf2024polling() {
-        val auditdir = "$testdataDir/cases/sf2024/polling/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = "$testdataDir/cases/sf2024/polling"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -163,8 +163,8 @@ class TestVerifyUseCases {
 
     // @Test
     fun testRunVerifySf2024pollingContest() {
-        val auditdir = "$testdataDir/cases/sf2024/polling/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, 1, show = true)
+        val topdir = "$testdataDir/cases/sf2024/polling"
+        val results = RunVerifyContests.runVerifyContests(topdir, 1, show = true)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -172,8 +172,8 @@ class TestVerifyUseCases {
 
     @Test
     fun testRunVerifyDHondt() {
-        val auditdir = "$testdataDir/cases/belgium/2024/Hainaut/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = "$testdataDir/cases/belgium/2024/Hainaut"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
         if (results.hasErrors) fail()

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/auditcenter/CreateCountyElection.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/auditcenter/CreateCountyElection.kt
@@ -155,7 +155,7 @@ fun createCountyElection(
     county: String,
     coloradoInput: ColoradoInput,
     cvrExportFile: String,
-    auditdir: String,
+    topdir: String,
     creation: AuditCreationConfig,
     roundConfig: AuditRoundConfig,
     mvrSource: MvrSource = MvrSource.testPrivateMvrs,
@@ -168,14 +168,14 @@ fun createCountyElection(
     val election = CreateCountyElection(county, coloradoInput, creation.auditType, export, mvrSource = mvrSource,
             hasStyle = roundConfig.sampling.sampling == Sampling.consistent)
 
-    createElectionRecord(election, auditDir = auditdir)
+    createElectionRecord(election, topdir = topdir)
     println("createCountyElection for $county took $stopwatch")
 
     val config = Config(election.electionInfo(), creation, roundConfig)
-    createAuditRecord(config, election, auditDir = auditdir)
+    createAuditRecord(config, election, topdir = topdir)
 
     if (startFirstRound) {
-        val result = startFirstRound(auditdir)
+        val result = startFirstRound(topdir)
         if (result.isErr) logger.error { result.toString() }
     }
     logger.info{"startFirstBoulderRound took $stopwatch"}

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/auditcenter/MakeElectionsSansCvrs.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/auditcenter/MakeElectionsSansCvrs.kt
@@ -28,7 +28,7 @@ class MakeElectionsSansCvrs {
     fun makeCounty2024OnlyTeller() {
         val topdir = "$testdataDir/cases/auditcenter/County2024OnlyTeller"
 
-        createCountyElectionSansCvrs(topdir, "$topdir/audit", Colorado2024General(),
+        createCountyElectionSansCvrs(topdir,  Colorado2024General(),
             creation, round, name = "County2024OnlyTeller", startFirstRound = true, onlyCounty="Teller")
     }
 
@@ -36,7 +36,7 @@ class MakeElectionsSansCvrs {
     fun makeCounty2024General() {
         val topdir = "$cases/corla/sansCvrs/Colorado2024"
 
-        createCountyElectionSansCvrs(topdir, "$topdir/audit", Colorado2024General(),
+        createCountyElectionSansCvrs(topdir,  Colorado2024General(),
             creation, round, name = "County2024General", startFirstRound = true)
     }
 
@@ -44,7 +44,7 @@ class MakeElectionsSansCvrs {
     fun makeColorado2022Primary() {
         val topdir = "$cases/corla/sansCvrs/Colorado2022Primary"
 
-        createCountyElectionSansCvrs(topdir, "$topdir/audit", Colorado2022Primary(),
+        createCountyElectionSansCvrs(topdir,  Colorado2022Primary(),
             creation, round, name = "Colorado2022Primary", startFirstRound = true)
     }
 
@@ -52,14 +52,14 @@ class MakeElectionsSansCvrs {
     fun makeColorado2020General() {
         val topdir = "$cases/corla/sansCvrs/Colorado2020"
 
-        createCountyElectionSansCvrs(topdir, "$topdir/audit", Colorado2020General(),
+        createCountyElectionSansCvrs(topdir, Colorado2020General(),
             creation, round, name = "Colorado2020sans", startFirstRound = true)
     }
 
     @Test
     fun readCountyAuditRecord() {
         val topdir = "$cases/corla/sansCvrs/Colorado2020sans/"
-        val auditRecord = AuditRecord.read("$topdir")
+        val auditRecord = AuditRecord.read(topdir)
         val countyRecord =  auditRecord as CountyAuditRecord
 
         println("countyRecord.countyData")

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/auditcenter/MakeElectionsWithCvrs.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/auditcenter/MakeElectionsWithCvrs.kt
@@ -1,15 +1,23 @@
 package org.cryptobiotic.rlauxe.auditcenter
 
+import com.github.michaelbull.result.Result
 import org.cryptobiotic.rlauxe.audit.AuditCreationConfig
 import org.cryptobiotic.rlauxe.audit.AuditRoundConfig
+import org.cryptobiotic.rlauxe.audit.AuditRoundIF
 import org.cryptobiotic.rlauxe.audit.AuditType
 import org.cryptobiotic.rlauxe.audit.ClcaConfig
 import org.cryptobiotic.rlauxe.audit.ContestSampleControl
 import org.cryptobiotic.rlauxe.audit.Sampling
 import org.cryptobiotic.rlauxe.audit.SimulationControl
+import org.cryptobiotic.rlauxe.audit.resampleAndSaveResults
+import org.cryptobiotic.rlauxe.audit.runRound
+import org.cryptobiotic.rlauxe.audit.runRoundResult
+import org.cryptobiotic.rlauxe.audit.startFirstRound
 import org.cryptobiotic.rlauxe.cases
 import org.cryptobiotic.rlauxe.persist.AuditRecord
 import org.cryptobiotic.rlauxe.persist.CountyAuditRecord
+import org.cryptobiotic.rlauxe.util.ErrorMessages
+import org.cryptobiotic.rlauxe.util.OnlyTask
 import org.cryptobiotic.rlauxe.votedatabase.colorado2020
 import kotlin.io.path.Path
 import kotlin.io.path.isDirectory
@@ -20,24 +28,48 @@ import kotlin.test.Test
 class MakeElectionsWithCvrs {
     val show = false
 
-    @Test
-    fun makeColorado2020() {
-        val topdir = "$cases/corla/withCvrs/Colorado2020"
+    val round = AuditRoundConfig(
+        SimulationControl(nsimTrials = 10, estPercentile = listOf(42, 55, 67)),
+        ContestSampleControl(
+            minRecountMargin = .005,
+            minMargin = .005,
+            minSize = 10,
+            contestSampleCutoff = 10000,
+            auditSampleCutoff = 200000,
+            sampling = Sampling.consistent),
+        ClcaConfig(), null)
 
-        val creation = AuditCreationConfig(AuditType.CLCA, riskLimit=.03, )
+    @Test
+    fun makeColorado2020uniform() {
+        val topdir = "$cases/corla/withCvrs/Colorado2020uniform"
+        val creation = AuditCreationConfig(AuditType.CLCA, riskLimit=.04, ) // TODO LOOK
         val round = AuditRoundConfig(
             SimulationControl(nsimTrials = 10, estPercentile = listOf(42, 55, 67)),
-            ContestSampleControl(minRecountMargin = .005,
+            ContestSampleControl(
+                minRecountMargin = .005,
+                minMargin = .005,
                 minSize = 10,
                 contestSampleCutoff = 10000,
                 auditSampleCutoff = 200000,
-                sampling = Sampling.consistent),
+                sampling = Sampling.uniform),
             ClcaConfig(), null)
 
-        // TODO topdir vs auditdir !!
         countyElectionWithCvrs(
             allColorado2020Counties(), Colorado2020General(), topdir,
-            creation, round, name = "Colorado2020", startFirstRound = true
+            creation, round, name = "Colorado2020uniform", startFirstRound = true,
+            isUniform = true,
+        )
+    }
+
+    @Test
+    fun makeColorado2020() {
+        val topdir = "$cases/corla/withCvrs/Colorado2020"
+        val creation = AuditCreationConfig(AuditType.CLCA, riskLimit=.04, ) // TODO LOOK
+
+        countyElectionWithCvrs(
+            allColorado2020Counties(), Colorado2020General(), topdir,
+            creation, round, name = "Colorado2020", startFirstRound = true,
+            isUniform = false,
         )
     }
 
@@ -55,9 +87,29 @@ class MakeElectionsWithCvrs {
     }
 
     @Test
+    fun startColorado2020() {
+        val topdir = "$cases/corla/withCvrs/Colorado2020uniform"
+        startFirstRound(topdir)
+    }
+
+    @Test
+    fun runColorado2020() {
+        val topdir = "$cases/corla/withCvrs/Colorado2020uniform"
+        runRound(topdir)
+    }
+    @Test
+    fun resampleColorado2020() {
+        val topdir = "$cases/corla/withCvrs/Colorado2020uniform"
+        resampleAndSaveResults(topdir)
+    }
+
+    @Test
     fun openColorado2020() {
-        val auditdir = "$cases/corla/withCvrs/Colorado2020"
-        val countyRecord = AuditRecord.read(auditdir) as CountyAuditRecord
+        val topdir = "$cases/corla/withCvrs/Colorado2020uniform"
+        val countyRecord = AuditRecord.read(topdir) as CountyAuditRecord
+
+        val what = runRoundResult(topdir)
+        println(what)
 
         println("countyRecord.countyData")
         // countyRecord.countyData.forEach { println( it) }
@@ -68,7 +120,7 @@ class MakeElectionsWithCvrs {
 
         val mvrCounts = countyRecord.countMvrsByCounty()
         println("countyRecord.countMvrsByCounty")
-        mvrCounts.forEach { println( it) }
+        mvrCounts.forEach { println(it) }
         println()
     }
 }

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/auditcenter/TestColoradoInputNames.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/auditcenter/TestColoradoInputNames.kt
@@ -5,7 +5,7 @@ import kotlin.test.assertTrue
 
 // check name consistency in ColoradoInput
 class TestColoradoInputNames {
-    val input: ColoradoInput = Colorado2024General()
+    val input: ColoradoInput = Colorado2020corrected()
 
     val canonical = readGeneralCanonicalList(input.generalCanonicalFile).associateBy { it.contestName }
     val canonicalContestNames = canonical.map{ it.key }
@@ -91,15 +91,15 @@ class TestColoradoInputNames {
     }
 
     @Test
-    fun checkCountyTabulateHasCanonical() {
-        println("\n------------------------- checkCountyTabulateHasCanonical")
+    fun checkContestTabulateHasCanonical() {
+        println("\n------------------------- checkContestTabulateHasCanonical")
         val missing = mutableListOf<String>()
 
-        // TODO read raw input ??
+        // raw inout
         val contestTabs: Map<String, ContestTabAllCounties> = input.contestTabsAllCounties
         canonical.values.forEach { cc ->
             if (!contestTabs.contains(cc.contestName)) {
-                println("countyTabulate missing canonical '${cc.contestName}'")
+                println("contestTabulate missing canonical contest '${cc.contestName}'")
                 missing.add(cc.contestName)
             } else {
                 val contestTab : ContestTabAllCounties = contestTabs[cc.contestName]!!
@@ -119,7 +119,6 @@ class TestColoradoInputNames {
         println("\n-------------------------- checkCountyTabulateAndCanonicalContests")
         val countyTabs: Map<String, CountyTabAllContests> = readCountyTabulateCsv(input.tabulateCountyFile)
         val countiesFromTab = countyTabs.keys.toSet().toList()
-
         compareLists(input.counties(), countiesFromTab, "canonical", "countyTabulateCsv")
     }
 

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/auditcenter/TestWriteCountyData.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/auditcenter/TestWriteCountyData.kt
@@ -16,7 +16,7 @@ class TestWriteCountyData {
     @Test
     fun testWriteCountyContestData() {
         val topdir = "${testdataDir}/cases/corla/consistent"
-        val countyAudit = AuditRecord.readWithResult("$topdir/audit").unwrap()
+        val countyAudit = AuditRecord.readWithResult(topdir).unwrap()
         val contestMap = countyAudit.contests.associate { it.contest.info().name to it }
         writeCountyContestData(topdir, contestMap, Colorado2024General())
 

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/belgium/MakeBelgiumElections.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/belgium/MakeBelgiumElections.kt
@@ -76,12 +76,11 @@ class MakeBelgiumElections {
 
 private fun runBelgiumElection(electionName: String, stopRound:Int=0): Int {
     val topdir = "$toptopdir/$electionName"
-    val auditdir = "$topdir/audit"
 
     var done = false
     var finalRound: AuditRoundIF? = null
     while (!done) {
-        val lastRound = runRound(inputDir = auditdir)
+        val lastRound = runRound(inputDir = topdir)
         if (lastRound != null) finalRound = lastRound
         done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5 || lastRound.roundIdx == stopRound
     }
@@ -98,10 +97,9 @@ private fun showBelgiumElection(electionName: String): Triple<Int, Int, Assorter
     println("======================================================")
     println("showBelgiumElection $electionName")
     val topdir = "$toptopdir/$electionName"
-    val auditdir = "$topdir/audit"
 
-    val auditRecord = AuditRecord.read(auditdir)
-        ?: throw RuntimeException("directory '$auditdir' does not contain an audit record")
+    val auditRecord = AuditRecord.read(topdir)
+        ?: throw RuntimeException("directory '$topdir' does not contain an audit record")
 
     val contestUA = auditRecord.contests.first()
     println(contestUA.show())

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/boulder/MakeBoulderElection.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/boulder/MakeBoulderElection.kt
@@ -20,7 +20,7 @@ class MakeBoulderElection {
 
     @Test
     fun createBoulder25oa() { // simulate CVRs
-        val auditdir = "$testdataDir/cases/boulder2025/oa/audit"
+        val topdir = "$testdataDir/cases/boulder2025/oa"
 
         val creation = AuditCreationConfig(AuditType.ONEAUDIT, riskLimit = .03, )
         val round = AuditRoundConfig(
@@ -38,7 +38,7 @@ class MakeBoulderElection {
             "2025",
             "src/test/data/Boulder2025/Redacted-CVR-PUBLIC.csv",
             "src/test/data/Boulder2025/2025C-Boulder-County-Official-Statement-of-Votes.csv",
-            auditdir = auditdir,
+            topdir = topdir,
             creation,
             round,
             distributeOvervotes = listOf(),
@@ -51,7 +51,7 @@ class MakeBoulderElection {
 
     @Test
     fun createBoulder24oa() {
-        val auditdir = "$testdataDir/cases/boulder24/oa/audit"
+        val topdir = "$testdataDir/cases/boulder24/oa"
 
         val creation = AuditCreationConfig(AuditType.ONEAUDIT, riskLimit = .03, )
         val round = AuditRoundConfig(
@@ -69,7 +69,7 @@ class MakeBoulderElection {
             "2024",
             "src/test/data/Boulder2024/2024-Boulder-County-General-Redacted-Cast-Vote-Record.zip",
             "src/test/data/Boulder2024/2024G-Boulder-County-Official-Statement-of-Votes.csv",
-            auditdir = auditdir,
+            topdir = topdir,
             creation,
             round,
             distributeOvervotes = listOf(0, 63)
@@ -78,8 +78,8 @@ class MakeBoulderElection {
 
     @Test
     fun testRunVerifyBoulder24oa() {
-        val auditdir = "$testdataDir/cases/boulder24/oa/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = false)
+        val topdir = "$testdataDir/cases/boulder24/oa"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = false)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -87,7 +87,7 @@ class MakeBoulderElection {
 
     @Test
     fun createBoulder24clca() { // simulate CVRs
-        val auditdir = "$testdataDir/cases/boulder24/clca/audit"
+        val topdir = "$testdataDir/cases/boulder24/clca"
 
         val creation = AuditCreationConfig(AuditType.CLCA, riskLimit = .03, )
         val round = AuditRoundConfig(
@@ -100,7 +100,7 @@ class MakeBoulderElection {
             "2024",
             "src/test/data/Boulder2024/2024-Boulder-County-General-Redacted-Cast-Vote-Record.zip",
             "src/test/data/Boulder2024/2024G-Boulder-County-Official-Statement-of-Votes.csv",
-            auditdir = auditdir,
+            topdir = topdir,
             creation,
             round,
             distributeOvervotes = listOf(0, 63)
@@ -109,8 +109,8 @@ class MakeBoulderElection {
 
     @Test
     fun testRunVerifyBoulder24clca() {
-        val auditdir = "$testdataDir/cases/boulder24/clca/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = false)
+        val topdir = "$testdataDir/cases/boulder24/clca"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = false)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -126,7 +126,7 @@ class MakeBoulderElection {
 
         println(combined.show())
 
-        val auditdir = "$testdataDir/cases/boulder23/oa/audit"
+        val topdir = "$testdataDir/cases/boulder23/oa"
 
         val creation = AuditCreationConfig(AuditType.ONEAUDIT, riskLimit = .03, )
         val round = AuditRoundConfig(
@@ -143,7 +143,7 @@ class MakeBoulderElection {
         // fun createBoulderElectionWithSovo(
         //    cvrExportFile: String,
         //    sovo: BoulderStatementOfVotes,
-        //    auditdir: String,
+        //    topdir: String,
         //    creation: AuditCreationConfig,
         //    round: AuditRoundConfig,
         //    mvrSource: MvrSource = MvrSource.testPrivateMvrs,
@@ -152,7 +152,7 @@ class MakeBoulderElection {
             "2023",
             cvrExportFile = "src/test/data/Boulder2023/Redacted-2023Coordinated-CVR.csv",
             sovo = combined,
-            auditdir = auditdir,
+            topdir = topdir,
             creation,
             round,
             distributeOvervotes = listOf(2),
@@ -173,7 +173,7 @@ class MakeBoulderElection {
      createBoulderElection(
          "src/test/data/Boulder2024/2024-Boulder-County-General-Recount-Redacted-Cast-Vote-Record.csv",
          "src/test/data/Boulder2024/2024G-Boulder-County-Amended-Statement-of-Votes.csv",
-         auditDir = "$testdataDir/cases/boulder24recount",
+         topdir = "$testdataDir/cases/boulder24recount",
          minRecountMargin = 0.0,
      )
  }
@@ -236,9 +236,9 @@ class MakeBoulderElection {
 
     class RunOneAuditVarianceTask(
         val runIndex: Int,
-        val topdir: String,
+        topdir: String,
     ) : ConcurrentTask<Boolean> {
-        val auditdir = "$topdir/audit$runIndex"
+        val topdirIdx = "$topdir$runIndex"
 
         override fun name() = "createBoulderElection $runIndex"
 
@@ -260,12 +260,12 @@ class MakeBoulderElection {
                 "2024",
                 "src/test/data/Boulder2024/2024-Boulder-County-General-Redacted-Cast-Vote-Record.zip",
                 "src/test/data/Boulder2024/2024G-Boulder-County-Official-Statement-of-Votes.csv",
-                auditdir = auditdir,
+                topdir = topdirIdx,
                 creation,
                 round,
                 distributeOvervotes = listOf(0, 63)
             )
-            return runAllRoundsAndVerify(auditdir, verify = false)
+            return runAllRoundsAndVerify(topdirIdx, verify = false)
         }
     }
 }

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/boulder/MakeBoulderRemoveN.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/boulder/MakeBoulderRemoveN.kt
@@ -24,8 +24,8 @@ class MakeBoulderRemoveN {
         val results = mutableListOf<AuditResult>()
 
         repeat(11) { removeN ->
-            val auditdir = "$testdataDir/cases/boulder24/clcan/audit$removeN"
-            val task = RunRemoveBoulderTask(removeN, 1, auditdir, AuditType.CLCA)
+            val topdirn = "$testdataDir/cases/boulder24/clcan$removeN"
+            val task = RunRemoveBoulderTask(removeN, 1, topdirn, AuditType.CLCA)
             val estResults: List<AuditResult> = task.run()
             results.addAll(estResults)
         }
@@ -38,8 +38,8 @@ class MakeBoulderRemoveN {
 
         val tasks = mutableListOf<ConcurrentTask<List<AuditResult>>>()
         repeat(11) { removeN ->
-            val auditDir = "$testdataDir/cases/boulder24/oan/audit$removeN"
-            tasks.add(RunRemoveBoulderTask(removeN, 1, auditDir, AuditType.ONEAUDIT))
+            val topdirn = "$testdataDir/cases/boulder24/oan$removeN"
+            tasks.add(RunRemoveBoulderTask(removeN, 1, topdirn, AuditType.ONEAUDIT))
         }
 
         val estResults: List<AuditResult> =
@@ -65,7 +65,7 @@ class MakeBoulderRemoveN {
 class RunRemoveBoulderTask(
     val removeN: Int,
     val nruns: Int,
-    val auditDir: String,
+    val topdir: String,
     val auditType: AuditType,
 ) : ConcurrentTask<List<AuditResult>> {
 
@@ -79,13 +79,13 @@ class RunRemoveBoulderTask(
             "2024",
             "src/test/data/Boulder2024/2024-Boulder-County-General-Redacted-Cast-Vote-Record.zip",
             "src/test/data/Boulder2024/2024G-Boulder-County-Official-Statement-of-Votes.csv",
-            auditdir = auditDir,
+            topdir = topdir,
             creation,
             round,
             distributeOvervotes = listOf(0, 63)
         )
 
-        val publisher = Publisher(auditDir)
+        val publisher = Publisher(topdir)
         val results = mutableListOf<AuditResult>()
         repeat(nruns) { run ->
             // TODO
@@ -93,11 +93,11 @@ class RunRemoveBoulderTask(
             //val nconfig = config.copy(removeMaxContests = removeN, seed = secureRandom.nextLong())
             //writeAuditConfigJsonFile(nconfig, publisher.auditConfigFile())
             println("${name()} removeN=$removeN run=$run")
-            startFirstRound(auditDir)
-            runAllRoundsAndVerify(auditDir, verify = false)
+            startFirstRound(topdir)
+            runAllRoundsAndVerify(topdir, verify = false)
 
             val contestState = mutableMapOf<Int, TestH0Status>()
-            val auditRecord = AuditRecord.read(auditDir)!!
+            val auditRecord = AuditRecord.read(topdir)!!
             auditRecord.rounds.forEach { auditRound ->
                 auditRound.contestRounds.forEach { contestRound ->
                     contestState[contestRound.id] = contestRound.status

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/boulder/TestBoulder2024Cvrs.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/boulder/TestBoulder2024Cvrs.kt
@@ -124,8 +124,8 @@ class TestBoulder2024Cvrs {
 
     @Test
     fun testMvrs() {
-        val auditdir = "$testdataDir/cases/boulder24/oa/audit"
-        val publisher = Publisher(auditdir)
+        val topdir = "$testdataDir/cases/boulder24/oa"
+        val publisher = Publisher(topdir)
         val sortedMvrs = readCardsCsvIterator(publisher.sortedMvrsFile(), null)
 
         val tab = ContestTabulation(17, 1, false, listOf(0,1))

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/corla/MakeColoradoElections.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/corla/MakeColoradoElections.kt
@@ -69,7 +69,7 @@ class MakeColoradoElections {
                 sampling = Sampling.uniform),
             ClcaConfig(), null)
 
-        createUniformElection(topdir, "$topdir/audit", Colorado2024General(),
+        createUniformElection(topdir,  Colorado2024General(),
             creation, round, name = "Corla24Uniform")
     }
 
@@ -84,7 +84,7 @@ class MakeColoradoElections {
                 sampling = Sampling.consistent),
             ClcaConfig(), null)
 
-        createCorlaElection(topdir, "$topdir/audit", Colorado2024General(),
+        createCorlaElection(topdir,  Colorado2024General(),
             null, creation, round, name = "Corla24Consistent", startFirstRound = true)
     }
 
@@ -98,7 +98,7 @@ class MakeColoradoElections {
             ContestSampleControl(minRecountMargin = .005, contestSampleCutoff = 200000, auditSampleCutoff = 100000),
             null, PollingConfig())
 
-        createCorlaElection(topdir, "$topdir/audit", Colorado2024General(),
+        createCorlaElection(topdir,  Colorado2024General(),
             pollingMode=PollingMode.withPools, creation, round)
     }
 
@@ -112,7 +112,7 @@ class MakeColoradoElections {
             ContestSampleControl(minRecountMargin = .005, contestSampleCutoff = 200000, auditSampleCutoff = 100000),
             null, PollingConfig())
 
-        createCorlaElection(topdir, "$topdir/audit", Colorado2024General(),
+        createCorlaElection(topdir,  Colorado2024General(),
             pollingMode=PollingMode.withBatches, creation, round)
     }
 
@@ -126,7 +126,7 @@ class MakeColoradoElections {
             ContestSampleControl(minRecountMargin = .005, contestSampleCutoff = 200000, auditSampleCutoff = 100000),
             null, PollingConfig())
 
-        createCorlaElection(topdir, "$topdir/audit", Colorado2024General(),
+        createCorlaElection(topdir,  Colorado2024General(),
             pollingMode=PollingMode.withoutBatches, creation, round)
     }
 
@@ -143,12 +143,12 @@ class MakeColoradoElections {
 
     // @Test
     fun testRunVerifyPolling() {
-        val auditdir = "$testdataDir/cases/corla/polling/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = true)
+        val topdir = "$testdataDir/cases/corla/polling"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = true)
         println()
         print(results)
 
-        val results2 = runVerifyAuditRecord(auditdir)
+        val results2 = runVerifyAuditRecord(topdir)
         println()
         print(results2)
         if (results.hasErrors) fail()
@@ -186,7 +186,7 @@ class MakeColoradoElections {
         val countySamples = countyPrecincts.associate { it.county to mutableMapOf<String, PrecinctSamples>() }
 
         // fake: reading the mvrs instead of the cvrs
-        val publisher = Publisher("$topDir/audit")
+        val publisher = Publisher(topDir)
         val sampledMvrs = readCardsAndMergeToList(publisher.sampleMvrsFile(1), null)
         println("number of samples = ${sampledMvrs.size}")
 

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/MakeSfElection.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/MakeSfElection.kt
@@ -17,7 +17,7 @@ class MakeSfElection {
 
     @Test
     fun makeSFElectionOA() {
-        val auditdir = "$testdataDir/cases/sf2024/oa/audit"
+        val topdir = "$testdataDir/cases/sf2024/oa"
 
         val creation = AuditCreationConfig(AuditType.ONEAUDIT, riskLimit=.05,)
         val round = AuditRoundConfig(
@@ -26,7 +26,7 @@ class MakeSfElection {
             ClcaConfig(), null)
 
         createSfElection(
-            auditdir=auditdir,
+            topdir=topdir,
             castVoteRecordZip,
             "ContestManifest.json",
             "CandidateManifest.json",
@@ -38,8 +38,8 @@ class MakeSfElection {
 
     @Test
     fun testRunVerifySFoa() {
-        val auditdir = "$testdataDir/cases/sf2024/oa/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = false)
+        val topdir = "$testdataDir/cases/sf2024/oa"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = false)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -47,7 +47,7 @@ class MakeSfElection {
 
     @Test
     fun makeSFElectionClca() {
-        val auditdir = "$testdataDir/cases/sf2024/clca/audit"
+        val topdir = "$testdataDir/cases/sf2024/clca"
 
         val creation = AuditCreationConfig(AuditType.CLCA, riskLimit=.05, )
         val round = AuditRoundConfig(
@@ -56,7 +56,7 @@ class MakeSfElection {
             ClcaConfig(fuzzMvrs=.001), null)
 
         createSfElection(
-            auditdir=auditdir,
+            topdir=topdir,
             castVoteRecordZip,
             "ContestManifest.json",
             "CandidateManifest.json",
@@ -68,7 +68,7 @@ class MakeSfElection {
 
     @Test
     fun makePrecinctAndStyleOA() {
-        val auditdir = "$testdataDir/cases/sf2024/oaps/audit"
+        val topdir = "$testdataDir/cases/sf2024/oaps"
         val contestManifestFilename = "ContestManifest.json"
         val candidateManifestFile = "CandidateManifest.json"
 
@@ -91,12 +91,12 @@ class MakeSfElection {
             mvrSource = mvrSource
         )
 
-        createElectionRecord(election, auditDir = auditdir)
+        createElectionRecord(election, topdir = topdir)
 
         val config = Config(election.electionInfo(), creation, round)
-        createAuditRecord(config, election, auditDir = auditdir)
+        createAuditRecord(config, election, topdir = topdir)
 
-        val result = startFirstRound(auditdir)
+        val result = startFirstRound(topdir)
         if (result.isErr) logger.error{ result.toString() }
     }
 }

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/MakeSfVarianceData.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/MakeSfVarianceData.kt
@@ -50,7 +50,7 @@ class MakeSfVarianceData {
         val topdir: String,
         val nsimTrials: Int,
     ) : ConcurrentTask<Boolean> {
-        val auditdir = "$topdir/audit$runIndex"
+        val topdirn = "$topdir$runIndex"
 
         override fun name() = "createSFElection $runIndex"
 
@@ -62,7 +62,7 @@ class MakeSfVarianceData {
                 ClcaConfig(), null)
 
             createSfElection(
-                auditdir=auditdir,
+                topdir=topdirn,
                 castVoteRecordZip,
                 "ContestManifest.json",
                 "CandidateManifest.json",
@@ -72,7 +72,7 @@ class MakeSfVarianceData {
             )
             GeneralAdaptiveBetting.showCounts("after create")
 
-            return runAllRoundsAndVerify(auditdir)
+            return runAllRoundsAndVerify(topdirn)
         }
     }
 
@@ -95,7 +95,7 @@ class MakeSfVarianceData {
         val topdir: String,
         val auditType: AuditType,
     ) : ConcurrentTask<Boolean> {
-        val auditdir = "$topdir/audit$runIndex"
+        val topdirn = "$topdir$runIndex"
         val contestManifestFilename = "ContestManifest.json"
         val candidateManifestFile = "CandidateManifest.json"
         val creation = AuditCreationConfig(AuditType.ONEAUDIT, riskLimit=.05,)
@@ -119,13 +119,13 @@ class MakeSfVarianceData {
                 mvrSource = mvrSource
             )
 
-            createElectionRecord(election, auditDir = auditdir)
+            createElectionRecord(election, topdir = topdirn)
 
             val config = Config(election.electionInfo(), creation, round)
-            createAuditRecord(config, election, auditDir = auditdir)
+            createAuditRecord(config, election, topdir = topdirn)
 
-            startFirstRound(auditdir)
-            return runAllRoundsAndVerify(auditdir)
+            startFirstRound(topdirn)
+            return runAllRoundsAndVerify(topdirn)
         }
     }
 
@@ -136,8 +136,8 @@ class MakeSfVarianceData {
 
         val tasks = mutableListOf<ConcurrentTask<List<AuditResult2>>>()
         repeat(8) { removeN ->
-            val auditdir = "$testdataDir/cases/sf2024/clcan/audit$removeN"
-            tasks.add(RunRemoveSFtask( removeN+2,20, auditdir, AuditType.CLCA, nsimTrials=20))
+            val topdirn = "$testdataDir/cases/sf2024/clcan$removeN"
+            tasks.add(RunRemoveSFtask( removeN+2,20, topdirn, AuditType.CLCA, nsimTrials=20))
         }
 
         val results: List<AuditResult2> =
@@ -153,8 +153,8 @@ class MakeSfVarianceData {
 
         val tasks = mutableListOf<ConcurrentTask<List<AuditResult2>>>()
         repeat(8) { removeN ->
-            val auditDir = "$testdataDir/cases/sf2024/oan/audit$removeN"
-            tasks.add(RunRemoveSFtask(removeN+2, 20, auditDir, AuditType.ONEAUDIT, nsimTrials=20))
+            val topdirn = "$testdataDir/cases/sf2024/oan$removeN"
+            tasks.add(RunRemoveSFtask(removeN+2, 20, topdirn, AuditType.ONEAUDIT, nsimTrials=20))
         }
 
         val estResults: List<AuditResult2> =
@@ -179,7 +179,7 @@ class MakeSfVarianceData {
     inner class RunRemoveSFtask(
         val removeN: Int,
         val nruns: Int,
-        val auditDir: String,
+        val topdir: String,
         val auditType: AuditType,
         val nsimTrials: Int,
     ) : ConcurrentTask<List<AuditResult2>> {
@@ -202,7 +202,7 @@ class MakeSfVarianceData {
                 )
 
                 createSfElection(
-                    auditdir = auditDir,
+                    topdir = topdir,
                     castVoteRecordZip,
                     "ContestManifest.json",
                     "CandidateManifest.json",
@@ -212,10 +212,10 @@ class MakeSfVarianceData {
                 )
 
                 println("${name()} removeN=$removeN run=$run")
-                runAllRoundsAndVerify(auditDir, verify = false)
+                runAllRoundsAndVerify(topdir, verify = false)
 
                 val contestState = mutableMapOf<Int, TestH0Status>()
-                val auditRecord = AuditRecord.read(auditDir)!!
+                val auditRecord = AuditRecord.read(topdir)!!
                 auditRecord.rounds.forEach { auditRound ->
                     auditRound.contestRounds.forEach { contestRound ->
                         contestState[contestRound.id] = contestRound.status
@@ -234,8 +234,8 @@ class MakeSfVarianceData {
     fun createSfRemoveNsp() {
         val tasks = mutableListOf<ConcurrentTask<List<AuditResult2>>>()
         repeat(8) { removeN ->
-            val auditDir = "$testdataDir/cases/sf2024/oaspn/audit$removeN"
-            tasks.add( RunRemoveSFtaskSP(removeN+2, 20, auditDir, nsimTrials=20))
+            val topdirn = "$testdataDir/cases/sf2024/oaspn$removeN"
+            tasks.add( RunRemoveSFtaskSP(removeN+2, 20, topdirn, nsimTrials=20))
         }
 
         val estResults: List<AuditResult2> =
@@ -261,14 +261,14 @@ class MakeSfVarianceData {
     inner class RunRemoveSFtaskSP(
         val removeN: Int,
         val nruns: Int,
-        val auditDir: String,
+        val topdir: String,
         val nsimTrials: Int,
     ) : ConcurrentTask<List<AuditResult2>> {
 
         val contestManifestFilename = "ContestManifest.json"
         val candidateManifestFile = "CandidateManifest.json"
 
-        override fun name() = "RunRemoveSFtaskSP $auditDir"
+        override fun name() = "RunRemoveSFtaskSP $topdir"
 
         override fun run(): List<AuditResult2> {
 
@@ -289,22 +289,22 @@ class MakeSfVarianceData {
                     poolsHaveOneCardStyle=true,
                     mvrSource = mvrSource
                 )
-                createElectionRecord(election, auditDir = auditDir)
+                createElectionRecord(election, topdir = topdir)
 
                 val config = Config(election.electionInfo(), creation, round)
-                createAuditRecord(config, election, auditDir = auditDir)
+                createAuditRecord(config, election, topdir = topdir)
 
-                val startResult = startFirstRound(auditDir)
+                val startResult = startFirstRound(topdir)
                 if (startResult.isErr) {
                     println( startResult.toString() )
                     return emptyList()
                 }
 
                 println("${name()} removeN=$removeN run=$run")
-                runAllRoundsAndVerify(auditDir, verify=false)
+                runAllRoundsAndVerify(topdir, verify=false)
 
                 val contestState = mutableMapOf<Int, TestH0Status>()
-                val auditRecord = AuditRecord.read(auditDir)!!
+                val auditRecord = AuditRecord.read(topdir)!!
                 auditRecord.rounds.forEach { auditRound ->
                     auditRound.contestRounds.forEach { contestRound ->
                         contestState[contestRound.id] = contestRound.status

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSf2024OneAuditIrv.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSf2024OneAuditIrv.kt
@@ -39,8 +39,8 @@ class TestSf2024OneAuditIrv() {
     val mvrs: CloseableIterable<AuditableCard>
 
     init {
-        val auditdir = "$testdataDir/cases/sf2024/oa/audit"
-        val auditRecord = AuditRecord.read(auditdir) as AuditRecord
+        val topdir = "$testdataDir/cases/sf2024/oa"
+        val auditRecord = AuditRecord.read(topdir) as AuditRecord
         val mvrManager = PersistedMvrManager(auditRecord)
         sortedManifest = mvrManager.sortedManifest()
         config = auditRecord.config
@@ -50,7 +50,7 @@ class TestSf2024OneAuditIrv() {
         cardPools = auditRecord.readCardPools()!!
 
         // use the cvrs from the clca as the mvrs
-        val cvrdir = "$testdataDir/cases/sf2024/clca/audit"
+        val cvrdir = "$testdataDir/cases/sf2024/clca"
         val cvrPublisher = Publisher(cvrdir)
         mvrs = readSortedManifest(cvrPublisher, infos, auditRecord.electionInfo.totalCardCount).cards
     }

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfElection.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfElection.kt
@@ -21,8 +21,8 @@ class TestSfElection {
 
     @Test
     fun testRunVerifySFoa() {
-        val auditdir = "$testdataDir/cases/sf2024/oa/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = false)
+        val topdir = "$testdataDir/cases/sf2024/oa"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = false)
         println()
         print(results)
         if (results.hasErrors) fail()
@@ -30,9 +30,9 @@ class TestSfElection {
 
     @Test
     fun testSFoaPopulations() {
-        val auditdir = "$testdataDir/cases/sf2024/oa/audit"
+        val topdir = "$testdataDir/cases/sf2024/oa"
 
-        val auditRecord = AuditRecord.read(auditdir) as AuditRecord
+        val auditRecord = AuditRecord.read(topdir) as AuditRecord
         val mvrManager = PersistedMvrManager(auditRecord, false)
         val cardManifest = mvrManager.sortedManifest()
         val pools = mvrManager.pools()!!
@@ -72,7 +72,7 @@ class TestSfElection {
         }
         assertEquals(count49, contest49.Npop)
 
-        val publisher = Publisher(auditdir)
+        val publisher = Publisher(topdir)
         val sortedMvrs = mvrManager.readCardsAndMerge(publisher.sortedMvrsFile())
         countCards = 0
         count49 = 0
@@ -100,8 +100,8 @@ class TestSfElection {
 
     @Test
     fun testSFmaxBet() {
-        val auditdir = "$testdataDir/cases/sf2024/oa/audit"
-        val publisher = Publisher(auditdir)
+        val topdir = "$testdataDir/cases/sf2024/oa"
+        val publisher = Publisher(topdir)
 
         val contests = readContestsJsonFileUnwrapped(publisher.contestsFile())
         val scontests = contests.sortedBy { it.id  }

--- a/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfElectionVunderFuzz.kt
+++ b/cases/src/test/kotlin/org/cryptobiotic/rlauxe/sf/TestSfElectionVunderFuzz.kt
@@ -19,8 +19,8 @@ import kotlin.test.assertEquals
 import kotlin.use
 
 class TestSfElectionVunderFuzz {
-    val auditdir = "$testdataDir/cases/sf2024/oa/audit"
-    val publisher = Publisher(auditdir)
+    val topdir = "$testdataDir/cases/sf2024/oa"
+    val publisher = Publisher(topdir)
 
     val mvrManager: PersistedMvrManager
     val sortedManifest: SortedManifest
@@ -31,7 +31,7 @@ class TestSfElectionVunderFuzz {
     val cardPools: List<CardPool>?
 
     init {
-        val auditRecord = AuditRecord.read(auditdir) as AuditRecord
+        val auditRecord = AuditRecord.read(topdir) as AuditRecord
         mvrManager = PersistedMvrManager(auditRecord)
         val mvrManager = PersistedMvrManager(auditRecord)
         sortedManifest = mvrManager.sortedManifest()

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRound.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditRound.kt
@@ -6,12 +6,14 @@ import org.cryptobiotic.rlauxe.betting.TestH0Status
 import org.cryptobiotic.rlauxe.betting.makeAprioriErrorRates
 import org.cryptobiotic.rlauxe.core.*
 import org.cryptobiotic.rlauxe.oneaudit.OneAuditClcaAssorter
+import org.cryptobiotic.rlauxe.strata.Strata
 import org.cryptobiotic.rlauxe.util.calcDecilesFromInt
 import org.cryptobiotic.rlauxe.util.df
 
 interface AuditRoundIF {
     val roundIdx: Int
     val contestRounds: List<ContestRound>
+    val countyStrata: List<Strata>? // for uniform audits
 
     var auditWasDone: Boolean
     var auditIsComplete: Boolean
@@ -28,17 +30,18 @@ interface AuditRoundIF {
 
  // Note: mutable
 data class AuditRound(
-    override val roundIdx: Int,
-    override val contestRounds: List<ContestRound>,
+     override val roundIdx: Int,
+     override val contestRounds: List<ContestRound>,
+     override var countyStrata: List<Strata>? = null, // for uniform audits
 
-    override var auditWasDone: Boolean = false,
-    override var auditIsComplete: Boolean = false,
-    override var samplePrns: List<Long>, // card prns to sample for this round (complete, not just new).
+     override var auditWasDone: Boolean = false,
+     override var auditIsComplete: Boolean = false,
+     override var samplePrns: List<Long>, // card prns to sample for this round (complete, not just new).
                                          // duplicates samplePrnsFile, so no need to serialze
-    override var nmvrs: Int = 0,    // mvrs in the round
-    override var newmvrs: Int = 0,  // new mvrs in the round
-    override var mvrsUnused: Int = 0,
-    override var mvrsUsed: Int = 0,
+     override var nmvrs: Int = 0,    // mvrs in the round
+     override var newmvrs: Int = 0,  // new mvrs in the round
+     override var mvrsUnused: Int = 0,
+     override var mvrsUsed: Int = 0,
 ) : AuditRoundIF {
     override var auditorMaxNewMvrs: Int? = null
 
@@ -53,7 +56,7 @@ data class AuditRound(
             val prevContestRound = this.contestRounds.find { it.id == contestRound.id }
             contestRound.createNextRound(prevContestRound)
         }
-        return AuditRound(roundIdx + 1, nextContests, samplePrns = emptyList())
+        return AuditRound(roundIdx + 1, nextContests, countyStrata=this.countyStrata, samplePrns = emptyList())
     }
 }
 
@@ -71,7 +74,6 @@ fun List<AuditRoundIF>.previousSamplePrns(currentRoundIdx: Int): Set<Long> {
 // TODO so what happens if we add new AssertionRound at round > 1 (Dhondt) ?
 data class ContestRound(val contestUA: ContestWithAssertions, val assertionRounds: List<AssertionRound>, val roundIdx: Int) {
     val id = contestUA.id
-
     val name = contestUA.name
     val Npop = contestUA.Npop
 
@@ -132,17 +134,24 @@ data class ContestRound(val contestUA: ContestWithAssertions, val assertionRound
         return assertionRounds.maxOfOrNull { it.auditResult?.pmin ?: 1.0 } ?: 1.0
     }
 
+    override fun toString(): String {
+        return "ContestRound(roundIdx=$roundIdx, id=$id, estMvrs=$estMvrs, estNewMvrs=$estNewMvrs, status=$status)"
+    }
+
     override fun equals(other: Any?): Boolean {
         if (this === other) return true
-        if (javaClass != other?.javaClass) return false
-
-        other as ContestRound
+        if (other !is ContestRound) return false
 
         if (roundIdx != other.roundIdx) return false
-        if (estNewMvrs != other.estNewMvrs) return false
+        if (maxSampleAllowed != other.maxSampleAllowed) return false
         if (estMvrs != other.estMvrs) return false
+        if (estNewMvrs != other.estNewMvrs) return false
         if (done != other.done) return false
         if (included != other.included) return false
+        if (haveSampleSize != other.haveSampleSize) return false
+        if (haveNewSampleSize != other.haveNewSampleSize) return false
+        if (auditorWantNewMvrs != other.auditorWantNewMvrs) return false
+        if (auditorWantRisk != other.auditorWantRisk) return false
         if (contestUA != other.contestUA) return false
         if (assertionRounds != other.assertionRounds) return false
         if (status != other.status) return false
@@ -152,18 +161,19 @@ data class ContestRound(val contestUA: ContestWithAssertions, val assertionRound
 
     override fun hashCode(): Int {
         var result = roundIdx
-        result = 31 * result + estNewMvrs
+        result = 31 * result + (maxSampleAllowed ?: 0)
         result = 31 * result + estMvrs
+        result = 31 * result + estNewMvrs
         result = 31 * result + done.hashCode()
         result = 31 * result + included.hashCode()
+        result = 31 * result + haveSampleSize
+        result = 31 * result + haveNewSampleSize
+        result = 31 * result + (auditorWantNewMvrs ?: 0)
+        result = 31 * result + (auditorWantRisk?.hashCode() ?: 0)
         result = 31 * result + contestUA.hashCode()
         result = 31 * result + assertionRounds.hashCode()
         result = 31 * result + status.hashCode()
         return result
-    }
-
-    override fun toString(): String {
-        return "ContestRound(roundIdx=$roundIdx, id=$id, estMvrs=$estMvrs, estNewMvrs=$estNewMvrs, status=$status)"
     }
 }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCard.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/AuditableCard.kt
@@ -27,6 +27,7 @@ interface AuditableCard: CvrIF, SamplingCardIF {
 interface SamplingCardIF {
     fun hasContest(contestId: Int): Boolean
     fun prn(): Long
+    fun poolName(): String
 }
 
 // mutable style, so we dont need multiple classes
@@ -95,6 +96,7 @@ data class AuditableCard (
 
     // SamplingCardIF
     override fun prn() = prn
+    override fun poolName() = style?.poolName() ?: "unknown"
 
     fun location() = location ?: id()
     fun index() = index

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CardStyle.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CardStyle.kt
@@ -26,6 +26,12 @@ interface StyleIF {
     //   fun votesAndUndervotes(contestId: Int): Vunder
 }
 
+// the pool name is the first token of the style name
+fun StyleIF.poolName(): String {
+    val split = this.name().split("-",".")
+    return split[0]
+}
+
 data class CardStyle(
     val name: String,
     val id: Int,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/Config.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/Config.kt
@@ -14,6 +14,7 @@ data class Config(
     val isClca = auditType == AuditType.CLCA
     val isOA = auditType == AuditType.ONEAUDIT
     val isPolling = auditType == AuditType.POLLING
+    val isUniform = round.sampling.sampling == Sampling.uniform
 
     init {
         require(creation.auditType == election.auditType) {"creation.auditType must equal electionInfo.auditType"}
@@ -40,7 +41,6 @@ data class Config(
     fun replaceSeed(seed: Long): Config {
         return Config(this.election, this.creation.copy(seed = seed), this.round, this.version)
     }
-
 
     override fun toString() = buildString {
         appendLine("Config(")
@@ -235,7 +235,7 @@ data class ContestSampleControl(
     //// checkContestsCorrectlyFormed: preAuditStatus
     val minRecountMargin: Double = 0.005, // do not audit contests less than this recount margin
     val minMargin: Double = 0.0, // do not audit contests less than this margin TODO really it should be noerror for clca?
-    val minSize: Int? = null, // do not audit contests with population less than this
+    val minSize: Int? = null, // do not audit contests with Nc less than this
 
     //// consistentSampling: contestRound.status, depends on having estimation
     val maxSamplePct: Double = 0.0, // do not audit contests with (estimated nmvrs / Npop) greater than this

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CreateAuditRecord.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CreateAuditRecord.kt
@@ -20,9 +20,9 @@ import kotlin.use
 
 private val logger = KotlinLogging.logger("StartAudit")
 
-fun createAuditRecord(config: Config, election: ElectionBuilder, auditDir: String, externalSortDir: String? = null,
+fun createAuditRecord(config: Config, election: ElectionBuilder, topdir: String, externalSortDir: String? = null,
                       validate: Boolean = false, sortManifest: Boolean = true) {
-    val publisher = Publisher(auditDir)
+    val publisher = Publisher(topdir)
 
     writeAuditCreationConfigJsonFile(config.creation, publisher.auditCreationConfigFile())
     logger.info{"writeAuditCreationConfig to ${publisher.auditCreationConfigFile()}\n  ${config.creation}"}
@@ -65,7 +65,7 @@ fun createAuditRecord(config: Config, election: ElectionBuilder, auditDir: Strin
     }
 
     if (validate) {
-        val verifyACResults = VerifyAuditCommitment(auditDir).verify()
+        val verifyACResults = VerifyAuditCommitment(topdir).verify()
         if (verifyACResults.hasErrors) {
             logger.error { "createAuditRecord VerifyAuditCommitment failed: ${verifyACResults}" }
         }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CreateElectionRecord.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/CreateElectionRecord.kt
@@ -40,15 +40,21 @@ interface ElectionBuilder {
 
 private val logger = KotlinLogging.logger("CreateElectionRecord")
 
-fun createElectionRecord(election: ElectionBuilder, auditDir: String, control: ContestSampleControl? = null, clear: Boolean = true, validate: Boolean = false) {
-    if (clear) clearDirectory(Path(auditDir))
+fun createElectionRecord(election: ElectionBuilder, topdir: String, control: ContestSampleControl? = null, clear: Boolean = true, validate: Boolean = false) {
+    if (clear) clearDirectory(Path(topdir))
 
-    val errs = validateOutputDir(Path.of(auditDir))
+    val errs = validateOutputDir(Path.of(topdir))
     if (errs.hasErrors()) {
         logger.error { errs.toString() }
         throw RuntimeException(errs.toString())
     }
-    val publisher = Publisher(auditDir)
+    val errs2 = validateOutputDir(Path.of("$topdir/audit"))
+    if (errs2.hasErrors()) {
+        logger.error { errs2.toString() }
+        throw RuntimeException(errs2.toString())
+    }
+
+    val publisher = Publisher(topdir)
     val electionInfo = election.electionInfo()
     writeElectionInfoJsonFile(electionInfo, publisher.electionInfoFile())
     logger.info{"createElectionRecord writeElectionInfoJsonFile to ${publisher.electionInfoFile()}\n  $electionInfo"}
@@ -88,7 +94,7 @@ fun createElectionRecord(election: ElectionBuilder, auditDir: String, control: C
     val contestsUA = election.contestsUA()
 
     val results = VerifyResults()
-    results.addMessage("---VerifyElection on $auditDir")
+    results.addMessage("---VerifyElection on $topdir")
     preAuditContestCheck(contestsUA, control, results)
 
     // write contests
@@ -97,7 +103,7 @@ fun createElectionRecord(election: ElectionBuilder, auditDir: String, control: C
 
     // taking forever - make optional
     if (validate) {
-        val verifyECResults = VerifyElectionCommitment(auditDir).verify()
+        val verifyECResults = VerifyElectionCommitment(topdir).verify()
         if (verifyECResults.hasErrors) {
             logger.error { "createElectionRecord VerifyElectionCommitment failed: ${verifyECResults}" }
         }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAuditRound.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAuditRound.kt
@@ -33,16 +33,16 @@ fun runRound(inputDir: String, onlyTask: OnlyTask? = null, auditorMaxNewMvrs: In
 }
 
 // run one round and get ready to run the next round; or get ready to run the first round.
-fun runRoundResult(auditDir: String, onlyTask: OnlyTask? = null, auditorMaxNewMvrs: Int? = null): Result<AuditRoundIF, ErrorMessages> {
+fun runRoundResult(topdir: String, onlyTask: OnlyTask? = null, auditorMaxNewMvrs: Int? = null): Result<AuditRoundIF, ErrorMessages> {
     val errs = ErrorMessages("runRoundResult")
 
     try {
-        if (notExists(Path.of(auditDir))) {
-            return errs.add( "audit Directory $auditDir does not exist" )
+        if (notExists(Path.of(topdir))) {
+            return errs.add( "directory $topdir does not exist" )
         }
-        val auditRecord = AuditRecord.read(auditDir)
+        val auditRecord = AuditRecord.read(topdir)
         if (auditRecord == null) {
-            return errs.add("directory '$auditDir' does not contain an audit record")
+            return errs.add("directory '$topdir' does not contain an audit record")
         }
         require(auditRecord is AuditRecord) // TODO
 
@@ -52,7 +52,7 @@ fun runRoundResult(auditDir: String, onlyTask: OnlyTask? = null, auditorMaxNewMv
         var auditWasRun = false
 
         if (workflow.auditRounds().isEmpty()) {
-            return startFirstRound(auditDir, onlyTask, auditorMaxNewMvrs)
+            return startFirstRound(topdir, onlyTask, auditorMaxNewMvrs)
 
         } else {
             // run the audit on the last round, if it wasnt done
@@ -86,7 +86,7 @@ fun runRoundResult(auditDir: String, onlyTask: OnlyTask? = null, auditorMaxNewMv
 
             // get matching mvrs if needed
             if (!nextRound.auditIsComplete && auditRecord.config.election.mvrSource == MvrSource.testPrivateMvrs) {
-                val publisher = Publisher(auditDir)
+                val publisher = auditRecord.publisher
                 val ncards = workflow.writeMvrsForRound(roundIdx)
                 logger.info{"writeMvrsForRound ${ncards} cards to ${publisher.sampleMvrsFile(roundIdx)}"}
             }
@@ -106,29 +106,29 @@ fun runRoundResult(auditDir: String, onlyTask: OnlyTask? = null, auditorMaxNewMv
     }
 }
 
-fun runAllRoundsAndVerify(auditdir: String, maxRounds:Int=7, verify:Boolean = true): Boolean {
+fun runAllRoundsAndVerify(topdir: String, maxRounds:Int=7, verify:Boolean = true): Boolean {
     println("============================================================")
     var done = false
     var lastRound: AuditRoundIF? = null
 
     while (!done) {
-        lastRound = runRound(inputDir = auditdir)
+        lastRound = runRound(inputDir = topdir)
         if (lastRound == null) return false
         done = lastRound.auditIsComplete || lastRound.roundIdx > maxRounds
         GeneralAdaptiveBetting.showCounts("round $lastRound")
     }
 
     if (lastRound != null) {
-        println("nrounds = ${lastRound.roundIdx} nmvrs = ${lastRound.nmvrs} auditdir=$auditdir")
+        println("nrounds = ${lastRound.roundIdx} nmvrs = ${lastRound.nmvrs} topdir=$topdir")
     } else {
-        println("failed in auditdir=$auditdir")
+        println("runAllRoundsAndVerify failed in $topdir")
         return false
     }
 
     println("============================================================")
 
     if (verify) {
-        val verifyRound = VerifyAuditRoundCommitment(auditdir).verify()
+        val verifyRound = VerifyAuditRoundCommitment(topdir).verify()
         if (verifyRound.hasErrors) {
             println()
             print(verifyRound)
@@ -140,8 +140,8 @@ fun runAllRoundsAndVerify(auditdir: String, maxRounds:Int=7, verify:Boolean = tr
 }
 
 // for testing
-fun resampleAndSaveResults(auditdir: String): Boolean {
-    val auditRecord = AuditRecord.read(auditdir)!! as AuditRecord
+fun resampleAndSaveResults(topdir: String): Boolean {
+    val auditRecord = AuditRecord.read(topdir)!! as AuditRecord
     return resampleAndSaveResults(auditRecord, auditRecord.rounds.last())
 }
 
@@ -155,7 +155,7 @@ fun resampleAndSaveResults(auditRecord: AuditRecord, lastRound: AuditRound): Boo
         chooseSamples(auditRecord.config.sampling, lastRound, mvrManager.samplingCards(), previousSamples)
 
         // writeAuditState
-        val publisher = Publisher(auditRecord.location)
+        val publisher = auditRecord.publisher
         writeAuditRoundJsonFile(lastRound, publisher.auditEstFile(lastRound.roundIdx))
         logger.info {"resampleAndRun writeAuditEstimation to ${publisher.auditEstFile(lastRound.roundIdx)}"}
 
@@ -183,7 +183,7 @@ fun saveAuditRound(auditRecord: AuditRecordIF, lastRound: AuditRoundIF): Boolean
     try {
 
         // writeAuditState
-        val publisher = Publisher(auditRecord.location)
+        val publisher = Publisher(auditRecord.topdir)
         writeAuditRoundJsonFile(lastRound, publisher.auditEstFile(lastRound.roundIdx))
         logger.info {"saveAuditRound to ${publisher.auditEstFile(lastRound.roundIdx)}"}
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAuditRoundAgain.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/RunAuditRoundAgain.kt
@@ -25,13 +25,13 @@ import java.nio.file.Path
 private val logger = KotlinLogging.logger("RunAuditRoundAgain")
 
 // for debugging, transparency. rlauxe-viewer
-fun runRoundAgain(auditDir: String, contestRound: ContestRound, assertionRound: AssertionRound): String {
+fun runRoundAgain(topdir: String, contestRound: ContestRound, assertionRound: AssertionRound): String {
     val contestId = contestRound.contestUA.id
     val contestName = contestRound.contestUA.name
     try {
-        if (notExists(Path.of(auditDir))) {
-            logger.warn { "Audit Directory $auditDir does not exist" }
-            return "Audit Directory $auditDir does not exist"
+        if (notExists(Path.of(topdir))) {
+            logger.warn { "Audit Directory $topdir does not exist" }
+            return "Audit Directory $topdir does not exist"
         }
         val roundIdx = assertionRound.roundIdx
         val assertion = assertionRound.assertion
@@ -40,11 +40,11 @@ fun runRoundAgain(auditDir: String, contestRound: ContestRound, assertionRound: 
         val taus = Taus(assertion.assorter.upperBound())
         val oaAssorter: OneAuditClcaAssorter? = if (cassertion?.cassorter is OneAuditClcaAssorter) cassertion.cassorter else null
 
-        val auditRecord = AuditRecord.read(auditDir)
+        val auditRecord = AuditRecord.read(topdir)
         if (auditRecord == null) {
-            return "directory '$auditDir' does not contain an audit record"
+            return "directory '$topdir' does not contain an audit record"
         }
-        logger.info { "runRoundAgain in $auditDir for round $roundIdx, contest '$contestName', and assertion $assertion" }
+        logger.info { "runRoundAgain in $topdir for round $roundIdx, contest '$contestName', and assertion $assertion" }
 
         val useAuditRecord = if (auditRecord is CompositeAuditRecord) {
             auditRecord.findComponentWithName(contestRound.contestUA.name)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/StartFirstRound.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/audit/StartFirstRound.kt
@@ -6,6 +6,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.util.OnlyTask
 import org.cryptobiotic.rlauxe.persist.AuditRecord
 import org.cryptobiotic.rlauxe.persist.Publisher
+import org.cryptobiotic.rlauxe.persist.json.writeContestsJsonFile
 import org.cryptobiotic.rlauxe.util.ErrorMessages
 import org.cryptobiotic.rlauxe.util.Stopwatch
 import org.cryptobiotic.rlauxe.verify.VerifyResults
@@ -17,17 +18,17 @@ import java.nio.file.Path
 
 private val logger = KotlinLogging.logger("StartAudit")
 
-fun startFirstRound(auditDir: String, onlyTask: OnlyTask? = null, auditorMaxNewMvrs: Int? = null): Result<AuditRoundIF, ErrorMessages> {
+fun startFirstRound(topdir: String, onlyTask: OnlyTask? = null, auditorMaxNewMvrs: Int? = null): Result<AuditRoundIF, ErrorMessages> {
     val errs = ErrorMessages("startFirstRound")
 
     try {
-        if (notExists(Path.of(auditDir))) {
-            return errs.add( "audit Directory $auditDir does not exist" )
+        if (notExists(Path.of(topdir))) {
+            return errs.add( "audit Directory $topdir does not exist" )
         }
 
         // delete any roundX subdirectories
-        val auditDirFile = File(auditDir)
-        auditDirFile.walkTopDown()
+        val topdirFile = File(topdir)
+        topdirFile.walkTopDown()
             .filter { it.isDirectory }
             .filter { it.name.startsWith("round") }
             .forEach {
@@ -36,9 +37,9 @@ fun startFirstRound(auditDir: String, onlyTask: OnlyTask? = null, auditorMaxNewM
                 println()
             }
 
-        val auditRecord = AuditRecord.read(auditDir)
+        val auditRecord = AuditRecord.read(topdir)
         if (auditRecord == null) {
-            return errs.add("directory '$auditDir' does not contain an audit record")
+            return errs.add("directory '$topdir' does not contain an audit record")
         }
         require(auditRecord is AuditRecord)
 
@@ -51,6 +52,11 @@ fun startFirstRound(auditDir: String, onlyTask: OnlyTask? = null, auditorMaxNewM
         // this may change the auditStatus to misformed.
         val results = VerifyResults()
         preAuditContestCheck(auditRecord.contests,  config.sampling, results)
+        // in case it changed TODO is this ok ??
+        val publisher = auditRecord.publisher
+        writeContestsJsonFile(auditRecord.contests, publisher.contestsFile())
+        logger.info{"startFirstRound write ${auditRecord.contests.size} contests to ${publisher.contestsFile()}"}
+
         if (results.hasErrors) {
             logger.warn{ results.toString() }
         } else {
@@ -64,7 +70,7 @@ fun startFirstRound(auditDir: String, onlyTask: OnlyTask? = null, auditorMaxNewM
 
         // get matching mvrs if needed
         if (auditRecord.config.mvrSource == MvrSource.testPrivateMvrs) {
-            val publisher = Publisher(auditDir)
+            val publisher = Publisher(topdir)
             val ncards = workflow.writeMvrsForRound(roundIdx)
             logger.info{"writeMvrsForRound ${ncards} cards to ${publisher.sampleMvrsFile(roundIdx)}"}
         }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/betting/Utils.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/betting/Utils.kt
@@ -1,5 +1,7 @@
 package org.cryptobiotic.rlauxe.betting
 
+import org.cryptobiotic.rlauxe.util.noerror
+
 val stdBet = 2.0 / 1.03905
 
 // SmithRamdas eq 33
@@ -65,6 +67,13 @@ fun estSampleSizeStandardBet(Npop: Int, noerror: Double, alpha: Double): Int {
     return estSampleSize(Npop, 2.0 / 1.03905, noerror, alpha)
 }
 
+// for viewer
+fun estSampleSizeStandardBet(voteDiff: Int, Npop: Int, upper: Double, alpha: Double ): Int {
+    val margin = voteDiff / Npop.toDouble()
+    val noerror = noerror(margin, upper)
+    return estSampleSize(Npop, 2.0 / 1.03905, noerror, alpha)
+}
+
 fun estSampleSize(Npop: Int, bet:Double, noerror: Double, alpha: Double): Int {
     val tracker = TrackerImpl()
     val Tneeded = 1.0 / alpha
@@ -82,6 +91,13 @@ fun estSampleSize(Npop: Int, bet:Double, noerror: Double, alpha: Double): Int {
 }
 
 fun estRiskStandardBet(Npop: Int, noerror: Double, nsamples: Int): Double {
+    return estRisk(Npop, 2.0 / 1.03905, noerror, nsamples)
+}
+
+// for viewer
+fun estRiskStandardBet(voteDiff: Int, Npop: Int, upper: Double, nsamples: Int, ): Double {
+    val margin = voteDiff / Npop.toDouble()
+    val noerror = noerror(margin, upper)
     return estRisk(Npop, 2.0 / 1.03905, noerror, nsamples)
 }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaRoundCli.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaRoundCli.kt
@@ -82,9 +82,9 @@ object RunRoundAgainCli {
     @JvmStatic
     fun main(args: Array<String>) {
         val parser = ArgParser("RunAudit")
-        val auditDir by parser.option(
+        val topdir by parser.option(
             ArgType.String,
-            shortName = "auditDir",
+            shortName = "topdir",
             description = "Directory containing input election record"
         ).required()
         val roundIdx by parser.option(
@@ -111,14 +111,14 @@ object RunRoundAgainCli {
         try {
             parser.parse(args)
 
-            val auditRecord = AuditRecord.read(auditDir)
+            val auditRecord = AuditRecord.read(topdir)
             if (auditRecord == null) {
-                println("auditRecord not found at $auditDir")
+                println("auditRecord not found at $topdir")
                 return
             }
             val auditRound = if (roundIdx == -1) auditRecord.rounds.last() else auditRecord.rounds.find { it.roundIdx == roundIdx }
             if (auditRound == null) {
-                println("AuditRound roundIdx $roundIdx not found at $auditDir")
+                println("AuditRound roundIdx $roundIdx not found at $topdir")
                 return
             }
             val contestRound = if (contestName != null) auditRound.contestRounds.find { it.name == contestName }
@@ -140,8 +140,7 @@ object RunRoundAgainCli {
                 return
             }
 
-            // fun runAudit(auditDir: String, contestRound: ContestRound, assertionRound: AssertionRound, auditRoundResult: AuditRoundResult): String {
-            val result = runRoundAgain(auditDir, contestRound, assertionRound)
+            val result = runRoundAgain(topdir, contestRound, assertionRound)
             println(result)
         } catch (t: Throwable) {
             println(t.message)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/cli/RunVerifyContests.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/cli/RunVerifyContests.kt
@@ -43,8 +43,8 @@ object RunVerifyContests {
         }
     }
 
-    fun runVerifyContests(auditDir: String, contestId: Int?, show: Boolean): VerifyResults {
-        val verifier = VerifyContests(auditDir, show)
+    fun runVerifyContests(topdir: String, contestId: Int?, show: Boolean): VerifyResults {
+        val verifier = VerifyContests(topdir, show)
         if (contestId != null) {
             val wantContest = verifier.allContests!!.find { it.id == contestId }
             if (wantContest == null) return VerifyResults("Cant find contest with id $contestId")

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ConsistentSampling.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/ConsistentSampling.kt
@@ -3,8 +3,12 @@ package org.cryptobiotic.rlauxe.estimate
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.audit.*
 import org.cryptobiotic.rlauxe.betting.TestH0Status
+import org.cryptobiotic.rlauxe.core.ContestWithAssertions
+import org.cryptobiotic.rlauxe.strata.Strata
+import org.cryptobiotic.rlauxe.strata.setHaveSampleSize
 import org.cryptobiotic.rlauxe.util.Stopwatch
 import org.cryptobiotic.rlauxe.util.CloseableIterable
+import kotlin.text.drop
 
 private val verifyMaxIndex = false
 private val logger = KotlinLogging.logger("ConsistentSampling")
@@ -113,10 +117,10 @@ fun chooseSamples(
     samplingCards: CloseableIterable<SamplingCardIF>,
     previousSamples: Set<Long> = emptySet(), // all previous prns ever sampled
 ): List<Long> {
-    if (sampling.sampling == Sampling.consistent || (auditRound.roundIdx == 1 && !auditRound.auditWasDone))
-        return consistentSampling(auditRound, samplingCards, previousSamples)
+    return if (sampling.sampling == Sampling.uniform)
+        uniformSampling(auditRound, samplingCards, previousSamples)
     else
-        return uniformSampling(auditRound, samplingCards, previousSamples)
+        consistentSampling(auditRound, samplingCards, previousSamples)
 }
 
 // From Consistent Sampling with Replacement, Ronald Rivest, August 31, 2018
@@ -131,7 +135,7 @@ fun chooseSamples(
 fun consistentSampling(
     auditRound: AuditRoundIF,
     samplingCards: CloseableIterable<SamplingCardIF>,
-    previousSamples: Set<Long> = emptySet(), // all previous prns ever sampled
+    previousSamples: Set<Long> = emptySet(),
 ): List<Long>  // debugging
 {
     val stopwatch = Stopwatch()
@@ -212,27 +216,6 @@ fun consistentSampling(
 
         cardIndex++
     }
-    /*
-    logger.info{"consistent sampling read $cardIndex cards"}
-    val contest19 = contestsIncluded.find { it.id == 19 }!!
-    logger.info { "contest ${contest19.id}:  (have) ${contest19.haveSampleSize} ${(wantSampleSize[contest19.id] ?: 0)} (want) maxSampleAllowed=${contest19.maxSampleAllowed}" }
-    val extract = mutableListOf<AuditableCard>()
-    sampledCards.forEachIndexed { idx, card ->
-        if (card.hasContest(19) && idx < contest19.maxSampleAllowed!!) {
-            extract.add(card)
-        }
-    }
-    println("extract 19 = ${extract.size}")
-    print("")
-    // TODO why would this happen ??
-    val wantMore = contestsIncluded.any { it.haveSampleSize < (wantSampleSize[it.id] ?: 0) }
-    if (wantMore) {
-        contestsIncluded.forEach {
-            if (it.haveSampleSize < (wantSampleSize[it.id] ?: 0))
-                logger.warn { "contest ${it.id}:  (have) ${it.haveSampleSize} < ${(wantSampleSize[it.id] ?: 0)} (want)" }
-        }
-    } */
-    // if (debugConsistent) logger.info{"**consistentSampling haveSampleSize = $haveSampleSize, haveNewSamples = $haveNewSamples, newMvrs=$newMvrs"}
 
     // set the results into the auditRound direclty
     auditRound.nmvrs = sampledPrns.size
@@ -243,17 +226,103 @@ fun consistentSampling(
     return sampledPrns
 }
 
-// we dont have an example of a uniform audit. Corla just using values from colorado-rla.
 fun uniformSampling(
     auditRound: AuditRoundIF,
     samplingCards: CloseableIterable<SamplingCardIF>,
-    previousSamples: Set<Long> = emptySet(), // all previous prns ever sampled
+    previousSamples: Set<Long> = emptySet(), // TODO
+): List<Long>  // debugging
+{
+    val stopwatch = Stopwatch()
+    if (auditRound.countyStrata == null)  return emptyList()
+    val countyStrataWant: Map<String, Strata> = auditRound.countyStrata!!.associateBy { it.strataName }
+    if (countyStrataWant.isEmpty()) return emptyList()
+
+    // included means these are included in the sampling
+    // we still want to estimate risks for not-done contests
+    //val contestsNotDone = auditRound.contestRounds.filter { !it.done }.toMutableList()
+    //val contestsIncluded = auditRound.contestRounds.filter { !it.done && it.included }
+    //if (contestsIncluded.isEmpty()) return emptyList()
+
+    var newMvrs = 0 // count when this card not in previous samples
+    auditRound.contestRounds.forEach {
+        it.haveSampleSize = 0
+        it.haveNewSampleSize = 0
+    }
+
+    val wantFromPools = countyStrataWant.mapValues { it.value.nmvrs }
+    val haveFromPools = mutableMapOf<String, Int>()
+    val sampledPrns = mutableListOf<Long>()
+    var cardIndex = 0  // track maximum index (not done yet)
+
+    var maxNewSamples = auditRound.auditorMaxNewMvrs // TODO test
+    if (maxNewSamples == null || maxNewSamples < 0) maxNewSamples = Int.MAX_VALUE
+    val useAll = auditRound.auditorMaxNewMvrs != null
+    val samplingCardIter = samplingCards.iterator()
+    while (
+        samplingCardIter.hasNext() &&
+        sampledPrns.size < maxNewSamples &&
+        wantFromPools.any { it.value > (haveFromPools[it.key] ?: 0) } // have < want
+    ) {
+        // get the next card in sorted order
+        val card = samplingCardIter.next()
+        val countyName = card.poolName()
+
+        // do we want it ?
+        val haveFromPool = haveFromPools.getOrDefault(countyName, 0)
+        val include = useAll || (haveFromPool < (wantFromPools[countyName] ?: 0))  // have < want
+
+        if (include) {
+            haveFromPools[countyName] = haveFromPool + 1
+            sampledPrns.add(card.prn())
+        }
+        cardIndex++
+
+        // debug
+        if (cardIndex % 5000 == 0) {
+            val need = mutableMapOf<String, Int>()
+            wantFromPools.forEach { (name, want) ->
+                val have = haveFromPools[countyName] ?: 0
+                val still = want - have
+                if (still > 0) need[name] = still
+            }
+            logger.info { " after $cardIndex cards, have ${sampledPrns.size} and still need = $need"}
+        }
+    }
+
+    // set the results into the contestRound
+    val countyStrata = mutableMapOf<String, Strata>()
+    countyStrataWant.forEach { (name, strata) ->
+        val have = haveFromPools[name] ?: 0
+        countyStrata[name] = Strata(name, have, strata.population)
+    }
+    setHaveSampleSize(auditRound.contestRounds.filter { !it.done }, countyStrata, useAll)
+
+    // set the results into the auditRound directly
+    auditRound.nmvrs = sampledPrns.size
+    auditRound.newmvrs = newMvrs
+    auditRound.samplePrns = sampledPrns
+
+    logger.info{" uniformSampling read $cardIndex and chose ${sampledPrns.size} cards; took $stopwatch"}
+    return sampledPrns
+}
+
+fun counties(contestUA: ContestWithAssertions): List<String> {
+    val CORLAcounties = contestUA.contest.info().metadata.get("CORLAcounties")
+    if (CORLAcounties == null) return emptyList()
+    val stripped = CORLAcounties.drop(1).dropLast(1)
+    return stripped.split(",".toRegex()).dropLastWhile { it.isEmpty() }
+}
+
+// we dont have an example of a uniform audit. Corla just using values from colorado-rla.
+fun uniformSamplingOld(
+    auditRound: AuditRoundIF,
+    samplingCards: CloseableIterable<SamplingCardIF>,
+    previousSamples: Set<Long> = emptySet(),
 ): List<Long> {
 
     // ignore included flag, eliminate done
     val contestsIncluded = auditRound.contestRounds.filter { !it.done }
     if (contestsIncluded.isEmpty()) return emptyList()
-
 
     var newMvrs = 0 // count when this card not in previous samples
     auditRound.contestRounds.forEach {
@@ -306,7 +375,8 @@ fun uniformSampling(
     auditRound.newmvrs = newMvrs
     auditRound.samplePrns = sampledPrns
 
-    logger.info{" consistentSampling chose ${sampledPrns.size} cards"}
+    logger.info{" uniformSamplingOld chose ${sampledPrns.size} cards"}
     return sampledPrns
 }
+
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/EstimateAudit.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/EstimateAudit.kt
@@ -46,7 +46,7 @@ private val showWork = false
 //   assertionRound.estimationResult = estimationResult
 
 class EstimateAudit(
-    val auditdir: String,
+    val topdir: String,
     val config: Config,
     val roundIdx: Int,
     val contests: List<ContestRound>,
@@ -71,7 +71,7 @@ class EstimateAudit(
         // each trial is running all the contests in the round (but only the minAssertion)
         val ntrials = if (auditType.isClca()) 1 else config.round.simulation.nsimTrials
         repeat(ntrials) { run ->
-            tasks.add(AuditTrialTask(auditdir, roundIdx, run+1, config, contestsToAudit, pools, styles, sortedManifest))
+            tasks.add(AuditTrialTask(topdir, roundIdx, run+1, config, contestsToAudit, pools, styles, sortedManifest))
         }
         val trialResults: List<List<AssertionTrialIF>> = ConcurrentTaskRunner<List<AssertionTrialIF>>().run(tasks, nthreads)
 
@@ -165,7 +165,7 @@ class EstimateAudit(
 
 // 1 trial, all contests
 class AuditTrialTask(
-    val auditdir: String,
+    val topdir: String,
     val roundIdx: Int,
     val run: Int,
     val config: Config,
@@ -238,7 +238,7 @@ class AuditTrialTask(
         if (keepSimMvrs) {
             // hmm on subsequent rounds, wont you get diffferent simulation on previous cards ?
             // yes but we skip cards already used using prevSamplesUsed ....
-            val publisher = Publisher(auditdir)
+            val publisher = Publisher(topdir)
             writeCardCsvFile(simMvrs , publisher.estMvrsFile(roundIdx, run))
         }
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/OneShotAudit.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/estimate/OneShotAudit.kt
@@ -13,15 +13,15 @@ import kotlin.math.max
 
 // AuditRecord must have privateMvrs; run actual audit to compare to estimation
 class OneShotAudit(
-    val auditdir: String,
+    val topdir: String,
 ) {
-    val record = AuditRecord.read(auditdir) as AuditRecord
+    val record = AuditRecord.read(topdir) as AuditRecord
     val config = record.config
 
     val mvrManager = PersistedMvrManager(record, false)
     val cardManifest = mvrManager.sortedManifest()
     val cardPools = mvrManager.pools()
-    val mvrs = mvrManager.readCardsAndMerge(Publisher(auditdir).sortedMvrsFile())
+    val mvrs = mvrManager.readCardsAndMerge(Publisher(topdir).sortedMvrsFile())
 
     fun run(skipContests: List<Int>? = null, writeFile: String? = null, show: Boolean = false): Int {
 
@@ -39,7 +39,7 @@ class OneShotAudit(
 
         val useSkipContests: List<Int> = skipContests ?: contestStatus.filter { !it.value }.map { it.key }
         val contestsUAs = record.contests.filter { it.id !in useSkipContests }
-        println("OneShotAudit exclude $useSkipContests on $auditdir")
+        println("OneShotAudit exclude $useSkipContests on $topdir")
 
         val assertionAudits = mutableListOf<AssertionTrialIF>()
         contestsUAs.forEach { contestUA ->

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/AuditRecord.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/AuditRecord.kt
@@ -29,7 +29,7 @@ import java.nio.file.Path
 import kotlin.io.path.Path
 
 interface AuditRecordIF {
-    val location: String
+    val topdir: String
     val config: Config
     val contests: List<ContestWithAssertions>
     val rounds: List<AuditRoundIF>
@@ -41,20 +41,18 @@ interface AuditRecordIF {
     fun readOneShotMvrs(): Map<Int, Int>
     fun readCardStyles(): List<StyleIF>?
     fun name(): String
-    fun auditdir() : String
 }
 
 open class AuditRecord(
-    override val location: String,
+    override val topdir: String,
     override val config: Config,
     override val contests: List<ContestWithAssertions>,
     override val rounds: List<AuditRound>,
     val nmvrs: Int // number of mvrs already sampled
 ): AuditRecordIF {
-    val publisher = Publisher(location)
+    val publisher = Publisher(topdir)
     val electionInfo = config.election
 
-    override fun auditdir() = location // it.location.substring(stateRecord.location.length)
     override fun name() = electionInfo.electionName // it.location.substring(stateRecord.location.length)
 
     override fun readSamplingCards(styles: List<StyleIF>?): CloseableIterable<SamplingCardIF>? {
@@ -124,11 +122,11 @@ open class AuditRecord(
     }
 
     fun showName(): String {
-        return "audit $location election ${electionInfo.electionName}"
+        return "audit $topdir election ${electionInfo.electionName}"
     }
 
     override fun toString() = buildString {
-        append("AuditRecord ${name()} location='$location'\n$config")
+        append("AuditRecord ${name()} location='$topdir'\n$config")
         appendLine("contests")
         contests.forEach{ appendLine("  $it")}
         appendLine("rounds")
@@ -139,19 +137,19 @@ open class AuditRecord(
         private val logger = KotlinLogging.logger("AuditRecord")
 
         // checks all types of AuditRecordIF
-        fun checkExists(location: String?): Boolean {
-            if (location == null) return false
-            if (CountyAuditRecord.checkExists(location)) return true
-            if (CountyComposite.checkExists(location)) return true
-            if (CompositeAuditRecord.checkExists(location)) return true
-            if (checkAuditRecordExists(location)) return true
+        fun checkExists(topdir: String?): Boolean {
+            if (topdir == null) return false
+            if (CountyAuditRecord.checkExists(topdir)) return true
+            if (CountyComposite.checkExists(topdir)) return true
+            if (CompositeAuditRecord.checkExists(topdir)) return true
+            if (checkAuditRecordExists(topdir)) return true
             return false
         }
 
         // check for just an AuditRecord
-        fun checkAuditRecordExists(location: String?): Boolean {
-            if (location == null) return false
-            val publisher = Publisher(location)
+        fun checkAuditRecordExists(topdir: String?): Boolean {
+            if (topdir == null) return false
+            val publisher = Publisher(topdir)
             if (!exists(publisher.electionInfoFile())) return false
             if (!exists(publisher.sortedCardsProtoFile()) && !exists(publisher.cardManifestFile())) return false
             if (!exists(publisher.contestsFile())) return false
@@ -159,24 +157,24 @@ open class AuditRecord(
         }
 
         // reads all types of AuditRecordIF
-        fun read(location: String): AuditRecordIF? {
+        fun read(topdir: String): AuditRecordIF? {
 
-            if (CountyAuditRecord.checkExists(location)) {
-                val countyAudit = CountyAuditRecord.readFrom(location)
+            if (CountyAuditRecord.checkExists(topdir)) {
+                val countyAudit = CountyAuditRecord.readFrom(topdir)
                 if (countyAudit != null) return countyAudit
             }
 
-            if (CountyComposite.checkExists(location)) {
-                val countyComposite = CountyComposite.readFrom(location)
+            if (CountyComposite.checkExists(topdir)) {
+                val countyComposite = CountyComposite.readFrom(topdir)
                 if (countyComposite != null) return countyComposite
             }
 
-            if (CompositeAuditRecord.checkExists(location)) {
-                val compositeRecord = CompositeAuditRecord.readFrom(location)
+            if (CompositeAuditRecord.checkExists(topdir)) {
+                val compositeRecord = CompositeAuditRecord.readFrom(topdir)
                 if (compositeRecord != null) return compositeRecord
             }
 
-            val auditRecordResult = readWithResult(location)
+            val auditRecordResult = readWithResult(topdir)
             if (auditRecordResult.isOk) {
                 return auditRecordResult.unwrap()
             } else {
@@ -186,10 +184,10 @@ open class AuditRecord(
         }
 
         // reads an AuditRecord
-        fun readWithResult(location: String): Result<AuditRecord, ErrorMessages> {
-            val errs = ErrorMessages("readAuditRecord from '${location}'")
+        fun readWithResult(topdir: String): Result<AuditRecord, ErrorMessages> {
+            val errs = ErrorMessages("readAuditRecord from '${topdir}'")
 
-            val publisher = Publisher(location)
+            val publisher = Publisher(topdir)
             val electionInfoResult = readElectionInfoJsonFile(publisher.electionInfoFile())
             val electionInfo = if (electionInfoResult.isOk) electionInfoResult.unwrap() else {
                 errs.addNested(electionInfoResult.unwrapError())
@@ -277,7 +275,7 @@ open class AuditRecord(
 
             return if (errs.hasErrors()) Err(errs) else {
                 val config = Config(electionInfo!!, auditCreationConfig!!, roundConfig)
-                Ok(AuditRecord(location, config, contests!!, rounds, countMvrsUsed))
+                Ok(AuditRecord(topdir, config, contests!!, rounds, countMvrsUsed))
             }
         }
     }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CompositeAuditRecord.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CompositeAuditRecord.kt
@@ -10,6 +10,7 @@ import org.cryptobiotic.rlauxe.audit.Config
 import org.cryptobiotic.rlauxe.audit.ContestRound
 import org.cryptobiotic.rlauxe.audit.SamplingCardIF
 import org.cryptobiotic.rlauxe.core.*
+import org.cryptobiotic.rlauxe.strata.Strata
 import org.cryptobiotic.rlauxe.util.CloseableIterable
 import org.cryptobiotic.rlauxe.util.ErrorMessages
 import org.cryptobiotic.rlauxe.util.sfn
@@ -30,7 +31,7 @@ interface CompositeRecordIF: AuditRecordIF {
 
 // used by Belgium. TODO can we make it a subclass of AuditRecord ?? Can we call it BelgiumAudit ?
 data class CompositeAuditRecord(
-    override val location: String,
+    override val topdir: String,
     override val config: Config,
     override val contests: List<ContestWithAssertions>,
     override val rounds: List<AuditRoundIF>,
@@ -39,19 +40,17 @@ data class CompositeAuditRecord(
 
     // used by viewer
     fun readPartyNames(): Map<Int, String> {
-        return readCanonicalPartyTxtFile("$location/$canonicalPartiesFilename")
+        return readCanonicalPartyTxtFile("$topdir/$canonicalPartiesFilename")
     }
 
     fun readSampleLimits(): List<SampleLimit> {
-        return readLimitsTxtFile("$location/$limitsFilename")
+        return readLimitsTxtFile("$topdir/$limitsFilename")
     }
 
     // used ??
     fun readCoalitions(): List<CoalitionList> {
-        return readCoalitionTxtFile("$location/$coalitionFilename")
+        return readCoalitionTxtFile("$topdir/$coalitionFilename")
     }
-
-    override fun auditdir() = "$location/audit"
 
     override fun readSortedManifest(styles: List<StyleIF>?): SortedManifest {
         return componentRecords.first().readSortedManifest(styles)
@@ -86,9 +85,9 @@ data class CompositeAuditRecord(
     }
 
     override fun toString() = buildString {
-        append("CompositeRecord location='$location'\n$config")
+        append("CompositeRecord location='$topdir'\n$config")
         appendLine("components")
-        componentRecords.forEach{ appendLine("  ${it.location}")}
+        componentRecords.forEach{ appendLine("  ${it.topdir}")}
         appendLine("contests")
         contests.forEach{ appendLine("  $it")}
         appendLine("rounds")
@@ -109,8 +108,8 @@ data class CompositeAuditRecord(
                 path.listDirectoryEntries().sorted().forEach { entry ->
                     val filename = entry.fileName.toString()
                     if (entry.isDirectory()  && filename != "private" && !filename.startsWith("round")) {
-                        val auditDir = "${entry.toAbsolutePath()}/audit"
-                        val publisher = Publisher(auditDir)
+                        val topdir = entry.toAbsolutePath().toString()
+                        val publisher = Publisher(topdir)
                         if (exists(publisher.electionInfoFile()) &&
                             // exists(publisher.cardManifestFile()) &&
                             exists(publisher.contestsFile())) return true
@@ -133,9 +132,9 @@ data class CompositeAuditRecord(
                 path.listDirectoryEntries().sorted().forEach { entry ->
                     val filename = entry.fileName.toString()
                     if (entry.isDirectory()  && filename != "private" && !filename.startsWith("round")) {
-                        val auditDir = "${entry.toAbsolutePath()}/audit"
-                        if (Path(auditDir).exists()) {
-                            val result: Result<AuditRecordIF, ErrorMessages> = AuditRecord.readWithResult(auditDir)
+                        val topdir = entry.toAbsolutePath().toString()
+                        if (Path(topdir).exists()) {
+                            val result: Result<AuditRecordIF, ErrorMessages> = AuditRecord.readWithResult(topdir)
                             if (result.isErr) {
                                 logger.warn {"  Error: ${result.component2()}" }
                             } else {
@@ -226,6 +225,7 @@ data class ProxyAuditRound(
     override var mvrsUnused: Int = 0,
 ) : AuditRoundIF {
     override var auditorMaxNewMvrs: Int? = null
+    override val countyStrata: List<Strata>? = null// for uniform audits
 
     init {
         auditWasDone = auditRounds.all { it.auditWasDone }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CountyAuditRecord.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CountyAuditRecord.kt
@@ -5,6 +5,7 @@ import com.github.michaelbull.result.unwrapError
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.cryptobiotic.rlauxe.audit.AuditRound
 import org.cryptobiotic.rlauxe.audit.Config
+import org.cryptobiotic.rlauxe.audit.poolName
 import org.cryptobiotic.rlauxe.core.ContestWithAssertions
 import org.cryptobiotic.rlauxe.persist.csv.readCardsCsvIterator
 import org.cryptobiotic.rlauxe.util.ContestTabulation
@@ -19,16 +20,15 @@ private val logger = KotlinLogging.logger("CountyAuditRecord")
 // CountyAudit assume existence of countyDataFile and countyContestDataFile. does not use nested county directories (yet)
 // Used by Corla
 class CountyAuditRecord(
-        location: String,
-        config: Config,
-        contests: List<ContestWithAssertions>,
-        rounds: List<AuditRound>,
-        nmvrs: Int, // number of mvrs already sampled
-        val countyData: List<CountyData>,
-        val countyContestData: List<CountyContestData>, // used by viewer
-): AuditRecord(location, config, contests, rounds, nmvrs)  {
+    topdir: String,
+    config: Config,
+    contests: List<ContestWithAssertions>,
+    rounds: List<AuditRound>,
+    nmvrs: Int, // number of mvrs already sampled
+    val countyData: List<CountyData>,
+    val countyContestData: List<CountyContestData>, // used by viewer
+): AuditRecord(topdir, config, contests, rounds, nmvrs)  {
 
-    override fun auditdir() = "$location/audit"
     private val styles by lazy { readCardStyles() ?: readCardPools() } // styles are preferred
 
     // for viewer
@@ -43,8 +43,7 @@ class CountyAuditRecord(
         val mvrCardIter = readCardsCsvIterator(mvrs, styles=styles)
         var count = 0
         mvrCardIter.forEach { mvr ->
-            val split = mvr.style()!!.name().split("-",".") // county is the first token of the style name HAHAHAHAH
-            val countyName = split[0]
+            val countyName = mvr.style()!!.poolName()
             val accum = mvrCount.getOrPut(countyName) { 0 }
             mvrCount[countyName] = accum + 1
             count++
@@ -75,11 +74,11 @@ class CountyAuditRecord(
         val countyContestDataFile = "countyContestData.csv"
 
         // check CountyComposite exists
-        fun checkExists(location: String?): Boolean {
-            if (location == null) return false
-            if (!exists("$location/$countyDataFile")) return false
-            if (!exists("$location/$countyContestDataFile")) return false
-            val publisher = Publisher("$location/audit")
+        fun checkExists(topdir: String?): Boolean {
+            if (topdir == null) return false
+            if (!exists("$topdir/$countyDataFile")) return false
+            if (!exists("$topdir/$countyContestDataFile")) return false
+            val publisher = Publisher(topdir)
             return (exists(publisher.electionInfoFile()) &&
                     exists(publisher.auditCreationConfigFile()) &&
                     exists(publisher.auditRoundProtoFile()) &&
@@ -87,17 +86,17 @@ class CountyAuditRecord(
         }
 
         // used by viewer
-        fun readFrom(location: String): CountyAuditRecord? {
-            val auditResult = AuditRecord.readWithResult("$location/audit")
+        fun readFrom(topdir: String): CountyAuditRecord? {
+            val auditResult = AuditRecord.readWithResult(topdir)
             val auditRecord = if (auditResult.isOk) auditResult.unwrap() else {
                 logger.warn { auditResult.unwrapError() }
                 return null
             }
 
-            val countyData = readCountyData("$location/$countyDataFile")
-            val countyContestData = readCountyContestData("$location/$countyContestDataFile")
+            val countyData = readCountyData("$topdir/$countyDataFile")
+            val countyContestData = readCountyContestData("$topdir/$countyContestDataFile")
 
-            return CountyAuditRecord(auditRecord.location, auditRecord.config, auditRecord.contests, auditRecord.rounds,
+            return CountyAuditRecord(auditRecord.topdir, auditRecord.config, auditRecord.contests, auditRecord.rounds,
                 auditRecord.nmvrs, countyData, countyContestData)
         }
     }
@@ -111,7 +110,7 @@ fun readCountyData(filename: String): List<CountyData> {
 
     val countyData = mutableListOf<CountyData>()
     while (true) {
-        var line = reader.readLine()
+        val line = reader.readLine()
         if (line == null) break
 
         val tokens = line.split(",")
@@ -134,7 +133,7 @@ fun readCountyContestData(filename: String): List<CountyContestData> {
 
         val countyData = mutableListOf<CountyContestData>()
         while (true) {
-            var line = reader.readLine()
+            val line = reader.readLine()
             if (line == null) break
 
             val tokens = line.split(",")

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CountyComposite.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/CountyComposite.kt
@@ -14,16 +14,14 @@ import org.cryptobiotic.rlauxe.core.*
 // so may not be needed
 
 class CountyComposite(
-    location: String,
+    topdir: String,
     config: Config,
     contests: List<ContestWithAssertions>,
     rounds: List<AuditRound>,
     nmvrs: Int,
     override val componentRecords: List<AuditRecord>, // optional
     val countyData: List<CountyData>,
-): AuditRecord(location, config, contests, rounds, nmvrs), CompositeRecordIF  {
-
-    override fun auditdir() = "$location/audit"
+): AuditRecord(topdir, config, contests, rounds, nmvrs), CompositeRecordIF  {
 
     override fun findComponentWithName(name: String): AuditRecord? {
         return componentRecords.find {
@@ -32,9 +30,9 @@ class CountyComposite(
     }
 
     override fun toString() = buildString {
-        append("CountyComposite location='$location'\n$config")
+        append("CountyComposite location='${this@CountyComposite.topdir}'\n$config")
         appendLine("components")
-        componentRecords.forEach{ appendLine("  ${it.name()} at ${it.location}")}
+        componentRecords.forEach{ appendLine("  ${it.name()} at ${it.topdir}")}
         appendLine("contests")
         contests.forEach{ appendLine("  $it")}
         appendLine("rounds")
@@ -50,33 +48,33 @@ class CountyComposite(
         val countyDataFile = "countyData.csv"
 
         fun fromStateAndCounties(stateRecord: AuditRecord, countyRecords: List<AuditRecord>, countyData: List<CountyData>): CountyComposite {
-            return CountyComposite(stateRecord.location, stateRecord.config, stateRecord.contests, stateRecord.rounds,
+            return CountyComposite(stateRecord.topdir, stateRecord.config, stateRecord.contests, stateRecord.rounds,
                 stateRecord.nmvrs, countyRecords, countyData)
         }
 
         // check CountyComposite exists
-        fun checkExists(location: String?): Boolean {
-            if (location == null) return false
-            if (!exists("$location/$countyDataFile")) return false
-            val publisher = Publisher("$location/audit")
+        fun checkExists(topdir: String?): Boolean {
+            if (topdir == null) return false
+            if (!exists("$topdir/$countyDataFile")) return false
+            val publisher = Publisher(topdir)
             return (exists(publisher.electionInfoFile()) &&
                 // exists(publisher.cardManifestFile()) &&
                 exists(publisher.contestsFile()))
         }
 
         // used by viewer
-        fun readFrom(location: String): CountyComposite? {
-            val stateLevelResult = AuditRecord.readWithResult("$location/audit")
+        fun readFrom(topdir: String): CountyComposite? {
+            val stateLevelResult = AuditRecord.readWithResult(topdir)
             val stateLevel = if (stateLevelResult.isOk) stateLevelResult.unwrap() else {
                 logger.warn { stateLevelResult.unwrapError() }
                 return null
             }
 
-            val components = if (CompositeAuditRecord.checkExists(location)) {
-                CompositeAuditRecord.readFrom(location)!!.componentRecords
+            val components = if (CompositeAuditRecord.checkExists(topdir)) {
+                CompositeAuditRecord.readFrom(topdir)!!.componentRecords
             } else emptyList()
 
-            val countyData = readCountyData("$location/$countyDataFile")
+            val countyData = readCountyData("$topdir/$countyDataFile")
 
             return fromStateAndCounties(stateLevel, components, countyData)
         }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/Publisher.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/Publisher.kt
@@ -42,67 +42,66 @@ $topdir/
             unsortedMvrs.csv     // AuditableCardCsv (optional)
  */
 
-class Publisher(val auditDir: String) {
-    // fun auditConfigFile() = "$auditDir/auditConfig.json"
-    fun auditCreationConfigFile() = "$auditDir/auditCreationConfig.json"
-    fun auditRoundProtoFile() = "$auditDir/auditRoundConfig.json"
-    // fun auditSeedFile() = "$auditDir/auditSeed.json"
-    fun cardManifestFile() = "$auditDir/cardManifest.csv" // cardManifest
-    fun cardPoolsFile() = "$auditDir/cardPools.csv"
-    fun countyCardPoolsFile() = "$auditDir/countyCardPools.csv"
-    fun countyCvrPoolsFile() = "$auditDir/countyCvrPools.csv"
-    fun cardStylesFile() = "$auditDir/cardStyles.json"
-    fun contestsFile() = "$auditDir/contests.json"
-    fun electionInfoFile() = "$auditDir/electionInfo.json"
-    fun fastSamplingFile() = "$auditDir/fastSampling.bin" //make sampling fast
-    fun sortedCardsFile() = "$auditDir/sortedCards.csv" // sorted cardManifest
-    fun sortedCardsProtoFile() = "$auditDir/sortedCards.proto" // cardManifest
+class Publisher(val topdir: String) {
+    val auditdir = "$topdir/audit"
+    fun auditCreationConfigFile() = "$auditdir/auditCreationConfig.json"
+    fun auditRoundProtoFile() = "$auditdir/auditRoundConfig.json"
+    fun cardManifestFile() = "$auditdir/cardManifest.csv" // cardManifest
+    fun cardPoolsFile() = "$auditdir/cardPools.csv"
+    fun countyCardPoolsFile() = "$auditdir/countyCardPools.csv"
+    fun countyCvrPoolsFile() = "$auditdir/countyCvrPools.csv"
+    fun cardStylesFile() = "$auditdir/cardStyles.json"
+    fun contestsFile() = "$auditdir/contests.json"
+    fun electionInfoFile() = "$auditdir/electionInfo.json"
+    fun fastSamplingFile() = "$auditdir/fastSampling.bin" //make sampling fast
+    fun sortedCardsFile() = "$auditdir/sortedCards.csv" // sorted cardManifest
+    fun sortedCardsProtoFile() = "$auditdir/sortedCards.proto" // cardManifest
 
     // private
-    fun sortedMvrsFile() = "$auditDir/private/sortedMvrs.csv"   // TODO make proto ??
-    fun privateOneshotFile() = "$auditDir/private/oneshot.txt"
-    fun unsortedMvrsFile() = "$auditDir/private/unsortedMvrs.csv"
-    fun unsortedMvrsDirectory() = "$auditDir/private"
+    fun sortedMvrsFile() = "$auditdir/private/sortedMvrs.csv"   // TODO make proto ??
+    fun privateOneshotFile() = "$auditdir/private/oneshot.txt"
+    fun unsortedMvrsFile() = "$auditdir/private/unsortedMvrs.csv"
+    fun unsortedMvrsDirectory() = "$auditdir/private"
 
     fun auditRoundConfigFile(round: Int): String {
-        val dir = "$auditDir/round$round"
+        val dir = "$auditdir/round$round"
         validateOutputDir(Path.of(dir), ErrorMessages("auditStateFile"))
         return "$dir/auditRoundConfig$round.json"
     }
 
     fun auditEstFile(round: Int): String {
-        val dir = "$auditDir/round$round"
+        val dir = "$auditdir/round$round"
         validateOutputDir(Path.of(dir), ErrorMessages("auditStateFile"))
         return "$dir/auditEst$round.json"
     }
 
     fun auditFile(round: Int): String {
-        val dir = "$auditDir/round$round"
+        val dir = "$auditdir/round$round"
         validateOutputDir(Path.of(dir), ErrorMessages("auditStateFile"))
         return "$dir/auditState$round.json"
     }
 
     fun samplePrnsFile(round: Int): String {
-        val dir = "$auditDir/round$round"
+        val dir = "$auditdir/round$round"
         validateOutputDir(Path.of(dir), ErrorMessages("samplePrnsFile"))
         return "$dir/samplePrns$round.json"
     }
 
     fun sampleCardsFile(round: Int): String {
-        val dir = "$auditDir/round$round"
+        val dir = "$auditdir/round$round"
         validateOutputDir(Path.of(dir), ErrorMessages("sampleCards"))
         return "$dir/sampleCards$round.csv"
     }
 
     fun sampleMvrsFile(round: Int): String {
-        val dir = "$auditDir/round$round"
+        val dir = "$auditdir/round$round"
         validateOutputDir(Path.of(dir), ErrorMessages("sampleMvrsFile")) // TODO bad idea ?
         return "$dir/sampleMvrs$round.csv"
     }
 
     // debugging see "keepSimMvrs" flag
     fun estMvrsFile(round: Int, trial: Int): String {
-        val dir = "$auditDir/round$round"
+        val dir = "$auditdir/round$round"
         validateOutputDir(Path.of(dir), ErrorMessages("sampleMvrsFile"))
         return "$dir/estMvrs$trial.csv"
     }
@@ -110,7 +109,7 @@ class Publisher(val auditDir: String) {
     // what round are we on?
     fun currentRound(): Int {
         var roundIdx = 1
-        while (Files.exists(Path.of("$auditDir/round$roundIdx"))) {
+        while (Files.exists(Path.of("$auditdir/round$roundIdx"))) {
             roundIdx++
         }
         return roundIdx - 1

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/bin/FastSamplingCard.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/bin/FastSamplingCard.kt
@@ -3,6 +3,7 @@ package org.cryptobiotic.rlauxe.persist.bin
 import org.cryptobiotic.rlauxe.audit.AuditableCard
 import org.cryptobiotic.rlauxe.audit.SamplingCardIF
 import org.cryptobiotic.rlauxe.audit.StyleIF
+import org.cryptobiotic.rlauxe.audit.poolName
 import org.cryptobiotic.rlauxe.util.CloseableIterator
 import java.io.BufferedInputStream
 import java.io.DataInputStream
@@ -14,6 +15,7 @@ import java.io.OutputStream
 data class FastSamplingCard(val prn : Long, val style: StyleIF) : SamplingCardIF {
     override fun prn() = prn
     override fun hasContest(contestId: Int) = style.hasContest( contestId)
+    override fun poolName() = style.poolName()
 }
 
 class FastSamplingCardIterator(inputFile: String, styles: List<StyleIF>, bufferSize: Int): CloseableIterator<SamplingCardIF> {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AuditRoundJson.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/persist/json/AuditRoundJson.kt
@@ -13,6 +13,7 @@ import org.cryptobiotic.rlauxe.audit.*
 import org.cryptobiotic.rlauxe.betting.ClcaErrorTracker
 import org.cryptobiotic.rlauxe.betting.TestH0Status
 import org.cryptobiotic.rlauxe.core.*
+import org.cryptobiotic.rlauxe.strata.Strata
 import org.cryptobiotic.rlauxe.util.ErrorMessages
 import org.cryptobiotic.rlauxe.util.Welford
 
@@ -38,6 +39,7 @@ import java.nio.file.StandardOpenOption
 data class AuditRoundJson(
     val roundIdx: Int,
     val contestRounds: List<ContestRoundJson>,
+    val countyStrata: List<StrataJson>? = null,
     val auditWasDone: Boolean,
     val auditIsComplete: Boolean,
     val nmvrs: Int,
@@ -51,6 +53,7 @@ fun AuditRoundIF.publishJson() : AuditRoundJson {
     return AuditRoundJson(
         this.roundIdx,
         contestRounds.map { it.publishJson() },
+        this.countyStrata?.map { it.publishJson() },
         this.auditWasDone,
         this.auditIsComplete,
         this.nmvrs,
@@ -70,6 +73,7 @@ fun AuditRoundJson.import(contestUAs: List<ContestWithAssertions>, samplePrns: L
     val auditRound = AuditRound(
         this.roundIdx,
         contestRounds,
+        this.countyStrata?.map { it.import() },
         this.auditWasDone,
         this.auditIsComplete,
         samplePrns,
@@ -81,6 +85,25 @@ fun AuditRoundJson.import(contestUAs: List<ContestWithAssertions>, samplePrns: L
     auditRound.auditorMaxNewMvrs = this.auditorMaxNewMvrs
     return auditRound
 }
+
+@Serializable
+data class StrataJson(
+    val strataName: String,// county name or a multicounty contest
+    val nmvrs: Int,  // may be wantMvrs or haveMvrs
+    val population: Int,
+)
+
+fun Strata.publishJson() = StrataJson(
+    strataName,
+    nmvrs,
+    population
+)
+
+fun StrataJson.import() = Strata(
+    strataName,
+    nmvrs,
+    population
+)
 
 // data class ContestRound(val contestUA: ContestWithAssertions, val assertionRounds: List<AssertionRound>, val roundIdx: Int) {
 //    val id = contestUA.id

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/strata/Strata.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/strata/Strata.kt
@@ -1,0 +1,123 @@
+package org.cryptobiotic.rlauxe.strata
+
+import org.cryptobiotic.rlauxe.audit.ContestRound
+import org.cryptobiotic.rlauxe.betting.estSampleSizeStandardBet
+import org.cryptobiotic.rlauxe.core.ContestWithAssertions
+import org.cryptobiotic.rlauxe.util.roundToClosest
+import kotlin.collections.set
+import kotlin.math.max
+import kotlin.text.drop
+
+// for one county or a multicounty
+data class Strata(
+    val strataName: String,// county name or a multicounty contest
+    val nmvrs: Int,  // may be wantMvrs or haveMvrs
+    val population: Int,
+)
+
+// Neals algorithm: use the minimum rate across strata
+fun computeMulticountyStrata(name: String, counties: Set<String>, countyStrata: Map<String, Strata>): Strata {
+    var orgSamples = 0
+    val minRate = counties.map {
+        val s = countyStrata[it]
+        if (s == null) 1.0 else {
+            orgSamples += s.nmvrs
+            s.nmvrs / s.population.toDouble()
+        }
+    }.min()
+
+    var npop = 0
+    var nmvrs = 0
+    counties.forEach {
+        val strata = countyStrata[it]
+        if (strata != null) {
+            npop += strata.population
+            val truncSamples = roundToClosest(strata.population * minRate)
+            nmvrs += truncSamples
+        }
+    }
+    return Strata(name, nmvrs, npop)
+}
+
+// countyStrata holds the single contest counties haveMvrs
+fun setHaveSampleSize(contestsIncluded: List<ContestRound>, countyStrata: Map<String, Strata>, useAll: Boolean): Map<String, Int> {
+    if (useAll) {
+        contestsIncluded.forEach { contestRound: ContestRound ->
+            val counties = counties(contestRound.contestUA)
+            if (counties != null) {
+                var count = 0
+                counties.forEach {
+                    count += countyStrata[it]?.nmvrs ?: 0
+                }
+                contestRound.haveSampleSize = count
+            }
+        }
+        return countyStrata.mapValues { it.value.nmvrs }
+    }
+    /* first make the county strata
+        val contestMap = contestsIncluded.associateBy { it.name }
+    val strataMap = mutableMapOf<String, Strata>()
+    haveFromPools.mapValues { (countyName, haveMvrs) ->
+        val contest = contestMap[countyName] ?: return@mapValues
+        Strata(countyName, haveMvrs, contestMap[it.key])
+    } */
+
+    val wantFromPools = mutableMapOf<String, Int>()
+    contestsIncluded.forEach { contestRound: ContestRound ->
+        val counties = counties(contestRound.contestUA)
+        if (counties != null) {
+            if (counties.size == 1) {
+                contestRound.haveSampleSize = countyStrata[counties.first()]!!.nmvrs
+            } else {
+                val strata = computeMulticountyStrata(contestRound.name, counties.toSet(), countyStrata)
+                contestRound.haveSampleSize = strata.nmvrs
+            }
+        }
+    }
+    return wantFromPools
+}
+
+////////////////////////////
+
+fun calcCountyStrataWant(contestsIncluded: List<ContestRound>, alpha: Double): List<Strata> {
+    val wantFromPools = calcWantedFromCountyPools(contestsIncluded, alpha)
+
+    val countyStrata = mutableListOf<Strata>()
+    contestsIncluded.forEach { contestRound: ContestRound ->
+        val counties = counties(contestRound.contestUA)
+        if (counties != null && counties.size == 1) {
+            val county = counties.first()
+            val wantFromPool = wantFromPools[county]!!
+            countyStrata.add(Strata( county,wantFromPool, contestRound.contestUA.population()))
+        }
+    }
+    return countyStrata
+}
+
+fun calcWantedFromCountyPools(contestsIncluded: List<ContestRound>, alpha: Double): Map<String, Int> {
+    val wantFromPools = mutableMapOf<String, Int>()
+    contestsIncluded.forEach { contestRound: ContestRound ->
+        val counties = counties(contestRound.contestUA)
+        if (counties != null && counties.size == 1) {
+            val county = counties.first()
+            val wantFromPool = wantFromPools.getOrDefault(county, 0)
+            val risk = contestRound.auditorWantRisk ?: alpha
+            wantFromPools[county] = max(wantFromPool, calcEstMvrs(contestRound.contestUA, risk))
+        }
+    }
+    return wantFromPools
+}
+
+fun counties(contestUA: ContestWithAssertions): List<String>? {
+    val CORLAcounties = contestUA.contest.info().metadata.get("CORLAcounties")
+    if (CORLAcounties == null) return null
+    val stripped = CORLAcounties.drop(1).dropLast(1)
+    return stripped.split(",".toRegex()).dropLastWhile { it.isEmpty() }
+}
+
+fun calcEstMvrs(contestUA: ContestWithAssertions, alpha: Double): Int {
+    val minAssertion = contestUA.minClcaAssertion()
+    if (minAssertion == null) return 0
+    val noerror = minAssertion.noerror // TODO can we use this ??
+    return estSampleSizeStandardBet(contestUA.population(), noerror, alpha)
+}

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/PreAuditContestCheck.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/PreAuditContestCheck.kt
@@ -46,8 +46,8 @@ fun preAuditContestCheck(contestsUA: List<ContestWithAssertions>, control: Conte
                     logger.info { "*** MinMargin contest ${contestUA.id} minMargin ${contestUA.minMargin()} <= ${control.minMargin}" }
                     contestUA.preAuditStatus = TestH0Status.MinMargin
                 }
-                if (contestUA.Npop <= (control.minSize ?: 0) ) {
-                    logger.info { "*** MinSize contest ${contestUA.id} population ${contestUA.Npop} <= ${control.minSize}" }
+                if (contestUA.Nc <= (control.minSize ?: 0) ) {
+                    logger.info { "*** MinSize contest ${contestUA.id} population ${contestUA.Nc} <= ${control.minSize}" }
                     contestUA.preAuditStatus = TestH0Status.MinSize
                 }
             }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyAuditCommitment.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyAuditCommitment.kt
@@ -23,7 +23,7 @@ import org.cryptobiotic.rlauxe.util.ErrorMessages
 import org.cryptobiotic.rlauxe.util.Prng
 import org.cryptobiotic.rlauxe.workflow.PersistedMvrManager
 
-class VerifyAuditCommitment(val location: String, contestId: Int? = null, show: Boolean = false) {
+class VerifyAuditCommitment(val topdir: String, contestId: Int? = null, show: Boolean = false) {
     val audit: AuditCommitment
     val auditType: AuditType
     val contests: List<ContestWithAssertions>
@@ -31,7 +31,7 @@ class VerifyAuditCommitment(val location: String, contestId: Int? = null, show: 
     val batchSet: Set<StyleIF>
 
     init {
-        val result = readAuditCommitment(location)
+        val result = readAuditCommitment(topdir)
         audit = if (result.isOk) result.unwrap() else {
             println(result.unwrapError())
             throw RuntimeException(result.unwrapError().toString())
@@ -46,7 +46,7 @@ class VerifyAuditCommitment(val location: String, contestId: Int? = null, show: 
 
     fun verify(): VerifyResults {
         val results = VerifyResults()
-        results.addMessage("---VerifyElection on $location")
+        results.addMessage("---VerifyElection on $topdir")
         if (contests.size == 1) results.addMessage("  ${contests.first()} ")
 
         verifySortedCardManifest(auditType, contests, audit.sortedManifest, infos, batchSet,
@@ -67,7 +67,7 @@ fun readAuditCommitment(topdir: String): Result<AuditCommitment, ErrorMessages> 
 
     val auditRecord = AuditRecord.read(topdir) as AuditRecord
     val mvrManager = PersistedMvrManager(auditRecord)
-    val publisher = Publisher("$topdir/audit")
+    val publisher = Publisher(topdir)
 
 
     val electionInfo = auditRecord.electionInfo

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyAuditRecord.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyAuditRecord.kt
@@ -11,7 +11,7 @@ import org.cryptobiotic.rlauxe.persist.Publisher
 import org.cryptobiotic.rlauxe.persist.existsOrZip
 import org.cryptobiotic.rlauxe.workflow.PersistedMvrManager
 
-class VerifyAuditRecord(val auditRecordLocation: String) {
+class VerifyAuditRecord(val topdir: String) {
     val auditRecord: AuditRecordIF
     val mvrManager: PersistedMvrManager
     val publisher: Publisher
@@ -20,7 +20,7 @@ class VerifyAuditRecord(val auditRecordLocation: String) {
     val allInfos: Map<Int, ContestInfo>?
 
     init {
-        val auditRecordResult = AuditRecord.readWithResult(auditRecordLocation)
+        val auditRecordResult = AuditRecord.readWithResult(topdir)
         if (auditRecordResult .isOk) {
             auditRecord = auditRecordResult.unwrap()
         } else {
@@ -30,7 +30,7 @@ class VerifyAuditRecord(val auditRecordLocation: String) {
         }
         mvrManager = PersistedMvrManager(auditRecord as AuditRecord, false)
 
-        publisher = Publisher(auditRecordLocation)
+        publisher = Publisher(topdir)
         config = auditRecord.config
         contests = auditRecord.contests
 
@@ -46,7 +46,7 @@ class VerifyAuditRecord(val auditRecordLocation: String) {
 
     fun verify(): VerifyResults {
         val result = VerifyResults()
-        result.addMessage("VerifyAuditRecord on $auditRecordLocation ")
+        result.addMessage("VerifyAuditRecord on $topdir ")
         auditRecord.rounds.forEach { verifyRound(it, result) }
 
         verifyMultipleRoundSampling(result)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyAuditRoundCommitment.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyAuditRoundCommitment.kt
@@ -11,7 +11,7 @@ import org.cryptobiotic.rlauxe.persist.Publisher
 import org.cryptobiotic.rlauxe.persist.existsOrZip
 import org.cryptobiotic.rlauxe.workflow.PersistedMvrManager
 
-class VerifyAuditRoundCommitment(val auditRecordLocation: String) {
+class VerifyAuditRoundCommitment(val topdir: String) {
     val auditRecord: AuditRecordIF
     val mvrManager: PersistedMvrManager
     val publisher: Publisher
@@ -20,7 +20,7 @@ class VerifyAuditRoundCommitment(val auditRecordLocation: String) {
     val allInfos: Map<Int, ContestInfo>?
 
     init {
-        val auditRecordResult = AuditRecord.readWithResult(auditRecordLocation)
+        val auditRecordResult = AuditRecord.readWithResult(topdir)
         if (auditRecordResult .isOk) {
             auditRecord = auditRecordResult.unwrap()
         } else {
@@ -30,7 +30,7 @@ class VerifyAuditRoundCommitment(val auditRecordLocation: String) {
         }
         mvrManager = PersistedMvrManager(auditRecord, false)
 
-        publisher = Publisher(auditRecordLocation)
+        publisher = auditRecord.publisher
         config = auditRecord.config
         contests = auditRecord.contests
 
@@ -46,7 +46,7 @@ class VerifyAuditRoundCommitment(val auditRecordLocation: String) {
 
     fun verify(show: Boolean = false): VerifyResults {
         val result = VerifyResults()
-        result.addMessage("VerifyAuditRoundCommitment on $auditRecordLocation ")
+        result.addMessage("VerifyAuditRoundCommitment on $topdir ")
         auditRecord.rounds.forEach { verifyRound(it, result) }
 
         verifyMultipleRoundSampling(result)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyElectionCommitment.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/verify/VerifyElectionCommitment.kt
@@ -24,8 +24,8 @@ import org.cryptobiotic.rlauxe.workflow.PersistedMvrManager
 import java.nio.file.Files
 import kotlin.io.path.Path
 
-class VerifyElectionCommitment(val location: String) {
-    val publisher = Publisher(location)
+class VerifyElectionCommitment(val topdir: String) {
+    val publisher = Publisher(topdir)
     val election: ElectionCommitment
     val auditType: AuditType
     val contests: List<ContestWithAssertions>
@@ -34,7 +34,7 @@ class VerifyElectionCommitment(val location: String) {
     val cardManifest: CloseableIterable<AuditableCard>
 
     init {
-        val result = readElectionCommitment(location)
+        val result = readElectionCommitment(topdir)
         election = if (result.isOk) result.unwrap() else {
             println(result.unwrapError())
             throw RuntimeException(result.unwrapError().toString())
@@ -50,7 +50,7 @@ class VerifyElectionCommitment(val location: String) {
 
     fun verify(): VerifyResults {
         val results = VerifyResults()
-        results.addMessage("---VerifyElection on $location")
+        results.addMessage("---VerifyElection on $topdir")
         if (contests.size == 1) results.addMessage("  ${contests.first()} ")
 
         val contestSummary = verifyCardManifest(auditType, contests, cardManifest, infos, batchSet, results)
@@ -80,10 +80,10 @@ class VerifyElectionCommitment(val location: String) {
 data class ElectionCommitment(val electionInfo: ElectionInfo, val contests: List<ContestWithAssertions>, val batches: List<StyleIF>?,
                               val pools: List<CardPoolIF>?, val cardManifest: CloseableIterable<AuditableCard> )
 
-fun readElectionCommitment(location: String): Result<ElectionCommitment, ErrorMessages> {
-    val errs = ErrorMessages("readElectionRecord from '${location}'")
+fun readElectionCommitment(topdir: String): Result<ElectionCommitment, ErrorMessages> {
+    val errs = ErrorMessages("readElectionRecord from '${topdir}'")
 
-    val auditRecord = AuditRecord.read(location) as AuditRecord
+    val auditRecord = AuditRecord.read(topdir) as AuditRecord
     val mvrManager = PersistedMvrManager(auditRecord)
 
     val electionInfo = auditRecord.electionInfo

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/AuditWorkflow.kt
@@ -6,6 +6,7 @@ import org.cryptobiotic.rlauxe.core.ContestWithAssertions
 import org.cryptobiotic.rlauxe.estimate.EstimateAudit
 import org.cryptobiotic.rlauxe.util.OnlyTask
 import org.cryptobiotic.rlauxe.estimate.removeContestsAndSample
+import org.cryptobiotic.rlauxe.strata.Strata
 import org.cryptobiotic.rlauxe.util.Stopwatch
 
 // abstract superclass of workflows
@@ -27,7 +28,8 @@ import org.cryptobiotic.rlauxe.util.Stopwatch
             val contestRounds = contestsUA() // these have been filtered to InProgress only
                 .filter{ onlyTask == null || it.id == onlyTask.contestId }
                 .map { ContestRound(it, roundIdx) }
-            AuditRound(roundIdx, contestRounds = contestRounds, samplePrns = emptyList())
+            val countyStrata = if (config.isUniform) emptyList<Strata>() else null
+            AuditRound(roundIdx, contestRounds = contestRounds, countyStrata=countyStrata, samplePrns = emptyList())
         } else {
             // next time, create from previous round
             previousRound.createNextRound()
@@ -42,7 +44,7 @@ import org.cryptobiotic.rlauxe.util.Stopwatch
 
         // estimate how many samples are needed for each contest, to satisfy the risk function,
         val estimate = EstimateAudit(
-            auditdir = mvrManager.auditdir(),
+            topdir = mvrManager.topdir(),
             config,
             auditRound.roundIdx,
             auditRound.contestRounds,

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/CompositeMvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/CompositeMvrManager.kt
@@ -21,7 +21,7 @@ open class CompositeMvrManager(
     val mvrWrite: Boolean = true
 ): MvrManager {
 
-    val publisher = Publisher(auditRecord.componentRecords.first().location)
+    val publisher = Publisher(auditRecord.componentRecords.first().topdir)
 
     override fun styles(): List<StyleIF>? {
         return readBatchesComposite(publisher)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/MvrManager.kt
@@ -21,7 +21,7 @@ interface MvrManager {
 
     fun makeMvrCardPairsForRound(round: Int): List<Pair<CvrIF, AuditableCard>>  // Pair(mvr, cvr)
     fun writeMvrsForRound(round: Int): Int
-    fun auditdir() = "none"
+    fun topdir() = "none"
 
     fun samplingCards(): CloseableIterable<SamplingCardIF> = sortedManifest().cards
 }

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManager.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedMvrManager.kt
@@ -22,7 +22,7 @@ import org.cryptobiotic.rlauxe.verify.verifyMvrCardPairs
 open class PersistedMvrManager(val auditRecord: AuditRecord, val mvrWrite: Boolean = true): MvrManager {
     val config = auditRecord.config
     val contestsUA = auditRecord.contests.filter { it.preAuditStatus == TestH0Status.InProgress } // note: only InProgress
-    val publisher = Publisher(auditRecord.location)
+    val publisher = Publisher(auditRecord.topdir)
 
     val styles by lazy { auditRecord.readCardStyles() ?: auditRecord.readCardPools() } // styles are preferred
     val sortedManifest by lazy { auditRecord.readSortedManifest(styles) }
@@ -45,7 +45,7 @@ open class PersistedMvrManager(val auditRecord: AuditRecord, val mvrWrite: Boole
         return if (cachedCards != null) CloseableIterable { cachedCards!!.iterator() } else sortedManifest().cards
     }
 
-    override fun auditdir() = auditRecord.location
+    override fun topdir() = auditRecord.topdir
 
     override fun sortedManifest() = sortedManifest
     override fun styles() = styles

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedWorkflow.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/workflow/PersistedWorkflow.kt
@@ -18,8 +18,7 @@ class PersistedWorkflow(
     val auditRecord: AuditRecordIF,
     val mvrWrite: Boolean = true, // skip writing when doing RunRoundAgain
 ): AuditWorkflow() {
-    val auditDir = auditRecord.location
-    val publisher = Publisher(auditDir)
+    val publisher = Publisher(auditRecord.topdir)
 
     private val config: Config
     private val auditContests: List<ContestWithAssertions>
@@ -51,32 +50,31 @@ class PersistedWorkflow(
         val nextRound = super.startNewRound(quiet, onlyTask, auditorMaxNewMvrs)
 
         if (nextRound.samplePrns.isEmpty()) {
-            logger.warn {"*** FAILED TO GET ANY SAMPLES (PersistentAudit)"}
-            nextRound.auditIsComplete = true
-        } else {
-            // heres where we limit the number of samples we are willing to audit
-            val riskMeasuringSampleLimit = config.creation.riskMeasuringSampleLimit
-            if (riskMeasuringSampleLimit != null && nextRound.samplePrns.size > riskMeasuringSampleLimit) {
-                nextRound.samplePrns = nextRound.samplePrns.subList(0, riskMeasuringSampleLimit)
-            }
+            logger.warn {"There are no samples chosen for round ${nextRound.roundIdx}"}
+        }
 
-            val auditRoundConfig = config.round
-            writeAuditRoundConfigJsonFile(auditRoundConfig, publisher.auditRoundConfigFile(nextRound.roundIdx))
-            logger.info {"startNewRound writeAuditRoundConfig to ${publisher.auditRoundConfigFile(nextRound.roundIdx)}"}
+        // heres where we limit the number of samples we are willing to audit
+        val riskMeasuringSampleLimit = config.creation.riskMeasuringSampleLimit
+        if (riskMeasuringSampleLimit != null && nextRound.samplePrns.size > riskMeasuringSampleLimit) {
+            nextRound.samplePrns = nextRound.samplePrns.subList(0, riskMeasuringSampleLimit)
+        }
 
-            writeAuditRoundJsonFile(nextRound, publisher.auditEstFile(nextRound.roundIdx))
-            logger.info {"startNewRound writeAuditEstimation to ${publisher.auditEstFile(nextRound.roundIdx)}"}
+        val auditRoundConfig = config.round
+        writeAuditRoundConfigJsonFile(auditRoundConfig, publisher.auditRoundConfigFile(nextRound.roundIdx))
+        logger.info {"startNewRound writeAuditRoundConfig to ${publisher.auditRoundConfigFile(nextRound.roundIdx)}"}
 
-            writeSamplePrnsJsonFile(nextRound.samplePrns, publisher.samplePrnsFile(nextRound.roundIdx))
-            logger.info {"startNewRound ${nextRound.samplePrns.size} samplePrns written to ${publisher.samplePrnsFile(nextRound.roundIdx)}"}
+        writeAuditRoundJsonFile(nextRound, publisher.auditEstFile(nextRound.roundIdx))
+        logger.info {"startNewRound writeAuditEstimation to ${publisher.auditEstFile(nextRound.roundIdx)}"}
 
-            // TODO what if we wrote mvrs as part of startNewRound instead of runAuditRound ??
-            //   in a real audit, need to set the real mvrs externally with EnterMvrsCli, which calls auditRecord.enterMvrs(mvrs)
-            //   in a test audit, the test mvrs are generated from the cardManifest, with optional fuzzing
-            if (mvrManager is PersistedMvrManagerTest) {
-                val sampledMvrs = mvrManager.setMvrsForRoundIdx(nextRound.roundIdx)
-                logger.info {"  added ${sampledMvrs.size} mvrs to mvrManager"}
-            }
+        writeSamplePrnsJsonFile(nextRound.samplePrns, publisher.samplePrnsFile(nextRound.roundIdx))
+        logger.info {"startNewRound ${nextRound.samplePrns.size} samplePrns written to ${publisher.samplePrnsFile(nextRound.roundIdx)}"}
+
+        // TODO what if we wrote mvrs as part of startNewRound instead of runAuditRound ??
+        //   in a real audit, need to set the real mvrs externally with EnterMvrsCli, which calls auditRecord.enterMvrs(mvrs)
+        //   in a test audit, the test mvrs are generated from the cardManifest, with optional fuzzing
+        if (mvrManager is PersistedMvrManagerTest) {
+            val sampledMvrs = mvrManager.setMvrsForRoundIdx(nextRound.roundIdx)
+            logger.info {"  added ${sampledMvrs.size} mvrs to mvrManager"}
         }
 
         return nextRound
@@ -110,7 +108,7 @@ class PersistedWorkflow(
     }
 
     override fun toString(): String {
-        return "PersistentWorkflow(auditDir='$auditDir', mode=$mvrSource, mvrManager=${mvrManager.javaClass.simpleName})"
+        return "PersistentWorkflow(topdir='${auditRecord.topdir}', mode=$mvrSource, mvrManager=${mvrManager.javaClass.simpleName})"
     }
 
     companion object {

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestConfig.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestConfig.kt
@@ -14,7 +14,7 @@ class TestConfig {
   electionInfo=ElectionInfo(electionName=testing, auditType=CLCA, totalCardCount=42, contestCount=1, cvrsContainUndervotes=true, pollingMode=null, mvrSource=testClcaSimulated, other={}), 
   creation=AuditCreationConfig(auditType=CLCA, riskLimit=0.05, seed=-1, riskMeasuringSampleLimit=null, other={}), 
   simulation=SimulationControl(nsimTrials=10, estPercentile=[50, 80], simFuzzPct=null, simulationStrategy=optimistic), 
-  sampling=ContestSampleControl(minRecountMargin=0.005, minMargin=0.0, maxSamplePct=0.0, contestSampleCutoff=2000, auditSampleCutoff=10000, other={}, sampling=consistent))
+  sampling=ContestSampleControl(minRecountMargin=0.005, minMargin=0.0, minSize=null, maxSamplePct=0.0, contestSampleCutoff=2000, auditSampleCutoff=10000, other={}, sampling=consistent))
   clcaConfig=ClcaConfig(strategy=generalAdaptive, fuzzMvrs=null, d=100, maxLoss=0.9624175929935999, apriori=TausRates(rates={})) )
 """
         assertEquals(expected, config.toString())
@@ -28,7 +28,7 @@ class TestConfig {
   electionInfo=ElectionInfo(electionName=testing, auditType=CLCA, totalCardCount=42, contestCount=1, cvrsContainUndervotes=true, pollingMode=null, mvrSource=testClcaSimulated, other={}), 
   creation=AuditCreationConfig(auditType=CLCA, riskLimit=0.1, seed=-1, riskMeasuringSampleLimit=null, other={}), 
   simulation=SimulationControl(nsimTrials=11, estPercentile=[50, 80], simFuzzPct=0.002, simulationStrategy=optimistic), 
-  sampling=ContestSampleControl(minRecountMargin=0.005, minMargin=0.0, maxSamplePct=0.0, contestSampleCutoff=2000, auditSampleCutoff=10000, other={}, sampling=consistent))
+  sampling=ContestSampleControl(minRecountMargin=0.005, minMargin=0.0, minSize=null, maxSamplePct=0.0, contestSampleCutoff=2000, auditSampleCutoff=10000, other={}, sampling=consistent))
   clcaConfig=ClcaConfig(strategy=generalAdaptive, fuzzMvrs=0.001, d=100, maxLoss=0.9624175929935999, apriori=TausRates(rates={})) )
 """
         assertEquals(expected, config.toString())
@@ -43,7 +43,7 @@ class TestConfig {
   electionInfo=ElectionInfo(electionName=testPollingAudit, auditType=POLLING, totalCardCount=4200, contestCount=11, cvrsContainUndervotes=true, pollingMode=withBatches, mvrSource=testPrivateMvrs, other={}), 
   creation=AuditCreationConfig(auditType=POLLING, riskLimit=0.05, seed=-1, riskMeasuringSampleLimit=null, other={}), 
   simulation=SimulationControl(nsimTrials=100, estPercentile=[50, 80], simFuzzPct=0.002, simulationStrategy=optimistic), 
-  sampling=ContestSampleControl(minRecountMargin=0.005, minMargin=0.0, maxSamplePct=0.0, contestSampleCutoff=10000, auditSampleCutoff=10000, other={}, sampling=consistent))
+  sampling=ContestSampleControl(minRecountMargin=0.005, minMargin=0.0, minSize=null, maxSamplePct=0.0, contestSampleCutoff=10000, auditSampleCutoff=10000, other={}, sampling=consistent))
   pollingConfig=PollingConfig(d=100) )
 """
         assertEquals(expected, config.toString())
@@ -72,7 +72,7 @@ class TestConfig {
   electionInfo=ElectionInfo(electionName=testSoftParams, auditType=CLCA, totalCardCount=4200, contestCount=11, cvrsContainUndervotes=true, pollingMode=null, mvrSource=testClcaSimulated, other={}), 
   creation=AuditCreationConfig(auditType=CLCA, riskLimit=0.045, seed=-1, riskMeasuringSampleLimit=1000, other={}), 
   simulation=SimulationControl(nsimTrials=1, estPercentile=[50, 80], simFuzzPct=null, simulationStrategy=optimistic), 
-  sampling=ContestSampleControl(minRecountMargin=0.0, minMargin=0.0, maxSamplePct=0.0, contestSampleCutoff=null, auditSampleCutoff=null, other={}, sampling=consistent))
+  sampling=ContestSampleControl(minRecountMargin=0.0, minMargin=0.0, minSize=null, maxSamplePct=0.0, contestSampleCutoff=null, auditSampleCutoff=null, other={}, sampling=consistent))
   clcaConfig=ClcaConfig(strategy=generalAdaptive, fuzzMvrs=0.0, d=100, maxLoss=0.9624175929935999, apriori=TausRates(rates={win-oth=0.0099})) )
 """
         assertEquals(expected, config.toString())
@@ -87,7 +87,7 @@ class TestConfig {
   electionInfo=ElectionInfo(electionName=testOneAudit, auditType=ONEAUDIT, totalCardCount=4200, contestCount=11, cvrsContainUndervotes=true, pollingMode=null, mvrSource=testPrivateMvrs, other={}), 
   creation=AuditCreationConfig(auditType=ONEAUDIT, riskLimit=0.05, seed=-1, riskMeasuringSampleLimit=null, other={}), 
   simulation=SimulationControl(nsimTrials=101, estPercentile=[50, 80], simFuzzPct=0.0021, simulationStrategy=optimistic), 
-  sampling=ContestSampleControl(minRecountMargin=0.005, minMargin=0.0, maxSamplePct=0.0, contestSampleCutoff=2000, auditSampleCutoff=10000, other={}, sampling=consistent))
+  sampling=ContestSampleControl(minRecountMargin=0.005, minMargin=0.0, minSize=null, maxSamplePct=0.0, contestSampleCutoff=2000, auditSampleCutoff=10000, other={}, sampling=consistent))
   clcaConfig=ClcaConfig(strategy=generalAdaptive, fuzzMvrs=0.0011, d=100, maxLoss=0.9624175929935999, apriori=TausRates(rates={})) )
 """
         assertEquals(expected, config.toString())

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestConfigBuilders.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestConfigBuilders.kt
@@ -40,25 +40,6 @@ class TestConfigBuilders {
         testConfigBuilderRoundtrip(electionInfo, target)
     }
 
-    //        createSfElection(
-    //            auditdir=auditdir,
-    //            AuditType.CLCA,
-    //            zipFilename,
-    //            "ContestManifest.json",
-    //            "CandidateManifest.json",
-    //            cvrExportCsv = cvrExportCsv,
-    //            contestSampleCutoff = 1000,
-    //            auditSampleCutoff = 2000,
-    //        )
-    //        (auditType == AuditType.CLCA) -> AuditConfig(
-    //            AuditType.CLCA, riskLimit = .05, nsimEst=20,
-    //            minRecountMargin=minRecountMargin,
-    //            minMargin=minMargin,
-    //            removeMaxContests = removeMaxContests,
-    //            contestSampleCutoff = contestSampleCutoff, auditSampleCutoff = auditSampleCutoff,
-    //            simFuzzPct=mvrFuzz, persistedWorkflowMode=PersistedWorkflowMode.testPrivateMvrs,
-    //            clcaConfig = ClcaConfig(fuzzMvrs=mvrFuzz)
-    //        )
     @Test
     fun testSfBuilderClca() {
         val electionInfo = ElectionInfo(
@@ -143,13 +124,10 @@ fun testConfigBuilderRoundtrip(electionInfo: ElectionInfo, target: Config) {
 
 fun createBoulderConfigBuilder(
     electionInfo: ElectionInfo, // trouble
-    //auditdir: String,
-    //auditType : AuditType,
     riskLimit: Double = 0.03,
     minRecountMargin: Double = .005,
     minMargin: Double = 0.0,
     maxSamplePct: Double = 0.0,
-    //auditConfigIn: AuditConfig? = null,
     mvrFuzz: Double? = null,
     contestSampleCutoff: Int?,
     auditSampleCutoff: Int?,
@@ -175,10 +153,7 @@ fun createBoulderConfigBuilder(
 }
 
 fun createSfConfigBuilder(
-    //auditdir: String,
     electionInfo: ElectionInfo, // trouble
-    //auditConfigIn: AuditConfig? = null,
-    // poolsHaveOneCardStyle: Boolean = false,
     estPercentile: List<Int>,
     mvrFuzz: Double? = null,
     minRecountMargin: Double = 0.005,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestHasStyles.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/audit/TestHasStyles.kt
@@ -349,8 +349,7 @@ class TestHasStyles {
                 name, auditType, contestsUA, testCards, cardPools = null, batches = batches,
             mvrSource=MvrSource.testPrivateMvrs)
 
-        val auditdir = "$topdir/audit"
-        createElectionRecord(election, auditDir = auditdir)
+        createElectionRecord(election, topdir = topdir)
 
         val creation = AuditCreationConfig(auditType, riskLimit=.05, seed = 123456789L)
         val round = AuditRoundConfig(
@@ -360,11 +359,11 @@ class TestHasStyles {
 
         val config = Config(election.electionInfo(), creation, round)
 
-        createAuditRecord(config, election, auditDir = auditdir)
+        createAuditRecord(config, election, topdir = topdir)
 
-        startFirstRound(auditdir)
+        startFirstRound(topdir)
 
-        return runAllRoundsAndVerify(auditdir)
+        return runAllRoundsAndVerify(topdir)
     }
 }
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/RunCalcClcaAssortAvg.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/RunCalcClcaAssortAvg.kt
@@ -30,7 +30,7 @@ object RunCalcAssortAvg {
     @JvmStatic
     fun main(args: Array<String>) {
         val parser = ArgParser("RunCalcAssortAvg")
-        val auditDir by parser.option(
+        val topdir by parser.option(
             ArgType.String,
             shortName = "in",
             description = "Directory containing input election record"
@@ -49,15 +49,15 @@ object RunCalcAssortAvg {
         try {
             parser.parse(args)
 
-            val auditRecordResult = AuditRecord.readWithResult(auditDir)
+            val auditRecordResult = AuditRecord.readWithResult(topdir)
             val auditRecord = if (auditRecordResult.isOk) auditRecordResult.unwrap() else {
-                println("auditRecord not found at $auditDir")
+                println("auditRecord not found at $topdir")
                 println(auditRecordResult.unwrapError())
                 return
             }
             require(auditRecord is AuditRecord)
             val config = auditRecord.config
-            println("auditRecord in $auditDir isOA=${config.isOA}")
+            println("auditRecord in $topdir isOA=${config.isOA}")
 
             var onlyContest: ContestWithAssertions? = null
             var onlyAssertion: ClcaAssertion? = null
@@ -102,7 +102,7 @@ object RunCalcAssortAvg {
 
             val mvrManager = PersistedMvrManager(auditRecord)
             val cardManifest = mvrManager.sortedManifest()
-            val publisher = Publisher(auditDir)
+            val publisher = Publisher(topdir)
             println("cardManifest has ${cardManifest.ncards} cards")
 
             val usePrivate = (config.mvrSource == MvrSource.testPrivateMvrs)

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestEnterMvrsCli.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestEnterMvrsCli.kt
@@ -9,24 +9,24 @@ class TestEnterMvrsCli {
 
     @Test
     fun testEnterMvrsClca() {
-        val auditDir = "src/test/data/testRunCli/clca/audit"
+        val topdir = "src/test/data/testRunCli/clca"
         EnterMvrsCli.main(
             arrayOf(
-                "-in", auditDir,
-                "-mvrs", "$auditDir/sortedCards.csv"
+                "-in", topdir,
+                "-mvrs", "$topdir/sortedCards.csv"
             )
         )
     }
 
     @Test
     fun testEnterMvrsError1() {
-        val auditDir = "/my/bad/testPersistentWorkflowClca"
+        val topdir = "/my/bad/testPersistentWorkflowClca"
 
         assertFailsWith<RuntimeException> {
             EnterMvrsCli.main(
                 arrayOf(
-                    "-in", auditDir,
-                    "-mvrs", "$auditDir/sortedCards.csv"
+                    "-in", topdir,
+                    "-mvrs", "$topdir/sortedCards.csv"
                 )
             )
         }
@@ -34,12 +34,12 @@ class TestEnterMvrsCli {
 
     @Test
     fun testEnterMvrsError2() {
-        val auditDir = "$testdataDir/persist/testPersistentWorkflowClca"
+        val topdir = "$testdataDir/persist/testPersistentWorkflowClca"
         assertFailsWith<RuntimeException> {
             EnterMvrsCli.main(
                 arrayOf(
-                    "-in", auditDir,
-                    "-mvrs", "$auditDir/noexist.csv"
+                    "-in", topdir,
+                    "-mvrs", "$topdir/noexist.csv"
                 )
             )
         }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunCalcAssortAvg.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunCalcAssortAvg.kt
@@ -7,11 +7,11 @@ class TestRunCalcAssortAvg {
 
     @Test
     fun testRunCalcAssortAvg() {
-        val auditdir = "$testdataDir/cases/boulder24/oa/audit"
+        val topdir = "$testdataDir/cases/boulder24/oa"
 
         RunCalcAssortAvg.main(
             arrayOf(
-                "-in", auditdir,
+                "-in", topdir,
                "-contest", "50", // use name for composite ??
                "-assertion", "1/0"
             )

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunCliInTemp.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunCliInTemp.kt
@@ -15,7 +15,6 @@ class TestRunCliInTemp {
     fun testCliRoundClca() {
         val topPath = createTempDirectory()
         val topdir = topPath.toString()
-        val auditdir = "$topdir/audit"
 
         RunRlaStartFuzz.main(
             arrayOf(
@@ -28,25 +27,25 @@ class TestRunCliInTemp {
         )
 
         println("============================================================")
-        RunVerifyContests.main(arrayOf("-in", auditdir))
+        RunVerifyContests.main(arrayOf("-in", topdir))
 
         println("============================================================")
         RunRlaRoundCli.main(
             arrayOf(
-                "-in", auditdir,
+                "-in", topdir,
             )
         )
 
         var done = false
         while (!done) {
-            val lastRound = runRound(inputDir = auditdir)
+            val lastRound = runRound(inputDir = topdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
         }
 
         println("============================================================")
         val status = RunVerifyAuditRecord.main(
             arrayOf(
-                "-in", auditdir,
+                "-in", topdir,
             )
         )
         println(status)
@@ -57,7 +56,6 @@ class TestRunCliInTemp {
     fun testCliRoundPolling() {
         val topPath = createTempDirectory()
         val topdir = topPath.toString()
-        val auditdir = "$topdir/audit"
 
         RunRlaStartFuzz.main(
             arrayOf(
@@ -71,16 +69,16 @@ class TestRunCliInTemp {
 
         var done = false
         while (!done) {
-            val lastRound = runRound(inputDir = auditdir)
+            val lastRound = runRound(inputDir = topdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 7
         }
 
         println("============================================================")
-        val results = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir=auditdir)
+        val results = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir=topdir)
         println(results)
 
         println("============================================================")
-        val results2 = RunVerifyContests.runVerifyContests(auditdir, null, false)
+        val results2 = RunVerifyContests.runVerifyContests(topdir, null, false)
         println()
         print(results2)
 
@@ -93,7 +91,6 @@ class TestRunCliInTemp {
     fun testCliRoundRaire() {
         val topPath = createTempDirectory()
         val topdir = topPath.toString()
-        val auditdir = "$topdir/audit"
 
         RunRlaStartFuzz.main(
             arrayOf(
@@ -108,17 +105,17 @@ class TestRunCliInTemp {
         )
 
         println("============================================================")
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, false)
+        val results = RunVerifyContests.runVerifyContests(topdir, null, false)
 
         println("============================================================")
         var done = false
         while (!done) {
-            val lastRound = runRound(inputDir = auditdir)
+            val lastRound = runRound(inputDir = topdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
         }
 
         println("============================================================")
-        val results2 = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir=auditdir)
+        val results2 = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir=topdir)
 
         topPath.deleteRecursively()
         if (results.hasErrors) fail()
@@ -129,7 +126,6 @@ class TestRunCliInTemp {
     fun testCliOneAudit() {
         val topPath = createTempDirectory()
         val topdir = topPath.toString()
-        val auditdir = "$topdir/audit"
 
         RunRlaStartFuzz.main(
             arrayOf(
@@ -142,19 +138,19 @@ class TestRunCliInTemp {
         )
 
         println("============================================================")
-        val resultsvc = RunVerifyContests.runVerifyContests(auditdir, null, false)
+        val resultsvc = RunVerifyContests.runVerifyContests(topdir, null, false)
         println()
         print(resultsvc)
 
         println("============================================================")
         var done = false
         while (!done) {
-            val lastRound = runRound(inputDir = auditdir)
+            val lastRound = runRound(inputDir = topdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
         }
 
         println("============================================================")
-        val results = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir = auditdir)
+        val results = RunVerifyAuditRecord.runVerifyAuditRecord(inputDir = topdir)
         println(results)
 
         if (results.hasErrors) fail()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRoundAgainCli.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunRoundAgainCli.kt
@@ -9,11 +9,11 @@ class TestRunRoundAgainCli {
 
     @Test
     fun testRunRoundAgainOneAudit() {
-        val auditdir = "$testdataDir/persist/testRunCli/oneaudit/audit"
+        val topdir = "$testdataDir/persist/testRunCli/oneaudit"
 
         RunRoundAgainCli.main(
             arrayOf(
-                "-auditDir", auditdir,
+                "-topdir", topdir,
                 "-contest", "1",
                 "-round", "1",
                 "-assertion", "first",
@@ -23,11 +23,11 @@ class TestRunRoundAgainCli {
 
     @Test
     fun testRunRoundAgainClca() {
-        val auditdir = "$testdataDir/cases/belgium/belgium2024/Bruxelles/audit"
+        val topdir = "$testdataDir/cases/belgium/belgium2024/Bruxelles"
 
         RunRoundAgainCli.main(
             arrayOf(
-                "-auditDir", auditdir,
+                "-topdir", topdir,
                 "-contest", "2",
                 "-round", "1",
                 "-assertion", "first",
@@ -37,11 +37,11 @@ class TestRunRoundAgainCli {
 
     @Test
     fun testRunRoundAgainPolling() {
-        val auditDir = "$testdataDir/persist/testRunCli/polling/audit"
+        val topdir = "$testdataDir/persist/testRunCli/polling"
 
         RunRoundAgainCli.main(
             arrayOf(
-                "-auditDir", auditDir,
+                "-topdir", topdir,
                 "-contest", "1",
                 "-round", "1",
                 "-assertion", "first",
@@ -51,11 +51,11 @@ class TestRunRoundAgainCli {
 
     @Test
     fun testRunRoundAgainRaire() {
-        val auditDir = "$testdataDir/persist/testRunCli/raire/audit"
+        val topdir = "$testdataDir/persist/testRunCli/raire"
 
         RunRoundAgainCli.main(
             arrayOf(
-                "-auditDir", auditDir,
+                "-topdir", topdir,
                 "-contest", "1",
                 "-round", "1",
                 "-assertion", "first",
@@ -65,11 +65,11 @@ class TestRunRoundAgainCli {
 
     @Test
     fun testRunRoundAgainComposite() {
-        val auditDir = "$testdataDir/cases/belgium/2024"
+        val topdir = "$testdataDir/cases/belgium/2024"
 
         RunRoundAgainCli.main(
             arrayOf(
-                "-auditDir", auditDir,
+                "-topdir", topdir,
                 "-contestName", "Namur",
                 "-round", "1",
                 "-assertion", "first",

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunVerifier.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/cli/TestRunVerifier.kt
@@ -11,13 +11,13 @@ class TestRunVerifyContests {
 
     @Test
     fun testRunVerifyClca() {
-        val auditdir = if (useLocal) "../core/src/test/data/testRunCli/clca/audit"
-            else "$testdataDir/persist/testRunCli/clca/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, 1, show = show)
+        val topdir = if (useLocal) "../core/src/test/data/testRunCli/clca"
+            else "$testdataDir/persist/testRunCli/clca"
+        val results = RunVerifyContests.runVerifyContests(topdir, 1, show = show)
         println()
         print(results)
 
-        val results2 = runVerifyAuditRecord(auditdir)
+        val results2 = runVerifyAuditRecord(topdir)
         println()
         print(results2)
         if (results.hasErrors) fail()
@@ -26,13 +26,13 @@ class TestRunVerifyContests {
 
     @Test
     fun testRunVerifyOA() {
-        val auditdir = if (useLocal) "../core/src/test/data/testRunCli/oneaudit/audit"
-            else "$testdataDir/persist/testRunCli/oneaudit/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = if (useLocal) "../core/src/test/data/testRunCli/oneaudit"
+            else "$testdataDir/persist/testRunCli/oneaudit"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
 
-        val results2 = runVerifyAuditRecord(auditdir)
+        val results2 = runVerifyAuditRecord(topdir)
         println()
         print(results2)
         if (results.hasErrors) fail()
@@ -41,13 +41,13 @@ class TestRunVerifyContests {
 
     @Test
     fun testRunVerifyPolling() {
-        val auditdir = if (useLocal) "../core/src/test/data/testRunCli/polling/audit"
-            else "$testdataDir/persist/testRunCli/polling/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = if (useLocal) "../core/src/test/data/testRunCli/polling"
+            else "$testdataDir/persist/testRunCli/polling"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
 
-        val results2 = runVerifyAuditRecord(auditdir)
+        val results2 = runVerifyAuditRecord(topdir)
         println()
         print(results2)
         if (results.hasErrors) fail()
@@ -56,13 +56,13 @@ class TestRunVerifyContests {
 
     @Test
     fun testRunVerifyRaire() {
-        val auditdir = if (useLocal) "../core/src/test/data/testRunCli/raire/audit"
-            else "$testdataDir/persist/testRunCli/raire/audit"
-        val results = RunVerifyContests.runVerifyContests(auditdir, null, show = show)
+        val topdir = if (useLocal) "../core/src/test/data/testRunCli/raire"
+            else "$testdataDir/persist/testRunCli/raire"
+        val results = RunVerifyContests.runVerifyContests(topdir, null, show = show)
         println()
         print(results)
 
-        val results2 = runVerifyAuditRecord(auditdir)
+        val results2 = runVerifyAuditRecord(topdir)
         println()
         print(results2)
         if (results.hasErrors) fail()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestCorlaEstimate.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/corla/TestCorlaEstimate.kt
@@ -28,8 +28,8 @@ class TestCorlaEstimate {
 
     @Test
     fun testCorlaCalc() {
-        val auditdir = "$testdataDir/cases/corla/uniform/audit"
-        val auditRecord = AuditRecord.read(auditdir)!!
+        val topdir = "$testdataDir/cases/corla/uniform"
+        val auditRecord = AuditRecord.read(topdir)!!
         val sorted = auditRecord.contests.sortedBy { it.Nphantoms }.reversed()
         sorted.forEach { contestUA ->
             val corlaEst = contestUA.contest.info().metadata.get("CORLAsample")
@@ -45,8 +45,7 @@ class TestCorlaEstimate {
 
     @Test
     fun testCountPhantoms() {
-        val auditdir = "$topdir/audit"
-        val auditRecord = AuditRecord.read(auditdir)!!
+        val auditRecord = AuditRecord.read(topdir)!!
         val mvrManager = PersistedMvrManager(auditRecord as AuditRecord)
         countPhantoms(mvrManager.sortedManifest(), 116)
     }

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/dhondt/TestBelgiumContest.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/dhondt/TestBelgiumContest.kt
@@ -23,8 +23,8 @@ class TestBelgiumContest {
     val sortedManifest: SortedManifest
 
     init {
-        val auditdir = "$testdataDir/cases/belgium/belgium2024/Bruxelles/audit"
-        val auditRecord = AuditRecord.read(auditdir) as AuditRecord
+        val topdir = "$testdataDir/cases/belgium/belgium2024/Bruxelles"
+        val auditRecord = AuditRecord.read(topdir) as AuditRecord
         val mvrManager = PersistedMvrManager(auditRecord)
         sortedManifest = mvrManager.sortedManifest()
         config = auditRecord.config

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/dhondt/TestCandidateSeats.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/dhondt/TestCandidateSeats.kt
@@ -9,8 +9,8 @@ import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class TestCandidateSeats {
-    val auditdir = "$testdataDir/cases/belgium/belgium2024/"
-    val auditRecord = AuditRecord.read(auditdir)!! as CompositeAuditRecord
+    val topdir = "$testdataDir/cases/belgium/belgium2024/"
+    val auditRecord = AuditRecord.read(topdir)!! as CompositeAuditRecord
     val contests = auditRecord.contests
     val partyNames = auditRecord.readPartyNames()
     val lastRound = auditRecord.rounds.last()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/dhondt/TestRelaxedAssertionsOld.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/dhondt/TestRelaxedAssertionsOld.kt
@@ -8,8 +8,8 @@ import org.cryptobiotic.rlauxe.testdataDir
 import kotlin.test.Test
 
 class TestRelaxedAssertionsOld {
-    val auditdir = "$testdataDir/cases/belgium/belgium2024/"
-    val auditRecord = AuditRecord.read(auditdir)!!
+    val topdir = "$testdataDir/cases/belgium/belgium2024/"
+    val auditRecord = AuditRecord.read(topdir)!!
     val contests = auditRecord.contests
     val lastRound = auditRecord.rounds.last()
     val config = auditRecord.config

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestConsistentSampling.kt
@@ -129,7 +129,7 @@ class TestConsistentSampling {
             //   useAssertionRound.estNewMvrs = newMvrs
             //   assertionRound.estimationResult = estimationResult
             val estimate = EstimateAudit(
-                mvrManager.auditdir(),
+                mvrManager.topdir(),
                 config,
                 auditRound.roundIdx,
                 auditRound.contestRounds,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestOneShot.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestOneShot.kt
@@ -10,13 +10,13 @@ class TestOneShot {
 
     @Test
     fun testOneShot() {
-        val auditdir = "$testdataDir/cases/corla/consistent/audit"
-        val record = AuditRecord.read(auditdir)
+        val topdir = "$testdataDir/cases/corla/consistent"
+        val record = AuditRecord.read(topdir)
         if (record == null) throw RuntimeException("record is null")
         require (record is AuditRecord)
 
-        val writeOneshot = Publisher(auditdir).privateOneshotFile()
-        val oneshot = OneShotAudit(auditdir)
+        val writeOneshot = Publisher(topdir).privateOneshotFile()
+        val oneshot = OneShotAudit(topdir)
         oneshot.run(null, writeOneshot, show=true)
 
         val oneshotNmvrs = record.readOneShotMvrs()
@@ -25,8 +25,8 @@ class TestOneShot {
 
     // @Test dont use for unit tests TODO WHY NOT?
     fun testEstimatePollingAudit() {
-        val auditdir = "/home/stormy/rla/cases/corla/polling/audit"
-        val record = AuditRecord.read(auditdir)
+        val topdir = "/home/stormy/rla/cases/corla/polling"
+        val record = AuditRecord.read(topdir)
         if (record == null) throw RuntimeException("record is null")
         require (record is AuditRecord)
         val mvrManager = PersistedMvrManager(record)
@@ -34,7 +34,7 @@ class TestOneShot {
         val roundIdx = 4
         val auditRound = record.rounds[roundIdx-1]
         val estaudit = EstimateAudit(
-            auditdir,
+            topdir,
             record.config,
             roundIdx,
             auditRound.contestRounds,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestUniformSampling.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/estimate/TestUniformSampling.kt
@@ -5,6 +5,7 @@ import org.cryptobiotic.rlauxe.betting.TestH0Status
 import org.cryptobiotic.rlauxe.betting.estRiskStandardBet
 import org.cryptobiotic.rlauxe.betting.estSampleSizeStandardBet
 import org.cryptobiotic.rlauxe.core.*
+import org.cryptobiotic.rlauxe.strata.Strata
 import org.cryptobiotic.rlauxe.util.dfn
 import org.cryptobiotic.rlauxe.util.nfn
 import org.cryptobiotic.rlauxe.util.trunc
@@ -30,8 +31,11 @@ class TestUniformSampling {
         val contestRounds = contestsUAs.map{ contest -> ContestRound(contest, 1) }
         // contestRounds.forEach { it.estMvrs = it.Npop / 11 } // random
 
-        val auditRound = AuditRound(1, contestRounds, samplePrns = emptyList())
+        val countyStrata = listOf(Strata("test", 42, 1287))
+        val auditRound = AuditRound(1, contestRounds, countyStrata = countyStrata, samplePrns = emptyList())
         auditRound.auditorMaxNewMvrs = 1111
+
+        // TODO need styles with poolNames, then wantFromPools says how many from each pool
 
         //// main side effects:
         ////    auditRound.nmvrs = sampledCards.size
@@ -107,7 +111,7 @@ class TestUniformSampling {
             //   useAssertionRound.estNewMvrs = newMvrs
             //   assertionRound.estimationResult = estimationResult
             val estimate = EstimateAudit(
-                mvrManager.auditdir(),
+                mvrManager.topdir(),
                 config,
                 auditRound.roundIdx,
                 auditRound.contestRounds,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/irv/TestSf2024OneAuditIrv.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/irv/TestSf2024OneAuditIrv.kt
@@ -29,8 +29,8 @@ class TestSf2024OneAuditIrv() {
     val mvrs = mutableListOf<AuditableCard>()
 
     init {
-        val auditdir = "$testdataDir/cases/sf2024/oa/audit"
-        val auditRecord = AuditRecord.read(auditdir) as AuditRecord
+        val topdir = "$testdataDir/cases/sf2024/oa"
+        val auditRecord = AuditRecord.read(topdir) as AuditRecord
         // cardManifest = auditRecord.readCardManifest()
         config = auditRecord.config
         contests = auditRecord.contests
@@ -39,7 +39,7 @@ class TestSf2024OneAuditIrv() {
         cardPools = auditRecord.readCardPools()!!
 
         // use the cvrs from the clca as the mvrs
-        val cvrdir = "$testdataDir/cases/sf2024/clca/audit"
+        val cvrdir = "$testdataDir/cases/sf2024/clca"
         val cvrPublisher = Publisher(cvrdir)
         cardManifest = readSortedManifest(cvrPublisher, infos, auditRecord.electionInfo.totalCardCount)
         mvrsIterable = cardManifest.cards

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/bin/TestFastSamplingCards.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/bin/TestFastSamplingCards.kt
@@ -17,7 +17,7 @@ class TestFastSamplingCards {
     // @Test
     fun writeSamplingCards() {
         val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
 
         val countyAudit = AuditRecord.read(topdir) as CountyAuditRecord
         val mvrManager = PersistedMvrManager(countyAudit)
@@ -36,7 +36,7 @@ class TestFastSamplingCards {
     @Test
     fun readSamplingCards() {
         val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
 
         val countyAudit = AuditRecord.read(topdir) as CountyAuditRecord
         val mvrManager = PersistedMvrManager(countyAudit)
@@ -57,13 +57,13 @@ class TestFastSamplingCards {
 
     // @Test
     fun testMakeFastCards() {
-        val auditdir = "${testdataDir}/cases/sf2024/oa/audit"
-        val auditRecord = AuditRecord.read(auditdir) as AuditRecord
+        val topdir = "${testdataDir}/cases/sf2024/oa"
+        val auditRecord = AuditRecord.read(topdir) as AuditRecord
         val mvrManager = PersistedMvrManager(auditRecord)
         val styles = mvrManager.styles()!!
 
         val stopwatch = Stopwatch()
-        val publisher = Publisher(auditdir)
+        val publisher = Publisher(topdir)
         val ncards = makeFastCards(publisher, styles)
         println("ncards = $ncards that took $stopwatch= ${stopwatch.elapsed(TimeUnit.MILLISECONDS)/ncards.toDouble()} ms/card")
 

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditRoundJson.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestAuditRoundJson.kt
@@ -11,6 +11,7 @@ import org.cryptobiotic.rlauxe.workflow.makeFuzzedCvrsForClca
 import org.cryptobiotic.rlauxe.persist.AuditRecord
 import org.cryptobiotic.rlauxe.irv.RaireContestWithAssertions
 import org.cryptobiotic.rlauxe.irv.simulateRaireTestContest
+import org.cryptobiotic.rlauxe.strata.Strata
 import org.cryptobiotic.rlauxe.workflow.*
 import kotlin.io.path.createTempFile
 import kotlin.test.Test
@@ -23,8 +24,8 @@ class TestAuditRoundJson {
 
     @Test
     fun testSf24oa() {
-        val auditdir = "/home/stormy/rla/cases/sf2024/oa/audit"
-        val record = AuditRecord.read(auditdir) as AuditRecord
+        val topdir = "/home/stormy/rla/cases/sf2024/oa"
+        val record = AuditRecord.read(topdir) as AuditRecord
         val contestsUAs = record.contests
 
         val scratchFile = createTempFile().toFile()
@@ -73,6 +74,7 @@ class TestAuditRoundJson {
         val target = AuditRound(
             2,
             contestRounds,
+            countyStrata = listOf(Strata("Silt", 42, 348730), Strata("Dawn", 422, 348730)),
             true,
             false,
             samplePrns = listOf(1,2,3),
@@ -103,6 +105,7 @@ class TestAuditRoundJson {
         val target = AuditRound(
             1,
             contestRounds,
+            countyStrata = null,
             false,
             false,
             samplePrns = listOf(1,2,3, 21),
@@ -149,6 +152,7 @@ class TestAuditRoundJson {
         val target = AuditRound(
             1,
             lastRound.contestRounds,
+            null,
             false,
             false,
             samplePrns = lastRound.samplePrns,
@@ -226,6 +230,7 @@ class TestAuditRoundJson {
         val target = AuditRound(
             1,
             nextRound.contestRounds,
+            null,
             false,
             false,
             samplePrns = nextRound.samplePrns,
@@ -273,6 +278,7 @@ class TestAuditRoundJson {
         val target = AuditRound(
             1,
             nextRound.contestRounds,
+            null,
             false,
             false,
             samplePrns = nextRound.samplePrns,

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestReadPopulations.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/json/TestReadPopulations.kt
@@ -15,9 +15,9 @@ class TestReadPopulations {
 
     @Test
     fun testReadPollingBatches() {
-        val auditdir = "$testdataDir/persist/testRunCli/polling/audit"
+        val topdir = "$testdataDir/persist/testRunCli/polling"
 
-        val publisher = Publisher(auditdir)
+        val publisher = Publisher(topdir)
         val pops = readStyles(publisher)!!
         println("read ${pops} batch (original)")
         val pool = pops.first()
@@ -39,10 +39,10 @@ class TestReadPopulations {
 
     @Test
     fun testReadOneAuditPools() {
-        val auditdir = "$testdataDir/persist/testRunCli/oneaudit/audit"
-        // val auditdir = "../core/src/test/data/testRunCli/oneaudit/audit"
+        val topdir = "$testdataDir/persist/testRunCli/oneaudit"
+        // val topdir = "../core/src/test/data/testRunCli/oneaudit"
 
-        val publisher = Publisher(auditdir)
+        val publisher = Publisher(topdir)
         val contests = readContestsJsonFileUnwrapped(publisher.contestsFile())
         val infos = contests.map { it.contest.info() }.associateBy { it.id }
         val cardPools = readCardPools(publisher, infos)!!

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/TestProtoCard.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/persist/protobuf/TestProtoCard.kt
@@ -21,7 +21,7 @@ class TestProtoCard {
     @Test
     fun testProtoAndCsvAgree () {
         val topdir = "$testdataDir/cases/auditcenter/County2024OnlyTeller"
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
         val bufferSize = 100_000
 
         val styles = readCardStylesJsonFile(publisher.cardStylesFile()).unwrap()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistedWorkflow.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistedWorkflow.kt
@@ -17,7 +17,6 @@ class TestPersistedWorkflow {
     fun testPersistedSingleClca() {
         // val topdir = kotlin.io.path.createTempDirectory().toString()
         val topdir = "$testdataDir/persist/persistWorkflow/singleClca"
-        val auditdir = "$topdir/audit"
 
         val N = 50000
         val testData = MultiContestTestData(1, 1, N, marginRange=0.03..0.03, ncands=2)
@@ -30,12 +29,12 @@ class TestPersistedWorkflow {
         val contestsUA = contests.map { ContestWithAssertions(it, isClca = true).addStandardAssertions() }
 
         val election = CreateElectionFromCvrs("testPersistedSingleClca", contestsUA, testMvrs, AuditType.CLCA, mvrSource=MvrSource.testPrivateMvrs)
-        createElectionRecord(election, auditDir = auditdir)
+        createElectionRecord(election, topdir = topdir)
 
         val config = Config.from(election.electionInfo(), nsimTrials = 10, contestSampleCutoff = 1000, simFuzzPct = .01)
 
-        createAuditRecord(config, election, auditDir = auditdir, externalSortDir=topdir, validate = true)
-        startFirstRound(auditdir)
+        createAuditRecord(config, election, topdir = topdir, externalSortDir=topdir, validate = true)
+        startFirstRound(topdir)
 
         runPersistedAudit(topdir)
     }
@@ -44,7 +43,6 @@ class TestPersistedWorkflow {
     fun testPersistedAuditClca() {
         // val topdir = kotlin.io.path.createTempDirectory().toString()
         val topdir = "$testdataDir/persist/persistWorkflow/clca"
-        val auditdir = "$topdir/audit"
 
         val N = 50000
         val testData = MultiContestTestData(11, 4, N, marginRange=0.03..0.05)
@@ -57,11 +55,11 @@ class TestPersistedWorkflow {
         val contestsUA = contests.map { ContestWithAssertions(it, isClca = true).addStandardAssertions() }
 
         val election = CreateElectionFromCvrs("testPersistedAuditClca", contestsUA, testMvrs, AuditType.CLCA, mvrSource=MvrSource.testPrivateMvrs)
-        createElectionRecord(election, auditDir = auditdir)
+        createElectionRecord(election, topdir = topdir)
 
         val config = Config.from(election.electionInfo(), nsimTrials = 10, contestSampleCutoff = 1000, simFuzzPct = .01)
-        createAuditRecord(config, election, auditDir = auditdir, externalSortDir=topdir, validate = true)
-        startFirstRound(auditdir)
+        createAuditRecord(config, election, topdir = topdir, externalSortDir=topdir, validate = true)
+        startFirstRound(topdir)
 
         runPersistedAudit(topdir)
     }
@@ -78,7 +76,6 @@ class TestPersistedWorkflow {
     fun testPersistedOneAudit() {
         // val topdir = kotlin.io.path.createTempDirectory().toString()
         val topdir = "$testdataDir/persist/persistWorkflow/oneaudit"
-        val auditdir = "$topdir/audit"
 
         val N = 5000
         // Synthetic cvrs for testing reflecting the exact contest votes, already has undervotes and phantoms.
@@ -94,12 +91,12 @@ class TestPersistedWorkflow {
 
         val election = CreateElectionFromCvrs("testPersistedOneAudit", contestsUA, mvrs, AuditType.ONEAUDIT,
             cardPools = cardPools, mvrSource=MvrSource.testPrivateMvrs)
-        createElectionRecord(election, auditDir = auditdir)
+        createElectionRecord(election, topdir = topdir)
 
         val config = Config.from(election.electionInfo(), nsimTrials = 10, contestSampleCutoff = 20000, simFuzzPct = .01)
 
-        createAuditRecord(config, election, auditDir = auditdir, externalSortDir=topdir, validate = true)
-        startFirstRound(auditdir)
+        createAuditRecord(config, election, topdir = topdir, externalSortDir=topdir, validate = true)
+        startFirstRound(topdir)
 
         runPersistedAudit(topdir, maxRounds=10)
     }
@@ -116,7 +113,6 @@ class TestPersistedWorkflow {
         val cvrPercent = .50
 
         val topdir = "$testdataDir/persist/persistWorkflow/oneauditProblem2"
-        val auditdir = "$topdir/audit"
 
         val electionInfo = ElectionInfo.forTest(AuditType.ONEAUDIT, MvrSource.testPrivateMvrs)
         val creation = AuditCreationConfig(AuditType.ONEAUDIT, riskLimit=.05,)
@@ -139,19 +135,17 @@ class TestPersistedWorkflow {
 
         val election = CreateElectionFromCvrs("testPersistedOneAudit", contestsUA, mvrs, AuditType.ONEAUDIT,
             cardPools = pools, mvrSource=MvrSource.testPrivateMvrs)
-        createElectionRecord(election, auditDir = auditdir)
+        createElectionRecord(election, topdir = topdir)
 
-        createAuditRecord(config, election, auditDir = auditdir, externalSortDir=topdir, validate=true)
-        startFirstRound(auditdir)
+        createAuditRecord(config, election, topdir = topdir, externalSortDir=topdir, validate=true)
+        startFirstRound(topdir)
 
         runPersistedAudit(topdir, maxRounds=10)
     }
 }
 
 fun runPersistedAudit(topdir: String, maxRounds:Int = 6) {
-    val auditdir = "$topdir/audit"
-
-    val verifyResults = RunVerifyContests.runVerifyContests(auditdir, null, show = true)
+    val verifyResults = RunVerifyContests.runVerifyContests(topdir, null, show = true)
     println()
     print(verifyResults)
     if (verifyResults.hasErrors) println("*** VERIFY FAILED") // fail() TODO
@@ -161,11 +155,11 @@ fun runPersistedAudit(topdir: String, maxRounds:Int = 6) {
     var lastRound: AuditRoundIF? = null
 
     while (!done) {
-        lastRound = runRound(inputDir = auditdir)
+        lastRound = runRound(inputDir = topdir)
         if (lastRound == null) fail()
 
         /* TODO!! ??
-        val enterResult = enterMvrs(auditdir, publisher.sortedCardsFile())
+        val enterResult = enterMvrs(topdir, publisher.sortedCardsFile())
         if (enterResult is Err) {
             println("enterMvrs failed ${enterResult.error}")
             fail()

--- a/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistentConsistentSampling.kt
+++ b/core/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/TestPersistentConsistentSampling.kt
@@ -9,10 +9,10 @@ class TestPersistentConsistentSampling {
 
     @Test   //  TODO what the hell are we testing ??
     fun testPersistentConsistentSampling() {
-        val auditDir = "../core/src/test/data/testRunCli/polling/audit"
-        val auditRecord = AuditRecord.read(auditDir)
+        val topdir = "../core/src/test/data/testRunCli/polling"
+        val auditRecord = AuditRecord.read(topdir)
         if (auditRecord == null) {
-            println("auditRecord not found at $auditDir")
+            println("auditRecord not found at $topdir")
             return
         }
         require(auditRecord is AuditRecord)

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaStartFuzz.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/cli/RunRlaStartFuzz.kt
@@ -123,8 +123,6 @@ fun startTestElectionClca(
     addRaire: Boolean,
     addRaireCandidates: Int,
 ) {
-    val auditdir = "$topdir/audit"
-
     val election = TestClcaElection(
         minMargin,
         pctPhantoms,
@@ -133,13 +131,13 @@ fun startTestElectionClca(
         addRaire,
         addRaireCandidates)
 
-    createElectionRecord(election, auditDir = auditdir)
+    createElectionRecord(election, topdir = topdir)
 
     val config = Config.from( election.electionInfo(), nsimTrials = 100, simFuzzPct = simFuzz, fuzzMvrs=fuzzMvrs)
 
-    createAuditRecord(config, election, auditDir = auditdir)
+    createAuditRecord(config, election, topdir = topdir)
 
-    val result = startFirstRound(auditdir)
+    val result = startFirstRound(topdir)
     if (result.isErr) error{ result.toString() }
 }
 
@@ -226,28 +224,28 @@ fun startTestElectionPolling(
     ncontests: Int = 11,
     pollingMode: PollingMode,
 ) {
-    val auditdir = "$topdir/audit"
+    val topdir = "$topdir"
 
     val election = TestPollingElection(
-        auditdir,
+        topdir,
         minMargin,
         pctPhantoms,
         ncards,
         ncontests,
         pollingMode
     )
-    createElectionRecord(election, auditDir = auditdir, )
+    createElectionRecord(election, topdir = topdir, )
 
     val config = Config.from(election.electionInfo(), nsimTrials = 20, simFuzzPct = simFuzz)
 
-    createAuditRecord(config, election, auditDir = auditdir)
+    createAuditRecord(config, election, topdir = topdir)
 
-    val result = startFirstRound(auditdir)
+    val result = startFirstRound(topdir)
     if (result.isErr) logger.error{ result.toString() }
 }
 
 class TestPollingElection(
-    val auditdir: String,
+    val topdir: String,
     minMargin: Double,
     pctPhantoms: Double?,
     ncards: Int,
@@ -320,10 +318,10 @@ fun startTestElectionOneAudit(
     cvrFraction: Double,
     extraPct: Double,
 ) {
-    val auditDir = "$topdir/audit"
+    val topdir = "$topdir"
 
     val election = TestOneAuditElection(
-        auditDir,
+        topdir,
         minMargin,
         cvrFraction = cvrFraction,
         ncards,
@@ -331,19 +329,19 @@ fun startTestElectionOneAudit(
         extraPct=extraPct,
         fuzzMvrs=fuzzMvrs,
     )
-    createElectionRecord(election, auditDir = auditDir, clear = true)
+    createElectionRecord(election, topdir = topdir, clear = true)
 
     val config = Config.from(election.electionInfo(), nsimTrials = 20, simFuzzPct = simFuzz,
         fuzzMvrs=fuzzMvrs)
 
-    createAuditRecord(config, election, auditDir = auditDir)
+    createAuditRecord(config, election, topdir = topdir)
 
-    val result = startFirstRound(auditDir)
+    val result = startFirstRound(topdir)
     if (result.isErr) error{ result.toString() }
 }
 
 class TestOneAuditElection(
-    val auditDir: String,
+    val topdir: String,
     minMargin: Double,
     cvrFraction: Double,
     ncards: Int,

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/timing/TestRunRoundCli.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/timing/TestRunRoundCli.kt
@@ -17,11 +17,10 @@ class TestRunRoundCli {
     @Test
     fun testRunRoundCli() {
         val topdir = "$cases/corla/withCvrs/Colorado2020"
-        val auditdir = "${topdir}/audit"
 
         RunRlaRoundCli.main(
             arrayOf(
-                "-in", auditdir,
+                "-in", topdir,
                 // "--auditorMaxNewMvrs", "105",
                 // "--onlyTask", "17-1/0",
             )
@@ -30,11 +29,11 @@ class TestRunRoundCli {
 
     @Test
     fun testRunAllRoundsCli() {
-        val auditdir = "${testdataDir}/cases/corla/polling/audit"
+        val topdir = "${testdataDir}/cases/corla/polling"
 
         /* RunRlaRoundCli.main(
             arrayOf(
-                "-in", auditdir,
+                "-in", topdir,
                 // "--onlyTask", "28-NEN 107/102",
             )
         ) */
@@ -44,7 +43,7 @@ class TestRunRoundCli {
         var done = false
         var finalRound: AuditRoundIF? = null
         while (!done) {
-            val lastRound = runRound(inputDir = auditdir)
+            val lastRound = runRound(inputDir = topdir)
             if (lastRound != null) finalRound = lastRound
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5 || lastRound.roundIdx == stopRound
         }
@@ -54,11 +53,11 @@ class TestRunRoundCli {
 
     @Test
     fun testStartAuditFirstRound() {
-        val auditdir = "/home/stormy/datadrive/rla/cases/corla/Colorado2020all"
+        val topdir = "/home/stormy/datadrive/rla/cases/corla/Colorado2020all"
 
         StartAuditFirstRoundCli.main(
             arrayOf(
-                "-in", auditdir,
+                "-in", topdir,
                 // "--onlyTask", "14-37/35",
             )
         )
@@ -66,14 +65,14 @@ class TestRunRoundCli {
 
     @Test
     fun testResampleAndSaveResults() {
-        val auditdir = "${cases}/corla/withCvrs/Colorado2020"
-        resampleAndSaveResults(auditdir)
+        val topdir = "${cases}/corla/withCvrs/Colorado2020"
+        resampleAndSaveResults(topdir)
     }
 
     @Test
     fun testRemoveAndResample() {
-        val auditdir = "${testdataDir}/cases/boulder24/oa/audit"
-        val auditRecord = AuditRecord.read(auditdir)!!
+        val topdir = "${testdataDir}/cases/boulder24/oa"
+        val auditRecord = AuditRecord.read(topdir)!!
         val lastRound = auditRecord.rounds.last()
         val removeContests = listOf(16,17)
         removeContests.forEach {

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/timing/TestWriteFiles.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/timing/TestWriteFiles.kt
@@ -16,7 +16,7 @@ class TestWriteFiles {
     @Test
     fun writeProtoFile () {
         val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
         val cardIter: CloseableIterator<AuditableCard> = readCardsCsvIterator(publisher.sortedCardsFile(), styles=null)
 
         val stopwatch = Stopwatch()

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/timing/TimeCardReading.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/timing/TimeCardReading.kt
@@ -43,7 +43,7 @@ class TimeCardReading {
         val stopwatch = Stopwatch()
         var totalRead = 0L
 
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
         val file = File(publisher.sortedCardsFile())
         val inputStream = file.inputStream()
         val fileLength = file.length()
@@ -68,7 +68,7 @@ class TimeCardReading {
         val stopwatch = Stopwatch()
         var ncards = 0
 
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
 
         val bufferSize = 8096 // 100_000
         val cardIter = CardCsvReader(publisher.sortedCardsFile(), null).iterator()
@@ -94,7 +94,7 @@ class TimeCardReading {
         val topdir = "${testdataDir}/cases/corla/consistent"
         val auditRecord = AuditRecord.read(topdir) as AuditRecord
         val mvrManager = PersistedMvrManager(auditRecord)
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
         val styles = mvrManager.styles()
 
         var accum = 0
@@ -133,7 +133,7 @@ class TimeCardReading {
         val topdir = "${testdataDir}/cases/corla/consistent"
         val auditRecord = AuditRecord.read(topdir) as AuditRecord
         val mvrManager = PersistedMvrManager(auditRecord)
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
         val styles = mvrManager.styles()
 
         val stopwatch = Stopwatch()
@@ -164,7 +164,7 @@ class TimeCardReading {
         val topdir = "${testdataDir}/cases/corla/consistent"
         val auditRecord = AuditRecord.read(topdir) as AuditRecord
         val mvrManager = PersistedMvrManager(auditRecord)
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
         val styles = mvrManager.styles()
 
         val bufferSize = 100_000
@@ -210,7 +210,7 @@ class TimeCardReading {
     @Test
     fun timeReadProto () {
         val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
         val protoFilename = publisher.sortedCardsProtoFile()
         val styles = readCardStylesJsonFile(publisher.cardStylesFile()).unwrap()
 
@@ -250,7 +250,7 @@ class TimeCardReading {
     @Test
     fun timeReadProtoIterable () {
         val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
         val protoFilename = publisher.sortedCardsProtoFile()
         val styles = readCardStylesJsonFile(publisher.cardStylesFile()).unwrap()
 
@@ -296,7 +296,7 @@ class TimeCardReading {
     @Test
     fun timeReadProtoNonGeneric () {
         val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
         val protoFilename = publisher.sortedCardsProtoFile()
         val styles = readCardStylesJsonFile(publisher.cardStylesFile()).unwrap()
 
@@ -331,7 +331,7 @@ class TimeCardReading {
     @Test
     fun timeFastSampling() {
         val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
 
         val countyAudit = AuditRecord.read(topdir) as CountyAuditRecord
         val mvrManager = PersistedMvrManager(countyAudit)

--- a/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/timing/TimeFastSamplingCards.kt
+++ b/core/src/testFixtures/kotlin/org/cryptobiotic/rlauxe/timing/TimeFastSamplingCards.kt
@@ -20,7 +20,7 @@ class TimeFastSamplingCards {
     @Test
     fun timeConsistentSampling() {
         val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
 
         val countyAudit = AuditRecord.read(topdir) as CountyAuditRecord
         val mvrManager = PersistedMvrManager(countyAudit)
@@ -35,7 +35,7 @@ class TimeFastSamplingCards {
     @Test
     fun timeConsistentSamplingCached() {
         val topdir = "${testdataDir}/cases/corla/consistent"
-        val publisher = Publisher("$topdir/audit")
+        val publisher = Publisher("$topdir")
 
         val countyAudit = AuditRecord.read(topdir) as CountyAuditRecord
         val mvrManager = PersistedMvrManager(countyAudit)

--- a/docs/notes/Corla2020corrected.md
+++ b/docs/notes/Corla2020corrected.md
@@ -1,0 +1,26 @@
+
+## targets only
+
+style nmvrs = 6006
+uniform nmvrs = 8245
+contests under maxRisk (style) = 452 / 651 = 69%
+contests under maxRisk (uniform) = 489 / 651 = 75%
+
+|               |  style  |  uniform |
+|---------------|---------|----------|
+| under maxRisk |   452   |    489   |
+| under      4% |   415   |    364   |
+| under      5% |   417   |    366   |
+| under     10% |   431   |    381   |
+
+style nmvrs = 29272
+uniform nmvrs = 8245
+contests under maxRisk (style) = 432 / 526 = 82%
+contests under maxRisk (uniform) = 364 / 526 = 69%
+
+|               |  style  |  uniform |
+|---------------|---------|----------|
+| under maxRisk |   432   |    364   |
+| under      4% |   432   |    364   |
+| under      5% |   432   |    366   |
+| under     10% |   437   |    381   |

--- a/docs/notes/Corla2020notes.md
+++ b/docs/notes/Corla2020notes.md
@@ -1,8 +1,9 @@
 # Corla2020 Notes
-6/23/26
+6/24/26
 
-I can read in most of the cvr data from https://votedatabase.com for the Colorado 2020 General elections. 
-Much of the work is matching the contest and candidate names from the cvr export file to what's in auditcenter.
+We obtained the cvr data from https://votedatabase.com for the Colorado 2020 General elections, and used it to run
+a real audit. This is for testing purposes only: the data is not official, some of the data is missing, in particular
+the redacted data is largely unaccounted for.
 
 ## votedatabase
 
@@ -47,70 +48,38 @@ See [Vote Differences](Corla2020cvrDiff.md) for details.
 
 ## Uniform vs Style Based Sampling
 
-These differ in which contests are chosen for the audit and how many are selected, which affects how the risk is measured for all contests.
+The Colorado 2020 General Election audit used a risk limit of 4%.
+
+Here are several scenarios that differ in which contests are chosen for the style-based audit. The uniform sample is what was actually done and does not vary.
 
 ### only targeted contests
- 
-````
-  style nmvrs = 4514
+
+style nmvrs = 4144
 uniform nmvrs = 8245
-contests under maxRisk (style) = 230 / 526 = 43%
-contests under maxRisk (uniform) = 460 / 526 = 87%
+contests under maxRisk (style) = 245 / 526 = 46%
+contests under maxRisk (uniform) = 364 / 526 = 69%
 
 |               |  style  |  uniform |
 |---------------|---------|----------|
-| under maxRisk |   230   |    460   |
-| under      3% |   230   |    460   |
-| under      5% |   239   |    478   |
-| under     10% |   261   |    485   |
-````
+| under maxRisk |   245   |    364   |
+| under      4% |   245   |    364   |
+| under      5% |   249   |    366   |
+| under     10% |   266   |    381   |
 
 ### targeted contests and other contests with estMvrs <= max
 
-````
-(max = 100)
-  style nmvrs = 8761
-uniform nmvrs = 8245
-contests under maxRisk (style) = 477 / 526 = 90%
-contests under maxRisk (uniform) = 460 / 526 = 87%
+max = 115
+rlauxe nmvrs = 8246
+corla nmvrs = 8245
+contests under maxRisk (style) = 481 / 526 = 91%
+contests under maxRisk (uniform) = 364 / 526 = 69%
 
 |               |  style  |  uniform |
 |---------------|---------|----------|
-| under maxRisk |   477   |    460   |
-| under      3% |   477   |    460   |
-| under      5% |   478   |    478   |
-| under     10% |   479   |    485   |
-````
-
-````
-(max = 90)
-  style nmvrs = 8302
-uniform nmvrs = 8245
-contests under maxRisk (style) = 468 / 526 = 88%
-contests under maxRisk (uniform) = 460 / 526 = 87%
-
-|               |  style  |  uniform |
-|---------------|---------|----------|
-| under maxRisk |   468   |    460   |
-| under      3% |   468   |    460   |
-| under      5% |   469   |    478   |
-| under     10% |   471   |    485   |
-````
-
-````
-(max=80)
-  style nmvrs = 8096
-uniform nmvrs = 8245
-contests under maxRisk (style) = 465 / 526 = 88%
-contests under maxRisk (uniform) = 460 / 526 = 87%
-
-|               |  style  |  uniform |
-|---------------|---------|----------|
-| under maxRisk |   465   |    460   |
-| under      3% |   465   |    460   |
-| under      5% |   466   |    478   |
-| under     10% |   468   |    485   |
-````
+| under maxRisk |   481   |    364   |
+| under      4% |   481   |    364   |
+| under      5% |   481   |    366   |
+| under     10% |   482   |    381   |
 
 ### targeted contests plus relaxed risks
 
@@ -122,19 +91,31 @@ Experiment with relaxing the risk limits:
 * if estMvrs in [50, 150), use 5% risk kimit
 * if estMvrs < 50, use 3% risk limit
 
-````
-  style nmvrs = 13074
-uniform nmvrs = 8245
-contests under maxRisk (style) = 518 / 526 = 98%
-contests under maxRisk (uniform) = 469 / 526 = 89%
+  style nmvrs = 13010
+  uniform nmvrs = 8245
+  contests under maxRisk (style) = 519 / 526 = 98%
+  contests under maxRisk (uniform) = 364 / 526 = 69%
 
 |               |  style  |  uniform |
 |---------------|---------|----------|
-| under maxRisk |   518   |    469   |
-| under      3% |   438   |    460   |
-| under      5% |   490   |    478   |
-| under     10% |   518   |    485   |
-````
+| under maxRisk |   519   |    364   |
+| under      4% |   450   |    364   |
+| under      5% |   491   |    366   |
+| under     10% |   519   |    381   |
+
+## all contests
+
+style nmvrs = 19978
+uniform nmvrs = 8245
+contests under maxRisk (style) = 526 / 526 = 100%
+contests under maxRisk (uniform) = 364 / 526 = 69%
+
+|               |  style  |  uniform |
+|---------------|---------|----------|
+| under maxRisk |   526   |    364   |
+| under      4% |   526   |    364   |
+| under      5% |   526   |    366   |
+| under     10% |   526   |    381   |
 
 ## TODO DONE
 
@@ -147,13 +128,14 @@ contests under maxRisk (uniform) = 469 / 526 = 89%
 * add Boulder redacted ballots back in (by simulation). DONE
 * compare votedatabase and auditcenter votes DONE
 * compare uniform and style sampling DONE
+* look for problems and bugs in uniform vs style comparison DONE
+* in separate election, generate synthetic cvrs for all counties in 2020 and compare to real ones DONE
+* improve algorithm for generating synthetic cvrs DONE
+* generate 2024 general election with synthetic cvrs DONE
 
 ## TODO
 
-* look for problems and bugs in uniform vs style comparison
-* in separate election, generate synthetic cvrs for all counties in 2020 and compare to real ones
-* improve algorithm for generating synthetic cvrs
-* generate 2024 general election with synthetic cvrs
+* show plot of incremental cost of adding the low margin contests: what do the lowest n contests cost ?
 
 ## Appendix A Votes differences between auditcenter and votedatabase
 

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/CardManifestAttack.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/attack/CardManifestAttack.kt
@@ -242,14 +242,14 @@ class CardManifestAttack {
         //// create a peristent audit
         val election = CreateElectionForAttack(listOf(contestUA), mcards, mvrs, cardPools, null)
 
-        val auditdir = "$topdir/audit"
+        val topdir = "$topdir"
         val config = Config.from(election.electionInfo(), nsimTrials = 10, contestSampleCutoff = 20000)
 
-        createAuditRecord(config, election, auditDir = auditdir, externalSortDir=topdir)
-        startFirstRound(auditdir)
+        createAuditRecord(config, election, topdir = topdir, externalSortDir=topdir)
+        startFirstRound(topdir)
 
         println("============================================================")
-        val resultsvc = RunVerifyContests.runVerifyContests(auditdir, null, true)
+        val resultsvc = RunVerifyContests.runVerifyContests(topdir, null, true)
         println()
         print(resultsvc)
         if (resultsvc.hasErrors) println("*** Verify fails") else println("*** Verify success")
@@ -257,7 +257,7 @@ class CardManifestAttack {
         println("============================================================")
         var done = false
         while (!done) {
-            val lastRound = runRound(inputDir = auditdir)
+            val lastRound = runRound(inputDir = topdir)
             done = lastRound == null || lastRound.auditIsComplete || lastRound.roundIdx > 5
         }
     }

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cases/CaseStudiesVarianceScatter.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/cases/CaseStudiesVarianceScatter.kt
@@ -28,7 +28,7 @@ class CaseStudiesVarianceScatter {
         caseStudiesVariancePlots(
             name,
             dirName,
-            "$testdataDir/cases/boulder24/clca/audit",
+            "$testdataDir/cases/boulder24/clca",
             "$testdataDir/cases/boulder24oa2/",
             null,
             false
@@ -44,7 +44,7 @@ class CaseStudiesVarianceScatter {
         caseStudiesVariancePlots(
             name,
             dirName,
-            "$testdataDir/cases/sf2024/clca/audit",
+            "$testdataDir/cases/sf2024/clca",
             "$testdataDir/cases/sf2024oa",
             "$testdataDir/cases/sf2024oasp",
             true
@@ -68,8 +68,8 @@ class CaseStudiesVarianceScatter {
         val totalOA = mutableListOf<Int>()
         val oneshotOA = mutableListOf<Int>()
         repeat(nruns) { run ->
-            val auditdir = "$oaAuditDir/audit${run+1}"
-            val pair = readAuditRecord(auditdir, "OneAudit")
+            val topdir = "$oaAuditDir${run+1}"
+            val pair = readAuditRecord(topdir, "OneAudit")
             println("OneAudit ${run+1} has ${clcaAssertionMap.size} assertions")
             if (pair != null) {
                 val (totalMvrs, allAssertions) = pair
@@ -82,14 +82,14 @@ class CaseStudiesVarianceScatter {
                 catPoints.addAll(cats)
                 readResults.add(allAssertions)
             }
-            // oneshotOA.add(OneShotAudit(auditdir).run(skip, writeFile=Publisher(auditdir).privateOneshotFile())) // TODO embed OneShotAudit into generation for speed of plotting
+            // oneshotOA.add(OneShotAudit(topdir).run(skip, writeFile=Publisher(topdir).privateOneshotFile())) // TODO embed OneShotAudit into generation for speed of plotting
         }
 
         val totalSP = mutableListOf<Int>()
         val oneshotSP = mutableListOf<Int>()
         repeat(nruns) { run ->
-            val auditdir = "$spAuditDir/audit${run+1}"
-            val pair = readAuditRecord(auditdir, "PrecinctStyleOA")
+            val topdir = "$spAuditDir${run+1}"
+            val pair = readAuditRecord(topdir, "PrecinctStyleOA")
             println("PrecinctStyleOA ${run+1} has ${clcaAssertionMap.size} assertions")
             if (pair != null) {
                 val (totalMvrs, allAssertions) = pair
@@ -102,7 +102,7 @@ class CaseStudiesVarianceScatter {
                 catPoints.addAll(cats)
                 readResults.add(allAssertions)
             }
-            // oneshotSP.add(OneShotAudit(auditdir).run(skip, writeFile=Publisher(auditdir).privateOneshotFile()))
+            // oneshotSP.add(OneShotAudit(topdir).run(skip, writeFile=Publisher(topdir).privateOneshotFile()))
         }
 
         println("$name in $dirName :")
@@ -214,8 +214,8 @@ fun List<Int>.stddev(): Double {
 
 data class CatPoint(val cat: String, val samplesUsed: Int, val margin: Double)
 
-fun readAuditRecord(auditDir: String, cat: String, marginOverride:Map<Int, Double>? = null): Pair<Int, Map<String, CatPoint>>? {
-    val auditRecordResult = AuditRecord.readWithResult(auditDir)
+fun readAuditRecord(topdir: String, cat: String, marginOverride:Map<Int, Double>? = null): Pair<Int, Map<String, CatPoint>>? {
+    val auditRecordResult = AuditRecord.readWithResult(topdir)
     if (auditRecordResult.isErr) {
         println(auditRecordResult)
         return null
@@ -238,6 +238,6 @@ fun readAuditRecord(auditDir: String, cat: String, marginOverride:Map<Int, Doubl
             }
         }
     }
-    println("read $auditDir totalMvrs=$totalMvrs")
+    println("read $topdir totalMvrs=$totalMvrs")
     return Pair(totalMvrs, allAssertions)
 }

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SFoaSingleRoundAuditTaskGenerator.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SFoaSingleRoundAuditTaskGenerator.kt
@@ -18,7 +18,7 @@ interface WorkflowResultListTaskGenerator {
 
 class SFoaSingleRoundAuditTaskGenerator(
     val run: Int,
-    val auditDir: String,
+    val topdir: String,
     val mvrsFuzzPct: Double = 0.0,
     val parameters : Map<String, Any>,
     val auditConfigIn: Config? = null,
@@ -30,7 +30,7 @@ class SFoaSingleRoundAuditTaskGenerator(
 
         return SfoaSingleRoundAuditTask(
             run,
-            auditDir,
+            topdir,
             parameters,
             quiet = false,
         )
@@ -39,7 +39,7 @@ class SFoaSingleRoundAuditTaskGenerator(
 
 class SfoaSingleRoundAuditTask(
     val run: Int,
-    val auditDir: String,
+    val topdir: String,
     val otherParameters: Map<String, Any>,
     val quiet: Boolean,
 ) : ConcurrentTask<List<WorkflowResult>> {
@@ -50,7 +50,7 @@ class SfoaSingleRoundAuditTask(
         println("SfoaSingleRoundAuditTask start ${name()}")
         val wresults = mutableListOf<WorkflowResult>()
 
-        val rlauxAudit = PersistedWorkflow.readFrom(auditDir)!!
+        val rlauxAudit = PersistedWorkflow.readFrom(topdir)!!
         val mvrManager = rlauxAudit.mvrManager()
         val batches = mvrManager.styles()
 
@@ -59,7 +59,7 @@ class SfoaSingleRoundAuditTask(
                 val assertionRound = AssertionRound(cassertion, 1, null)
                 val contestRound = ContestRound(contestUA, listOf(assertionRound), 1)
 
-                val skipper = AuditableCardCsvReaderSkip("$auditDir/sortedCards.csv", skipPerRun * run, batches)
+                val skipper = AuditableCardCsvReaderSkip("$topdir/sortedCards.csv", skipPerRun * run, batches)
                 val manifestWithSkipper = SortedManifest(skipper, 0)
 
                 val sampler =

--- a/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SfSingleRoundAuditTaskGenerator.kt
+++ b/plots/src/test/kotlin/org/cryptobiotic/rlauxe/workflow/SfSingleRoundAuditTaskGenerator.kt
@@ -17,7 +17,7 @@ import org.cryptobiotic.rlauxe.util.Closer
 // only used by SfAuditVariance
 class SfSingleRoundAuditTaskGenerator(
     val run: Int,
-    val auditDir: String,
+    val topdir: String,
     val mvrsFuzzPct: Double = 0.0,
     val parameters : Map<String, Any>,
     val auditConfigIn: Config? = null,
@@ -29,7 +29,7 @@ class SfSingleRoundAuditTaskGenerator(
 
         return SfSingleRoundAuditTask(
             run,
-            auditDir,
+            topdir,
             parameters,
             quiet = false,
         )
@@ -41,7 +41,7 @@ class SfSingleRoundAuditTaskGenerator(
 // 1. original probably didnt use diluted margin
 class SfSingleRoundAuditTask(
     val run: Int,
-    val auditDir: String,
+    val topdir: String,
     val otherParameters: Map<String, Any>,
     val quiet: Boolean,
 ) : ConcurrentTask<List<WorkflowResult>> {
@@ -52,7 +52,7 @@ class SfSingleRoundAuditTask(
         println("SfSingleRoundAuditTask start ${name()}")
         val wresults = mutableListOf<WorkflowResult>()
 
-        val rlauxAudit = PersistedWorkflow.readFrom(auditDir)!!
+        val rlauxAudit = PersistedWorkflow.readFrom(topdir)!!
         val mvrManager = rlauxAudit.mvrManager()
         val batches = mvrManager.styles()
 
@@ -61,7 +61,7 @@ class SfSingleRoundAuditTask(
                 val assertionRound = AssertionRound(cassertion, 1, null)
                 val contestRound = ContestRound(contestUA, listOf(assertionRound), 1)
 
-                val skipper = AuditableCardCsvReaderSkip("$auditDir/sortedCards.csv", skipPerRun * run, batches)
+                val skipper = AuditableCardCsvReaderSkip("$topdir/sortedCards.csv", skipPerRun * run, batches)
                 val manifestWithSkipper = SortedManifest(skipper, 0, )
 
                 val sampler =


### PR DESCRIPTION
UniformSampling
- gather code into strata/Strata
- estSampleSizeStandardBet(), estRiskStandardBet()

always use topdir to open an AuditRecord

more improvements for ColoradoInput
- skipCounties
- Colorado2020 has 4% risk limit

SamplingCardIF.poolName()