### PR TITLE
D'hondt update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 **rlauxe ("r-lux")**
 
 WORK IN PROGRESS
-_last changed: 06/26/2026_
+_last changed: 06/29/2026_
 
 A library for [Risk Limiting Audits](https://en.wikipedia.org/wiki/Risk-limiting_audit) (RLA), based on Philip Stark's SHANGRLA framework and related code.
 The Rlauxe library is an independent implementation of the SHANGRLA framework, based on the

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/dhondt/CandidateSeats.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/dhondt/CandidateSeats.kt
@@ -81,6 +81,7 @@ class CandSeatRangeBuilder(val contestRound: ContestRound) {
     val thrashers: List<AltThrasher>
 
     val partyRanges: ContestSeats // contest/party seat ranges from all failed assertions
+    val partyMap = dcontest.parties.associateBy { it.id }
 
     init {
         // dhondt assertion failures
@@ -201,6 +202,24 @@ class CandSeatRangeBuilder(val contestRound: ContestRound) {
         return ContestSeats(dc.id, partySeats.values.toList())
     }
 
+    // or just always make it ??
+    fun findAssorter(winnerScore: DhondtScore, loserScore: DhondtScore) : DHondtAssorter {
+
+        val winnerName = "${dcontest.info.candidateIdToName[winnerScore.candidate]}/${winnerScore.divisor}"
+        val loserName = "${dcontest.info.candidateIdToName[loserScore.candidate]}/${loserScore.divisor}"
+        val alreadyHave = assorters.find { it is DHondtAssorter &&
+                it.winnerNameRound() == winnerName &&
+                it.loserNameRound() == loserName} as DHondtAssorter?
+        if (alreadyHave != null) return alreadyHave
+
+        val winningCandidate: DhondtCandidate = partyMap[winnerScore.candidate]!!.copy()
+        val losingCandidate: DhondtCandidate = partyMap[loserScore.candidate]!!.copy()
+        winningCandidate.lastSeatWon = winnerScore.divisor
+        losingCandidate.firstSeatLost = loserScore.divisor
+
+        return DHondtAssorter.makeFrom(dcontest.info, winningCandidate, losingCandidate, dcontest.Nc)
+    }
+
     inner class AltThrasher(val name: String, fromContest: DHondtContest, val thrasher: ThresholdRiskFailure) {
         val altContest: AltContest
 
@@ -281,6 +300,7 @@ class CandSeatRangeBuilder(val contestRound: ContestRound) {
     fun makeAltContestFromFlippedAssertion(fromContest: DHondtContest, failure: DhondtRiskFailure): AltContest {
         // in order to flip the winner/loser assertion, youd have to change the reported votes / margin
         // and all the changed assertions would depend on what the score gap is.
+        // println("*** make makeAltContestFromFlippedAssertion for ${failure.assorter}")
 
         // lets just manipuate the lastSeatWon/firstSeatLost
         val winner = failure.assorter.winner()
@@ -314,6 +334,9 @@ class CandSeatRangeBuilder(val contestRound: ContestRound) {
         dalt.assorters.addAll(assorters)
 
         return AltContest(dalt, failure = failure)
+        //println(altContest.alt)
+        //println("*** end makeAltContestFromFlippedAssertion for ${failure.assorter}")
+        //return altContest
     }
 
     fun check(dh: DHondtContest) {

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/dhondt/DHondtAssorter.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/dhondt/DHondtAssorter.kt
@@ -8,6 +8,9 @@ import org.cryptobiotic.rlauxe.util.dfn
 import org.cryptobiotic.rlauxe.util.estMarginUpperFromSamples
 import org.cryptobiotic.rlauxe.util.margin2mean
 import org.cryptobiotic.rlauxe.util.mean2margin
+import org.cryptobiotic.rlauxe.util.roundUp
+
+/* You can transform to Plurality contest with voteForN=nwinners and the candidates are the $candName/$round */
 
 // winner,loser: candidate ids
 // lastSeatWon: last seat won by winner
@@ -65,17 +68,15 @@ data class DHondtAssorter(val info: ContestInfo, val winner: Int, val loser: Int
     }
 
     override fun desc() = "${shortName()}: upperBound=${df(upperBound())}"
-    override fun shortName() = "DHondt w/l=${winnerNameRound()}/${loserNameRound()}"
-    fun reverseName() = "DHondt w/l=${loserNameRound()}/${winnerNameRound()}"
+    override fun shortName() = "DHondt w-l=${winnerNameRound()}-${loserNameRound()}"
+    fun reverseName() = "DHondt w-l=${loserNameRound()}-${winnerNameRound()}"
 
     // Youd like to be able to add new assorters as needed, but the factoring out into contests.json makes that harder
     // we could add new assertionRound, but dont have the new assorters in contests.json
-    // TODO I think you need both the candidate and the round to be unique.
-    //    val winner: Int, val loser: Int, val lastSeatWon: Int, val firstSeatLost: Int
-    override fun hashcodeDesc() = "${winnerNameRound()}/${loserNameRound()} ${info.name}" // must be unique for serialization
+    override fun hashcodeDesc() = "${winnerNameRound()}-${loserNameRound()} ${info.name}" // must be unique for serialization
 
-    fun winnerNameRound() =  "${info.candidateIdToName[winner()]}-$lastSeatWon"
-    fun loserNameRound() =  "${info.candidateIdToName[loser()]}-$firstSeatLost"
+    fun winnerNameRound() =  "${info.candidateIdToName[winner()]}/$lastSeatWon"
+    fun loserNameRound() =  "${info.candidateIdToName[loser()]}/$firstSeatLost"
 
     fun showAssertionDifficulty(votesForWinner: Int, votesForLoser: Int): String {
         val winnerScore = votesForWinner / lastSeatWon.toDouble()
@@ -89,14 +90,15 @@ data class DHondtAssorter(val info: ContestInfo, val winner: Int, val loser: Int
         return winnerScore - loserScore
     }
 
-    fun getScoreRange(Npop: Int, nsamples: Int, alpha: Double) : Int {
+    fun scoreRange(Npop: Int, nsamples: Int, alpha: Double) : Int {
         val stdBet = 2.0 / 1.03905
         val marginUpper = estMarginUpperFromSamples(stdBet, nsamples, alpha)
-        val margin = marginUpper * upperBound()
+        val margin = marginUpper * upperBound()  // this would be the difference in scores except for the affine transform
         val hmean = margin2mean(margin)
 
-        val gmean = (hmean - .5) / c
-        return (Npop * gmean).toInt()
+        // hmean = c * voteDiff/Npop + 0.5     // see makeFrom, below
+        // (hmean - .5) * Npop / c = voteDiff
+        return roundUp((hmean - .5) * Npop / c)
     }
 
     override fun calcMarginFromRegVotes(useVotes: Map<Int, Int>?, N: Int): Double {
@@ -179,7 +181,6 @@ data class DHondtAssorter(val info: ContestInfo, val winner: Int, val loser: Int
         }
 
         fun makeFrom(info: ContestInfo, winner: DhondtCandidate, loser: DhondtCandidate, Nc: Int, Npop: Int?=null): DHondtAssorter {
-
             // Let f_e,s = Te/d(s) for entity e and seat s
             // f_A,WA > f_B,LB, so e = A and s = Wa
 

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/dhondt/DhondtContest.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/dhondt/DhondtContest.kt
@@ -218,14 +218,6 @@ class DHondtContest(
 
     data class Dround(val candId: Int, val score: Double, val round: Int, val winningSeat: Int?)
 
-    // this needs to be recalculated as the mvrLimit might change
-/*     private var candSeats: CandSeatRangeBuilder2? = null
-    private fun getCandSeats(contestRound: ContestRound): CandSeatRangeBuilder2 {
-        if (candSeats != null) return candSeats!!
-        candSeats = CandSeatRangeBuilder2(contestRound)
-        return candSeats!!
-    } */
-
     fun showRelaxedAssertions(contestRound: ContestRound): String {
         val cands = CandSeatRangeBuilder(contestRound)
         val relax = RelaxedAssertionReport(cands)

--- a/core/src/main/kotlin/org/cryptobiotic/rlauxe/dhondt/RelaxedAssertionReport.kt
+++ b/core/src/main/kotlin/org/cryptobiotic/rlauxe/dhondt/RelaxedAssertionReport.kt
@@ -1,14 +1,15 @@
 package org.cryptobiotic.rlauxe.dhondt
 
 import io.github.oshai.kotlinlogging.KotlinLogging
-import org.cryptobiotic.rlauxe.core.ClcaAssertion
+import org.cryptobiotic.rlauxe.util.Indent
 import org.cryptobiotic.rlauxe.util.dfn
 import org.cryptobiotic.rlauxe.util.nfn
 import org.cryptobiotic.rlauxe.util.sfn
 import org.cryptobiotic.rlauxe.util.trunc
+import kotlin.math.min
 
 class RelaxedAssertionReport(val builder: CandSeatRangeBuilder) {
-    val dcontest = builder.dcontest
+    val dcontest: DHondtContest = builder.dcontest
     val sortedLoserGroups: List<DhondtLoserGroup>
 
     init {
@@ -25,9 +26,44 @@ class RelaxedAssertionReport(val builder: CandSeatRangeBuilder) {
         sortedLoserGroups = dhondtLoserGroups.values.toList().sortedByDescending { it.highScore() }
     }
 
-    fun showRelaxedAssertion(cassertion: ClcaAssertion) = buildString {
-        // build an alternative contest with the named assertion absent
-        // just
+    private val show = false
+    private val showLosers = 6
+
+    data class Score(val winner: DhondtScore, val loser: DhondtScore, val startLoser: Int, val nlosers: Int) {
+        var assorter: DHondtAssorter? = null
+        var diff: Int = 0
+        var minDiff: Int = 0
+        var fails: Boolean = false
+
+        fun name(): String {
+            return if (assorter != null)
+                "${assorter!!.winnerNameRound()}-${assorter!!.loserNameRound()}"
+            else
+                "${winner.candidate}/${winner.divisor}-${loser.candidate}/${loser.divisor}"
+        }
+
+        override fun toString() = "${if (fails) "**" else ""}(winner=${winner.candidate}/${winner.divisor}, loser=${loser.candidate}/${loser.divisor}, " +
+                "startLoser=$startLoser)"
+    }
+
+    class KeepScore() {
+        val rows = mutableMapOf<Int, RowScores>()
+        fun addColumn(startRow: Int, cols: MutableList<Score>) {
+            repeat(cols.size) { idx ->
+                val row = rows.getOrPut(startRow + idx, { RowScores(startRow + idx) })
+                row.scores.add(cols[idx])
+            }
+        }
+
+        fun getRow(row: Int): List<Score> {
+            if (rows[row] == null)
+                print("")
+            return rows[row]?.scores ?: emptyList()
+        }
+
+        class RowScores(val row: Int) {
+            val scores = mutableListOf<Score>()
+        }
     }
 
     fun showRelaxedAssertions(): String = buildString {
@@ -35,34 +71,107 @@ class RelaxedAssertionReport(val builder: CandSeatRangeBuilder) {
         appendLine("${dcontest}")
         appendLine("reported winners")
         append(" seat ${sfn("winner-round", candNameWidth)}     ${sfn("nvotes", 6)}, ")
-        append("${sfn(" score", 6)},  ${sfn("scoreDiff", 6)}, ")
+        append(" ${sfn(" score", 6)}, scoreDiff, scoreDiffMin")
         appendLine()
+
         // sorted scores
-        var prev: Int? = null
-        repeat(dcontest.nseats + 3) { idx ->
+        var prevScore: DhondtScore? = null
+        // the winners
+        repeat(dcontest.nseats) { idx ->
             val score = dcontest.sortedScores[idx]
             // sortedRawScores.filter{ it.divisor <= maxRound }.forEachIndexed { idx, score ->
             val candId = score.candidate
-            if (idx < dcontest.nseats) append(" (${nfn(idx + 1, 2)}) ") else append("      ")
+            append(" (${nfn(idx + 1, 2)}) ")
             val nameRound = "${builder.orgInfo.candidateIdToName[candId]!!}-${score.divisor}"
             val below = if (builder.belowMinPct.contains(candId)) "*" else " "
             append(" ${trunc(nameRound, candNameWidth)}$below, ")
             append(" ${nfn(builder.votes[candId]!!, 6)}, ${nfn(score.score.toInt(), 6)}, ")
 
-            if (prev != null) append("   ${nfn(prev - score.score.toInt(), 6)},")
-            prev = score.score.toInt()
+            if (prevScore != null) append("    ${nfn(prevScore.score.toInt() - score.score.toInt(), 6)},")
+            prevScore = score
             appendLine()
         }
+        val lastWinner = prevScore!!
+
+        // the losers
+        val losersLeft: Int = dcontest.sortedScores.size - dcontest.nseats
+        val maxLosers = min(showLosers, losersLeft)
+        var keepScore = KeepScore()
+
+        // build KeepScore
+        repeat(maxLosers) { idx ->
+            val scoreRank = dcontest.nseats + idx
+            val loser = dcontest.sortedScores[scoreRank]
+            val score = Score(lastWinner, loser, dcontest.nseats + idx + 1, dcontest.nseats + maxLosers)
+            buildKeepScore(score, keepScore, Indent(0, nspaces=4))
+        }
+
+        repeat(maxLosers) { idx ->
+            val scoreRank = dcontest.nseats + idx
+            val loser = dcontest.sortedScores[scoreRank]
+            // sortedRawScores.filter{ it.divisor <= maxRound }.forEachIndexed { idx, score ->
+            val candId = loser.candidate
+            append("      ")
+            val nameRound = "${builder.orgInfo.candidateIdToName[candId]}-${loser.divisor}"
+            val below = if (builder.belowMinPct.contains(candId)) "*" else " "
+            append(" ${trunc(nameRound, candNameWidth)}$below, ")
+            append(" ${nfn(builder.votes[candId]!!, 6)}, ${nfn(loser.score.toInt(), 6)}, ")
+
+            val scoreTree = Score(lastWinner, loser, dcontest.nseats+idx+1, dcontest.nseats+maxLosers)
+            val sb = StringBuffer()
+            showRowScore(scoreTree, keepScore, sb)
+            appendLine(sb)
+            if (show) println()
+        }
+
         appendLine()
 
         append( showDhondtRiskFailures() )
         appendLine()
+    }
 
-        // threshold assertion failures
-        //if (builder.altThrashContests.isNotEmpty()) {
-        //    append( showAltThrashContest(builder.altThrashContests.first()) )
-        //}
-        //appendLine()
+    fun showRowScore(score : Score, keepScore: KeepScore, sb: StringBuffer) {
+        showScore(score, sb)
+        keepScore.getRow(score.startLoser).forEach { sib ->
+            showScoreWithName(sib, sb)
+        }
+    }
+
+    fun showScore(score : Score, sb: StringBuffer) {
+        testScore(score)
+        sb.append("    ${nfn(score.diff, 6)}, ${nfn(score.minDiff,6)}${if (score.fails) "*" else " "}")
+    }
+
+    fun showScoreWithName(score : Score, sb: StringBuffer) {
+        testScore(score)
+        val s = " ${score.name()}: ${score.diff}, ${score.minDiff}${if (score.fails) "*" else " "}"
+        sb.append(" ${trunc(s, 40)};")
+    }
+
+    fun buildKeepScore(score : Score, keepScore: KeepScore, indent: Indent) {
+        testScore(score)
+        if (show) println("${indent}$score")
+
+        if (score.fails) {
+            val col = mutableListOf<Score>()
+            for (scoreRank in score.startLoser until score.nlosers) {
+                val nextLoser = dcontest.sortedScores[scoreRank]
+                val test = Score(score.loser, nextLoser, scoreRank+1, score.nlosers)
+                col.add(test)
+            }
+            keepScore.addColumn(score.startLoser+1, col)
+            col.forEach {
+                buildKeepScore(it, keepScore, indent.incr())
+            }
+        }
+    }
+
+    fun testScore(score: Score) {
+        score.diff = score.winner.score.toInt() - score.loser.score.toInt()
+        val assorter = builder.findAssorter(score.winner, score.loser)
+        score.minDiff = assorter.scoreRange(dcontest.Nc, builder.nsamples, alpha)
+        score.fails = (score.diff < score.minDiff)
+        score.assorter = assorter
     }
 
     // not crazy about these DhondtLoserGroup
@@ -79,7 +188,7 @@ class RelaxedAssertionReport(val builder: CandSeatRangeBuilder) {
             if (winningSeat == null)
                 append("       ")
             else
-                append(" (${nfn(winningSeat!!, 2)})  ")
+                append(" (${nfn(winningSeat, 2)})  ")
 
             if (idx == 0) {
                 append(failure.loserScore.showLoser(
@@ -98,6 +207,11 @@ class RelaxedAssertionReport(val builder: CandSeatRangeBuilder) {
             idx++
         }
     }
+
+    // a >? b
+    // a > c
+    // b >? c
+    //
 
     // not crazy about these DhondtLoserGroup
     fun showDhondtRiskFailures(sortedGroups: List<DhondtLoserGroup>) = buildString {
@@ -184,7 +298,7 @@ class RelaxedAssertionReport(val builder: CandSeatRangeBuilder) {
 
         // sorted scores
         var prev: Int? = null
-        repeat(nseats+ 3) { idx ->
+        repeat(nseats + 3) { idx ->
             val score = sortedScores[idx]
             val candId = score.candidate
             if (idx < nseats) append(" (${nfn(idx + 1, 2)}) ") else append("      ")
@@ -194,6 +308,9 @@ class RelaxedAssertionReport(val builder: CandSeatRangeBuilder) {
 
             if (prev != null) append(" ${nfn(prev - score.score.toInt(), 6)},")
             prev = score.score.toInt()
+
+            // find the assertion
+            // append("${sfn("scoreRange", 10)}")
             appendLine()
         }
         // appendLine("winners=${alt.winnerSeats}")


### PR DESCRIPTION
redo Dhondt relaxed assertions
switch to "winner/round"-"loser/round" for assertions
must regenerate all dhondt data.
redo scoreRange calculation